### PR TITLE
docs(autobrowse): swap slusa-payment for amazon-add-to-cart in examples

### DIFF
--- a/skills/autobrowse/SKILL.md
+++ b/skills/autobrowse/SKILL.md
@@ -20,7 +20,7 @@ Invocation is flexible — both explicit flags and free-form natural language wo
 ```
 /autobrowse --task google-flights
 /autobrowse --task google-flights --iterations 10 --env remote
-/autobrowse --tasks google-flights,slusa-payment
+/autobrowse --tasks google-flights,amazon-add-to-cart
 /autobrowse --all
 
 # Also fine — parse freely:
@@ -230,7 +230,7 @@ After all sub-agents complete, print a markdown table:
 | Task | Iterations | Final Status | Graduated | Cost |
 |------|-----------|--------------|-----------|------|
 | google-flights | 5 | ✅ pass | yes | $0.42 |
-| slusa-payment | 5 | ❌ fail | no | $1.20 |
+| amazon-add-to-cart | 5 | ❌ fail | no | $1.20 |
 
 Then write a persistent session report to `./autobrowse/reports/` so there's a durable record of the run inside the workspace:
 


### PR DESCRIPTION
## Summary
- Replace `slusa-payment` with `amazon-add-to-cart` in the two example usages in `skills/autobrowse/SKILL.md` (invocation example and results-table example).

## Test plan
- [ ] Render the SKILL.md and confirm the example task names read sensibly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates example command and sample results table; no runtime behavior is affected.
> 
> **Overview**
> Updates `skills/autobrowse/SKILL.md` examples to use `amazon-add-to-cart` in **multi-task invocation** (`--tasks ...`) and the **sample final report table**, replacing the previous `slusa-payment` task reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62f200dbde8192d5db8ede33e669fc9b147d6d68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->