### PR TITLE
Add `browse upload` to browser skill docs

### DIFF
--- a/skills/browser/REFERENCE.md
+++ b/skills/browser/REFERENCE.md
@@ -182,6 +182,16 @@ browse select "#country" "United States"
 browse select "#tags" "javascript" "typescript"    # multi-select
 ```
 
+#### `upload <selector> <files...>`
+
+Upload file(s) to an `<input type="file">` element. Works with both local and remote Browserbase sessions (remote uses base64 injection). Supports ref-based selectors from snapshot.
+
+```bash
+browse upload "#fileUpload" ./document.pdf          # single file
+browse upload @0-5 ./photo.png                      # using ref from snapshot
+browse upload "#files" ./a.png ./b.png              # multiple files
+```
+
 #### `press <key>`
 
 Press a keyboard key or key combination.

--- a/skills/browser/SKILL.md
+++ b/skills/browser/SKILL.md
@@ -80,6 +80,7 @@ browse click <ref>                       # Click element by ref from snapshot (e
 browse type <text>                       # Type text into focused element
 browse fill <selector> <value>           # Fill input and press Enter
 browse select <selector> <values...>     # Select dropdown option(s)
+browse upload <selector> <files...>      # Upload file(s) to <input type="file">
 browse press <key>                       # Press key (Enter, Tab, Escape, Cmd+A, etc.)
 browse drag <fromX> <fromY> <toX> <toY>  # Drag from one point to another
 browse scroll <x> <y> <deltaX> <deltaY> # Scroll at coordinates


### PR DESCRIPTION
## Summary
- Document `browse upload <selector> <files...>` in the browser skill SKILL.md and REFERENCE.md
- Added to interaction commands section with examples for single file, multiple files, and ref-based selectors
- Notes remote Browserbase support (base64 injection path)

## Context
Implementation PR: browserbase/stagehand#1906

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes adding usage guidance for a new CLI command, with no runtime or behavioral code changes.
> 
> **Overview**
> Documents the new **`browse upload <selector> <files...>`** interaction command in the browser skill docs.
> 
> Adds a dedicated `upload` section to `REFERENCE.md` (including examples for single/multiple file uploads and using snapshot refs like `@0-5`) and lists `browse upload` in the `SKILL.md` interaction command cheat sheet, noting remote Browserbase support via base64 injection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f29217581fcdfc6cbb207dc3eda03f825d68564. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->