### PR TITLE
Add `browse get markdown` to browser skill docs

### DIFF
--- a/skills/browser/REFERENCE.md
+++ b/skills/browser/REFERENCE.md
@@ -101,7 +101,7 @@ browse screenshot --full-page            # capture entire scrollable page
 
 #### `get <property> [selector]`
 
-Get page properties. Available properties: `url`, `title`, `text`, `html`, `value`, `box`, `visible`, `checked`.
+Get page properties. Available properties: `url`, `title`, `text`, `html`, `markdown`, `value`, `box`, `visible`, `checked`.
 
 ```bash
 browse get url                           # current URL
@@ -109,13 +109,17 @@ browse get title                         # page title
 browse get text "body"                   # all visible text (selector required)
 browse get text ".product-info"          # text within a CSS selector
 browse get html "#main"                  # inner HTML of an element
+browse get markdown                      # full page body as markdown
+browse get markdown ".article"           # specific element as markdown
 browse get value "#email-input"          # value of a form field
 browse get box "#header"                 # bounding box (centroid coordinates)
 browse get visible ".modal"              # check if element is visible
 browse get checked "#agree"              # check if checkbox/radio is checked
 ```
 
-**Note**: `get text` requires a CSS selector argument — use `"body"` for full page text.
+**Note**: `get text` and `get html` require a selector argument — use `"body"` for full page content. `get markdown` defaults to body when no selector is given.
+
+**Tip**: Prefer `get markdown` over `get text` or `get html` when you need readable page content for analysis — it preserves links, headings, and structure without HTML noise.
 
 #### `refs`
 

--- a/skills/browser/SKILL.md
+++ b/skills/browser/SKILL.md
@@ -69,6 +69,7 @@ browse get url                           # Get current URL
 browse get title                         # Get page title
 browse get text <selector>               # Get text content (use "body" for all text)
 browse get html <selector>               # Get HTML content of element
+browse get markdown [selector]           # Get page content as markdown (defaults to body)
 browse get value <selector>              # Get form field value
 ```
 


### PR DESCRIPTION
## Summary
- Document `browse get markdown [selector]` in the browser skill SKILL.md and REFERENCE.md
- Added to page state commands section and get property reference
- Added tip recommending `get markdown` over `get text`/`get html` for readable content

## Context
Implementation PR: browserbase/stagehand#1907

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds guidance for a new `browse get markdown` property and clarifies selector requirements for existing `get` properties.
> 
> **Overview**
> Documents the new `browse get markdown [selector]` option in the browser skill docs, including examples for full-page and element-scoped markdown extraction.
> 
> Updates the `get <property>` reference to list `markdown`, clarifies that `get text`/`get html` require a selector while `get markdown` defaults to `body`, and adds a tip recommending markdown for more readable structured content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b540c8bcd770554321f8c33fa2c2d720cdb20b5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->