### PR TITLE
fix chrome download instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ Claude will handle the rest.
 ### Chrome not found
 
 Install Chrome for your platform:
-- **macOS**: https://www.google.com/chrome/
-- **Windows**: https://www.google.com/chrome/
+- **macOS** or **Windows**: https://www.google.com/chrome/
 - **Linux**: `sudo apt install google-chrome-stable`
 
 ### Profile refresh


### PR DESCRIPTION
- chrome & windows install link point to the same place: https://www.google.com/chrome/
- consolidated into single link for clarity