### PR TITLE
feat: event-prospecting skill v0.1

### DIFF
--- a/docs/plans/2026-04-25-event-prospecting-design.md
+++ b/docs/plans/2026-04-25-event-prospecting-design.md
@@ -1,0 +1,218 @@
+# event-prospecting — design
+
+**Status**: approved 2026-04-25
+**Sibling skills**: company-research, cold-outbound, account-positioning, competitor-analysis, github-stargazers
+**Path**: `/Users/jay/skills/skills/event-prospecting/`
+
+## Purpose
+
+Take a conference / event speakers URL, extract the people, filter their companies against the user's ICP, then deep-research only the people at ICP-fit companies. Output a person-first HTML report where each card answers "why should the AE talk to this person?" with all their public links and a one-click DM opener.
+
+Architectural shape: a thin front-end (event recon + extract) and back-end (person enrichment + HTML) wrapped around the company-research backend. Most of the cost lives in company-research; this skill is glue + a different report.
+
+## What problem this solves
+
+GTM teams scrape conference speaker lists into spreadsheets manually or via Clay / Apify actors. The work that follows — figuring out *which* speakers actually matter for THIS sender, what the wedge is, and how to open the conversation — stays manual. This skill collapses that to one command per event.
+
+Five gaps this targets (per find-skills research, 2026-04-25):
+1. JS-rendered / Next.js speaker pages — most existing tools degrade
+2. Sponsor → buying-committee mapping — tools dump company names but don't fan out
+3. ICP scoring tied to *event context* (track / sponsor tier / talk topic) — generic ICP isn't enough
+4. Multi-event recurrence — "this person spoke at 4 events I care about"
+5. Open agent-native skill that chains scrape → enrich → score → CSV in one install
+
+v0.1 hits #1, #3, #5. #2 and #4 are v0.2 candidates.
+
+## Pipeline (10 steps)
+
+| Step | What | Reuses |
+|------|------|--------|
+| 0 | Setup output dir `~/Desktop/{event_slug}_prospects_{YYYY-MM-DD-HHMM}/` | — |
+| 1 | Load user profile from `profiles/{slug}.json`. Fail loudly if missing — point at company-research to build one. | company-research profile shape |
+| 2 | **Recon** the event URL. Detect platform (Next.js `__NEXT_DATA__`, Sessionize public API, Lu.ma JSON-LD, Eventbrite JSON-LD, custom). Persist `recon.json`. | NEW |
+| 3 | **Extract people** using platform-specific shortcut. For Next.js: 4 `browse` commands extract structured speaker JSON. Output `people.jsonl`. | NEW |
+| 4 | Group by `.company` → unique seed company list (e.g. 240 people → 99 companies). | NEW (~5 LOC) |
+| 5 | **ICP triage** — for each unique company, fetch homepage + score against user ICP (one tool call per company). | extract_page.mjs |
+| 6 | **Filter** companies by `icp_fit_score >= --icp-threshold` (default 6). | NEW (~10 LOC) |
+| 7 | **Deep research** the ICP-fit companies — full Plan→Research→Synthesize pattern, one subagent per company. Writes `companies/{slug}.md` with frontmatter scores. | company-research's `references/research-patterns.md` verbatim |
+| 8 | **Enrich speakers** at ICP-fit companies only. Per person: LinkedIn snippet, recent activity (podcast / blog / talk / GitHub / X) for hook generation, harvest all public links. Writes `people/{slug}.md`. | NEW |
+| 9 | Compile HTML report — person-first index, plus per-person + per-company drill-downs. Open in browser. Write `results.csv` for cold-outbound. | extends company-research's `compile_report.mjs` |
+
+## Per-person card design
+
+The primary deliverable. The index is a stack of these, ranked by ICP score.
+
+```
+┌────────────────────────────────────────────────┐
+│  {Name}                              ICP {NN}  │
+│  {Title} · {Company}                           │
+│                                                │
+│  🔗 {LinkedIn} {X} {GitHub} {Blog} {Podcast}   │  ← all public links found
+│                                                │
+│  ▸ Why the company: {1-line ICP-fit reason}    │  ← option B always visible
+│  ▸ Why the person: {role / decision power}     │
+│  ▸ Hook: {event-context first, fallback recent}│
+│                                                │
+│  [📋 Copy DM opener]  [🔬 Research deeper]    │  ← copy-to-clipboard buttons
+└────────────────────────────────────────────────┘
+```
+
+**Hook source priority** (run sequentially per person, stop at first hit):
+1. Event-context: what they're doing AT this event (panel topic, talk title, sponsor tier)
+2. Recent activity (last 6 months): podcast / talk / blog / GitHub / LinkedIn post
+3. Company-context: signal from company's recent news (funding, product launch)
+
+**Copy DM opener** — copies a 2-3 sentence opener that references the hook + names a Browserbase tie-in. Same data as the bullets, rewritten as prose. Ready to paste into LinkedIn / cold email.
+
+**🔬 Research deeper** — copies a pre-tailored Claude Code prompt to clipboard:
+
+> "Use event-prospecting to deepen the brief on {Name} ({Company}, {LinkedIn URL}). Source event: {Event Name}. Existing notes: {full path to .md}. Pull recent podcast appearances, GitHub activity, and any signals about {topic-from-hook}. Append findings to the same file."
+
+User pastes into their CC session, the skill picks up the existing `.md` and extends it. No URL scheme, no local server, works in any browser, works after the run.
+
+## Output structure
+
+```
+~/Desktop/stripesessions_prospects_2026-04-25-2030/
+├── recon.json                       # platform detection + extraction strategy
+├── people.jsonl                     # raw extract from event page (line-per-person)
+├── seed_companies.txt               # unique companies fed to ICP triage
+├── companies/                       # company-research output, verbatim shape
+│   ├── openai.md                    # frontmatter has icp_fit_score
+│   ├── bridge.md
+│   └── ... (only ICP fits get full deep research; non-fits get a thin triage stub)
+├── people/                          # only ICP-fit companies' speakers
+│   ├── greg-brockman.md             # frontmatter has links + hook
+│   └── ...
+├── index.html                       # person-first ranked card grid
+├── companies.html                   # ICP-ranked table, expandable to attendees
+├── people.html                      # filterable speaker grid (alternate view)
+└── results.csv                      # cold-outbound-ready
+```
+
+## Reuses from company-research
+
+**Verbatim** (shell-call or import):
+- `scripts/extract_page.mjs` — bb fetch + browse fallback + JSON envelope handling
+- `scripts/list_urls.mjs` — URL dedup
+- `scripts/compile_report.mjs` — extend with new renderers, don't fork
+- `references/research-patterns.md` — Plan→Research→Synthesize pattern for company lane
+- `references/example-research.md` — per-company .md format
+- `profiles/{slug}.json` — user profile (interchangeable across all GTM skills)
+
+**Extend**:
+- `compile_report.mjs` — add `renderEventIndex()` (person cards), `renderPersonPage()`, `renderCompaniesWithAttendees()`. Existing functions untouched.
+
+## New scripts (small)
+
+- `scripts/recon.mjs` (~80 LOC) — platform detector. Probes in priority order: `__NEXT_DATA__`, Sessionize generator meta, Lu.ma og:site_name, Eventbrite, JSON-LD `Event`, fall through to markdown extraction.
+- `scripts/extract_event.mjs` (~60 LOC) — reads `recon.json`, dispatches to platform-specific extractor, outputs `people.jsonl`.
+- `scripts/enrich_person.mjs` (~100 LOC) — per-person: bb search "{name} {company} linkedin", harvest links, generate hook from event-context + recent activity. Run as a subagent batch.
+- `references/event-platforms.md` — list of known platforms + extractor strategies (so future contributors can add platforms without touching core code).
+- `references/workflow.md` — full workflow recipe, adapted from company-research.
+
+## Defaults
+
+| Flag | Default | Notes |
+|------|---------|-------|
+| `--icp-threshold` | `6` | Out of 10. Companies below this don't get deep research. |
+| `--depth` | `deep` | quick = no person enrichment; deep = recon + ICP triage + deep research + person enrichment; deeper = + multi-source link harvest |
+| `--user-company` | required | Slug; reads `profiles/{slug}.json` |
+| Output dir | `~/Desktop/{event_slug}_prospects_{YYYY-MM-DD-HHMM}/` | Matches sibling skills |
+
+## Cost model (Stripe Sessions example)
+
+| Phase | Tool calls | Wall clock |
+|-------|-----------|-----------|
+| Recon + extract | 4 | 6s |
+| ICP triage on 99 companies | 99 | ~3 min (parallel) |
+| Deep research on ~30 ICP fits | ~150 | ~8 min (parallel) |
+| Enrich ~50 speakers at fits | ~100 | ~4 min (parallel) |
+| Compile HTML | 0 | 1s |
+| **Total** | **~350** | **~15 min** |
+
+vs. naive enrich-everyone design: ~600 calls and similar wall clock with thinner per-row output. Company-first cuts cost ~45% AND produces richer rationale because the company is fully understood by the time we look at the person.
+
+## Out of scope for v0.1
+
+- **event-follow-up** — sibling skill for post-event workflow (photos / notes / RSVP exports → CRM-ready follow-ups). Different inputs, different urgency, different output. Ships separately.
+- **Sponsor → buying-committee fan-out** — sponsors paid (strong signal) but don't always send their decision-makers as speakers. v0.2.
+- **Multi-event recurrence** — "this person spoke at 4 events I care about". v0.2.
+- **Live local-server "research deeper" trigger** — clipboard for v0.1.
+- **CRM integration** — read existing customers / drop matches.
+- **Pricing normalization, SWOT, Porter's** — different skill.
+
+## Risks
+
+- **Platform drift**: event sites redesign every year. Mitigation: recon + platform-specific shortcuts are 30 LOC each, easy to update.
+- **LinkedIn auth wall**: snippets only via bb search, never deep-fetch. Same rule as competitor-analysis.
+- **ICP threshold tuning**: 6/10 is a guess. Will need calibration on real runs.
+- **Hook quality**: depends on whether person has public signal in last 6 months. For obscure speakers, hook falls back to event-context, which is always at least one bullet.
+
+## Test plan
+
+- **Stripe Sessions** (https://stripesessions.com/speakers) — Next.js / `__NEXT_DATA__`. 240 speakers, 99 companies, expect ~30 ICP fits for Browserbase.
+- **AI Engineer Summit** — different platform (custom or Sessionize), validates platform detection.
+- **A small Lu.ma event** — JSON-LD path validation.
+- **Unknown CMS** — fall-through to markdown extraction.
+
+## Architecture diagram
+
+```
+┌──────────────────────────┐
+│ INPUT: speakers URL      │
+│ + user profile slug      │
+└─────────────┬────────────┘
+              ▼
+┌──────────────────────────┐
+│ NEW: recon.mjs           │
+│ NEW: extract_event.mjs   │
+│ → people.jsonl           │
+└─────────────┬────────────┘
+              ▼
+┌──────────────────────────┐
+│ Group by company         │
+│ → seed_companies.txt     │
+└─────────────┬────────────┘
+              ▼
+┌──────────────────────────┐
+│ REUSE: extract_page.mjs  │
+│ + ICP triage             │
+│ → companies/*.md         │
+└─────────────┬────────────┘
+              ▼
+┌──────────────────────────┐
+│ Filter score >= 6        │
+└─────────────┬────────────┘
+              ▼
+┌──────────────────────────┐
+│ REUSE: research-patterns │
+│ Deep research subagents  │
+│ (only on ICP fits)       │
+└─────────────┬────────────┘
+              ▼
+┌──────────────────────────┐
+│ NEW: enrich_person.mjs   │
+│ Speakers at ICP fits     │
+│ → people/*.md            │
+└─────────────┬────────────┘
+              ▼
+┌──────────────────────────┐
+│ EXTEND: compile_report   │
+│ → index.html (person-1st)│
+│ → results.csv            │
+└──────────────────────────┘
+```
+
+## Approved 2026-04-25
+
+Lock-ins from brainstorming dialog:
+- Person-first primary view (not company-first); index is a stack of person cards
+- Hook source: event-context first, fallback to recent activity (deep mode)
+- 3-bullet "why" + one-click DM opener + clipboard "research deeper" button
+- All public links surfaced (LinkedIn, X, GitHub, blog, podcast)
+- Two skills, not one: event-prospecting (pre-event) and event-follow-up (post-event, ships later)
+- Company-first ICP filter before person enrichment (cost + quality win)
+- Deterministic extraction primary; no Stagehand fallback in v0.1
+
+Next: hand off to writing-plans for the implementation plan.

--- a/docs/plans/2026-04-25-event-prospecting.md
+++ b/docs/plans/2026-04-25-event-prospecting.md
@@ -1,0 +1,1122 @@
+# Event-Prospecting Skill Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build a `event-prospecting` skill at `/Users/jay/skills/skills/event-prospecting/` that takes a conference speakers URL, extracts people, filters by ICP at the company level, deep-researches the fit-companies' people, and outputs a person-first HTML report.
+
+**Architecture:** Thin wrapper around `company-research`. New code is the event-recon front-end (recon → platform-specific extract → group-by-company), the per-person enrichment back-end, and the HTML report extension. ICP scoring + deep company research is delegated to `company-research`'s existing pipeline by reusing `extract_page.mjs` and the Plan→Research→Synthesize subagent prompt pattern verbatim.
+
+**Tech Stack:** Node.js (no transpile, ESM `.mjs`), Bash subagents via Claude Code Agent tool, Browserbase CLIs (`bb fetch`, `bb search`, `browse goto`, `browse eval`, `browse get markdown`), HTML/CSS/vanilla-JS for the report.
+
+**Reference design:** `docs/plans/2026-04-25-event-prospecting-design.md` (already committed).
+
+---
+
+## Branch setup
+
+This plan assumes the implementer:
+1. Creates a new branch `event-prospecting` cut from `main`
+2. Has `competitor-analysis` branch checked out somewhere or merged into main (so they can reference the latest patterns at `/Users/jay/skills/skills/competitor-analysis/`)
+3. Has `company-research` already at `/Users/jay/skills/skills/company-research/` (it's on main)
+
+If `competitor-analysis` isn't merged to main yet, do step 1 cutting from `competitor-analysis` instead — the design borrows from both, but compiles the report by extending company-research's compile script, so company-research is the strict dependency.
+
+```bash
+git checkout main
+git pull
+git checkout -b event-prospecting
+mkdir -p skills/event-prospecting/{scripts,references,profiles}
+```
+
+---
+
+## Phase A — Scaffolding + Recon
+
+Goal at end of Phase A: `node scripts/recon.mjs https://stripesessions.com/speakers` prints a recon.json that correctly identifies "next-data" and locates the speaker JSON path inside `__NEXT_DATA__`.
+
+### Task A1: Scaffold the skill directory
+
+**Files:**
+- Create: `skills/event-prospecting/scripts/package.json`
+- Create: `skills/event-prospecting/profiles/example.json`
+- Create: `skills/event-prospecting/.gitignore`
+
+**Step 1: Create the directory layout**
+
+```bash
+mkdir -p skills/event-prospecting/{scripts,references,profiles}
+```
+
+**Step 2: Write package.json**
+
+```json
+{
+  "name": "event-prospecting-scripts",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true
+}
+```
+
+**Step 3: Copy the example profile from company-research** (same shape across GTM skills)
+
+```bash
+cp skills/company-research/profiles/example.json skills/event-prospecting/profiles/example.json
+```
+
+**Step 4: Write .gitignore**
+
+```
+node_modules/
+*.log
+.DS_Store
+```
+
+**Step 5: Commit**
+
+```bash
+git add skills/event-prospecting/
+git commit -m "scaffold(event-prospecting): directory layout + example profile"
+```
+
+---
+
+### Task A2: Copy reused scripts from company-research
+
+These are deliberate copies (not symlinks) so the skill is self-contained — same approach competitor-analysis took. We accept a small DRY cost for shippability.
+
+**Files:**
+- Create: `skills/event-prospecting/scripts/extract_page.mjs` (copy from company-research)
+- Create: `skills/event-prospecting/scripts/list_urls.mjs` (copy from company-research)
+
+**Step 1: Copy both files**
+
+```bash
+cp skills/company-research/scripts/extract_page.mjs skills/event-prospecting/scripts/
+cp skills/company-research/scripts/list_urls.mjs skills/event-prospecting/scripts/
+```
+
+**Step 2: Sanity-check they still run standalone**
+
+```bash
+node skills/event-prospecting/scripts/extract_page.mjs --help
+node skills/event-prospecting/scripts/list_urls.mjs --help
+```
+
+Expected: both print usage and exit 0.
+
+**Step 3: Commit**
+
+```bash
+git add skills/event-prospecting/scripts/extract_page.mjs skills/event-prospecting/scripts/list_urls.mjs
+git commit -m "scaffold(event-prospecting): reuse extract_page + list_urls from company-research"
+```
+
+---
+
+### Task A3: Write recon.mjs — Next.js detector (the proven path)
+
+`recon.mjs` is the most important new script. It probes the event URL and writes `recon.json` describing the platform + extraction strategy. The first detector we ship is Next.js / `__NEXT_DATA__` because that's what we validated on Stripe Sessions.
+
+**Files:**
+- Create: `skills/event-prospecting/scripts/recon.mjs`
+
+**Step 1: Write a fixture-driven test plan first**
+
+Create `skills/event-prospecting/scripts/__fixtures__/stripe-snapshot.json`:
+
+```json
+{
+  "title": "Stripe Sessions 2026 | Speakers",
+  "hasNextData": true,
+  "nextDataLen": 439761,
+  "speakerArrayPaths": [
+    ".props.pageProps.featuredSpeakers.speakers.items",
+    ".props.pageProps.moreSpeakers.speakers.items"
+  ],
+  "totalSpeakers": 240
+}
+```
+
+This fixture documents what Stripe Sessions looked like at design time. recon.json output for Stripe should match this.
+
+**Step 2: Write recon.mjs**
+
+```javascript
+#!/usr/bin/env node
+// recon.mjs — probe an event URL, identify the platform, persist a recon.json
+// describing how to extract people. Output dir is the second arg or stdout.
+//
+// Usage: node recon.mjs <event-url> [output-dir]
+//
+// Detection priority:
+//   1. Next.js __NEXT_DATA__ (custom Next sites — Stripe Sessions class)
+//   2. Sessionize generator meta or sessionz.io script
+//   3. Lu.ma og:site_name
+//   4. Eventbrite og:site_name
+//   5. JSON-LD Event block
+//   6. Fall through to markdown-extraction strategy
+
+import { execFileSync } from 'child_process';
+import { writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+
+const args = process.argv.slice(2);
+if (args.length < 1 || args.includes('--help')) {
+  console.error(`Usage: node recon.mjs <event-url> [output-dir]`);
+  process.exit(1);
+}
+
+const url = args[0];
+const outDir = args[1];
+
+function browse(...subargs) {
+  return execFileSync('browse', subargs, {
+    encoding: 'utf-8', maxBuffer: 8 * 1024 * 1024, timeout: 60000,
+  });
+}
+
+function probe() {
+  // Navigate + settle
+  browse('goto', url);
+  browse('wait', 'timeout', '2500');
+  const titleRes = JSON.parse(browse('get', 'title'));
+  const title = titleRes.title || '';
+
+  // Probe in priority order via a single eval — cheaper than N calls.
+  const probeJs = `(() => {
+    const nd = document.getElementById('__NEXT_DATA__');
+    const meta = document.querySelector('meta[name="generator"]');
+    const og = document.querySelector('meta[property="og:site_name"]');
+    const jsonLd = [...document.querySelectorAll('script[type="application/ld+json"]')]
+      .map(s => { try { return JSON.parse(s.textContent); } catch { return null; }})
+      .filter(Boolean);
+    return {
+      hasNextData: !!nd,
+      nextDataLen: nd ? nd.textContent.length : 0,
+      generator: meta ? meta.content : null,
+      ogSite: og ? og.content : null,
+      jsonLdEvents: jsonLd.filter(j => j['@type'] === 'Event').length,
+      hostname: location.hostname
+    };
+  })()`;
+  const evalRes = JSON.parse(browse('eval', probeJs));
+  const r = evalRes.result || {};
+
+  // Decide platform
+  let platform = 'custom';
+  let strategy = 'markdown';
+  let nextDataPaths = null;
+
+  if (r.hasNextData) {
+    platform = 'next-data';
+    strategy = 'next-data-eval';
+    // Find arrays of speaker-like objects inside __NEXT_DATA__
+    const findJs = `(() => {
+      const data = JSON.parse(document.getElementById('__NEXT_DATA__').textContent);
+      const out = [];
+      function walk(o, path='') {
+        if (Array.isArray(o)) {
+          if (o.length > 3 && typeof o[0] === 'object' && o[0] !== null) {
+            const keys = Object.keys(o[0]);
+            const hasName = keys.some(k => /name/i.test(k));
+            const hasLinkedIn = JSON.stringify(o[0]).match(/linkedin/i);
+            if (hasName && hasLinkedIn) out.push({ path, len: o.length, keys: keys.slice(0,12) });
+          }
+          o.forEach((v,i) => walk(v, path+'['+i+']'));
+        } else if (o && typeof o === 'object') {
+          Object.keys(o).forEach(k => walk(o[k], path+'.'+k));
+        }
+      }
+      walk(data);
+      // Keep only top-level (non-nested) speaker arrays — drop talks[N].speakers
+      return out.filter(x => !/\\.talks\\[\\d+\\]\\.speakers/.test(x.path)).slice(0, 5);
+    })()`;
+    const findRes = JSON.parse(browse('eval', findJs));
+    nextDataPaths = (findRes.result || []).map(x => x.path);
+  } else if (r.generator && /sessionize/i.test(r.generator)) {
+    platform = 'sessionize';
+    strategy = 'sessionize-api';
+  } else if (r.hostname && /lu\\.ma/.test(r.hostname)) {
+    platform = 'luma';
+    strategy = 'json-ld';
+  } else if (r.ogSite && /eventbrite/i.test(r.ogSite)) {
+    platform = 'eventbrite';
+    strategy = 'json-ld';
+  } else if (r.jsonLdEvents > 0) {
+    platform = 'json-ld';
+    strategy = 'json-ld';
+  }
+
+  return {
+    url,
+    title,
+    platform,
+    strategy,
+    nextDataPaths,
+    signals: r,
+    probedAt: new Date().toISOString(),
+  };
+}
+
+const result = probe();
+
+if (outDir) {
+  mkdirSync(outDir, { recursive: true });
+  const path = join(outDir, 'recon.json');
+  writeFileSync(path, JSON.stringify(result, null, 2));
+  console.error(`recon.json written → ${path}`);
+}
+console.log(JSON.stringify(result, null, 2));
+```
+
+**Step 3: Run against Stripe Sessions to verify**
+
+```bash
+node skills/event-prospecting/scripts/recon.mjs https://stripesessions.com/speakers
+```
+
+Expected output:
+```json
+{
+  "url": "https://stripesessions.com/speakers",
+  "title": "Stripe Sessions 2026 | Speakers",
+  "platform": "next-data",
+  "strategy": "next-data-eval",
+  "nextDataPaths": [
+    ".props.pageProps.featuredSpeakers.speakers.items",
+    ".props.pageProps.moreSpeakers.speakers.items"
+  ],
+  ...
+}
+```
+
+**Step 4: Commit**
+
+```bash
+git add skills/event-prospecting/scripts/recon.mjs skills/event-prospecting/scripts/__fixtures__/
+git commit -m "feat(event-prospecting): recon.mjs detects Next.js + locates speaker arrays"
+```
+
+---
+
+### Task A4: Add fallback platform detectors (markdown extraction)
+
+The Next.js detector covers Stripe-class events. We need at least the markdown fallback to handle "unknown" sites without crashing. Sessionize / Lu.ma / Eventbrite branches are stubs that just set the strategy field — actual extractors come in Phase B.
+
+**Files:**
+- Modify: `skills/event-prospecting/scripts/recon.mjs` (markdown fallback already in code above; verify by testing on a non-Next site)
+
+**Step 1: Test fallback on a non-Next site**
+
+Find a small static event site and run recon. e.g. a personal-site events page. Expected: `platform: "custom"`, `strategy: "markdown"`. No crash.
+
+**Step 2: Commit any tweaks**
+
+If recon needed adjustments to handle the fallback gracefully, commit them.
+
+```bash
+git commit -am "fix(event-prospecting): recon falls through cleanly for unknown platforms"
+```
+
+---
+
+## Phase B — Extraction + Group-by-company
+
+Goal at end of Phase B: `node scripts/extract_event.mjs <output-dir>` reads `recon.json`, runs the platform-specific extractor, writes `people.jsonl`, and emits `seed_companies.txt` with deduped companies.
+
+### Task B1: Write extract_event.mjs — Next.js extractor
+
+The Next.js extractor reads `recon.json` and runs ONE `browse eval` to pull every speaker out of `__NEXT_DATA__` using the paths recon found. This is the path validated against Stripe.
+
+**Files:**
+- Create: `skills/event-prospecting/scripts/extract_event.mjs`
+
+**Step 1: Write the extractor**
+
+```javascript
+#!/usr/bin/env node
+// extract_event.mjs — read recon.json, dispatch to platform-specific extractor,
+// write people.jsonl (one speaker per line) and seed_companies.txt.
+//
+// Usage: node extract_event.mjs <output-dir>
+
+import { execFileSync } from 'child_process';
+import { readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+const outDir = process.argv[2];
+if (!outDir) { console.error('Usage: extract_event.mjs <output-dir>'); process.exit(1); }
+
+const recon = JSON.parse(readFileSync(join(outDir, 'recon.json'), 'utf-8'));
+
+function browse(...subargs) {
+  return execFileSync('browse', subargs, {
+    encoding: 'utf-8', maxBuffer: 16 * 1024 * 1024, timeout: 60000,
+  });
+}
+
+function slugify(s) {
+  return (s || '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+function extractFromNextData(paths) {
+  // Build a JS expression that walks __NEXT_DATA__ for each path and unions the arrays.
+  const js = `(() => {
+    const data = JSON.parse(document.getElementById('__NEXT_DATA__').textContent);
+    function get(obj, path) {
+      // path like '.props.pageProps.foo[0].bar' — naive parser, sufficient
+      const tokens = path.match(/\\.[a-zA-Z_$][\\w$]*|\\[\\d+\\]/g) || [];
+      let cur = obj;
+      for (const t of tokens) {
+        if (!cur) return null;
+        if (t.startsWith('.')) cur = cur[t.slice(1)];
+        else cur = cur[parseInt(t.slice(1, -1), 10)];
+      }
+      return cur;
+    }
+    const all = [];
+    ${JSON.stringify(paths)}.forEach(p => {
+      const arr = get(data, p);
+      if (Array.isArray(arr)) all.push(...arr);
+    });
+    return all.map(s => ({
+      name: s.name || s.fullName || null,
+      title: s.title || s.role || null,
+      company: s.companyName || s.company || s.org || null,
+      linkedin: s.linkedInProfile || s.linkedinUrl || s.linkedin || null,
+      bio: s.bio || s.description || null,
+    }));
+  })()`;
+  const res = JSON.parse(browse('goto', recon.url));
+  browse('wait', 'timeout', '2000');
+  const evalRes = JSON.parse(browse('eval', js));
+  return evalRes.result || [];
+}
+
+function extractFromMarkdown() {
+  browse('goto', recon.url);
+  browse('wait', 'timeout', '2500');
+  const md = JSON.parse(browse('get', 'markdown')).markdown || '';
+  // Naive: find blocks of "#### {Name}\n\n{Role}\n\n{Company}\n\n[LinkedIn]({url})"
+  // This is a fallback — coverage is best-effort.
+  const blocks = md.split(/\\n#{2,4} /);
+  const out = [];
+  for (const b of blocks) {
+    const lines = b.split(/\\n+/).map(l => l.trim()).filter(Boolean);
+    if (lines.length < 2) continue;
+    const name = lines[0];
+    if (!/^[A-Z]/.test(name)) continue;
+    const linkedinMatch = b.match(/linkedin\\.com\\/in\\/([\\w-]+)/i);
+    out.push({
+      name,
+      title: lines[1] || null,
+      company: lines[2] || null,
+      linkedin: linkedinMatch ? `https://www.linkedin.com/in/${linkedinMatch[1]}/` : null,
+    });
+  }
+  return out;
+}
+
+let people = [];
+if (recon.strategy === 'next-data-eval') {
+  people = extractFromNextData(recon.nextDataPaths || []);
+} else if (recon.strategy === 'markdown') {
+  people = extractFromMarkdown();
+} else {
+  console.error(`Strategy ${recon.strategy} not implemented in v0.1; falling back to markdown.`);
+  people = extractFromMarkdown();
+}
+
+// Add a slug
+people = people.map(p => ({ ...p, slug: slugify(p.name) }));
+
+// Write people.jsonl
+const peopleFile = join(outDir, 'people.jsonl');
+writeFileSync(peopleFile, people.map(p => JSON.stringify(p)).join('\\n') + '\\n');
+
+// Roll up to unique companies
+const companies = [...new Set(people.map(p => p.company).filter(Boolean))].sort();
+writeFileSync(join(outDir, 'seed_companies.txt'), companies.join('\\n') + '\\n');
+
+console.error(`Extracted ${people.length} people, ${companies.length} unique companies → ${outDir}`);
+console.log(JSON.stringify({ peopleCount: people.length, companyCount: companies.length, peopleFile }, null, 2));
+```
+
+**Step 2: Test against Stripe Sessions**
+
+```bash
+mkdir -p /tmp/event_test
+node skills/event-prospecting/scripts/recon.mjs https://stripesessions.com/speakers /tmp/event_test
+node skills/event-prospecting/scripts/extract_event.mjs /tmp/event_test
+```
+
+Expected:
+- `/tmp/event_test/people.jsonl` exists with ~240 lines
+- `/tmp/event_test/seed_companies.txt` has ~99 companies
+- First line of people.jsonl is Patrick Collison
+
+**Step 3: Verify output shape**
+
+```bash
+head -3 /tmp/event_test/people.jsonl | node -e 'process.stdin.on("data",d=>d.toString().trim().split("\\n").forEach(l=>console.log(JSON.parse(l).name+" — "+JSON.parse(l).company)))'
+wc -l /tmp/event_test/people.jsonl /tmp/event_test/seed_companies.txt
+```
+
+Expected: ~240 / ~99.
+
+**Step 4: Commit**
+
+```bash
+git add skills/event-prospecting/scripts/extract_event.mjs
+git commit -m "feat(event-prospecting): extract speakers from Next.js + markdown fallback"
+```
+
+---
+
+### Task B2: Filter the user's own company + obvious noise from seed list
+
+Drop the user's own employees (Stripe employees from a Stripe-hosted event) and event-staff entries. Keep the logic in the extractor so downstream steps see clean data.
+
+**Files:**
+- Modify: `skills/event-prospecting/scripts/extract_event.mjs`
+
+**Step 1: Add filter logic**
+
+After the `people = people.map(...)` line, insert:
+
+```javascript
+// Filter event-host employees and obvious noise. The host org domain is derived
+// from the event URL — for stripesessions.com, that's stripe.
+const hostOrg = (() => {
+  try {
+    const h = new URL(recon.url).hostname.replace(/^www\\./, '');
+    // 'stripesessions.com' → 'stripe' (drop the 'sessions' suffix or take the first chunk)
+    return h.split('.')[0].replace(/sessions?$/, '').replace(/conf$/, '');
+  } catch { return null; }
+})();
+
+const filterArgs = process.argv.slice(2);
+const userCompanyArg = (() => {
+  const i = filterArgs.indexOf('--user-company');
+  return i !== -1 ? filterArgs[i + 1] : null;
+})();
+
+const dropList = new Set([
+  hostOrg && hostOrg.toLowerCase(),
+  userCompanyArg && userCompanyArg.toLowerCase(),
+].filter(Boolean));
+
+const filtered = people.filter(p => {
+  if (!p.company) return true; // keep "unknown company" — synth assigns later
+  return !dropList.has(p.company.toLowerCase());
+});
+
+console.error(`Filtered ${people.length - filtered.length} host-org / user-company employees`);
+people = filtered;
+```
+
+**Step 2: Test on Stripe**
+
+```bash
+node skills/event-prospecting/scripts/extract_event.mjs /tmp/event_test --user-company browserbase
+```
+
+Expected: people.jsonl drops from ~240 to ~160 (Stripe employees removed).
+
+**Step 3: Commit**
+
+```bash
+git commit -am "feat(event-prospecting): filter host-org + user-company employees from speaker list"
+```
+
+---
+
+## Phase C — ICP triage + deep research (delegate to company-research)
+
+Goal at end of Phase C: A single shell script orchestrates the company-research deep-research pattern over `seed_companies.txt`, producing `companies/{slug}.md` files with `icp_fit_score` in frontmatter.
+
+### Task C1: Write SKILL.md skeleton with the 10-step pipeline
+
+The SKILL.md is what Claude Code reads when invoking the skill. Write a complete frontmatter + 10-step pipeline first, even if some steps are stubs.
+
+**Files:**
+- Create: `skills/event-prospecting/SKILL.md`
+
+**Step 1: Write frontmatter + intro**
+
+Mirror competitor-analysis SKILL.md frontmatter exactly. Include trigger keywords for "conference", "event", "speakers", "attendees", "stripe sessions", "ai engineer summit".
+
+```markdown
+---
+name: event-prospecting
+description: |
+  Event prospecting skill. Takes a conference / event speakers URL,
+  extracts the people, filters their companies against the user's
+  ICP, then deep-researches only the speakers at ICP-fit companies.
+  Outputs a person-first HTML report where each card answers "why
+  should the AE talk to this person?" with all public links and a
+  one-click DM opener.
+  Use when the user wants to: (1) find leads at a specific
+  conference, (2) prep for an event, (3) research event speakers,
+  (4) build a target list from a sponsor/exhibitor page,
+  (5) scrape conference speakers and rank by ICP fit.
+  Triggers: "find leads at {event}", "research speakers at",
+  "prospect this conference", "stripe sessions leads",
+  "ai engineer summit prospects", "event prospecting",
+  "scrape conference speakers", "who should I meet at".
+license: MIT
+compatibility: Requires bb CLI (@browserbasehq/cli) and BROWSERBASE_API_KEY env var. Also requires browse CLI (@browserbasehq/browse-cli) for JS-heavy pages.
+allowed-tools: Bash Agent AskUserQuestion
+metadata:
+  author: browserbase
+  version: "0.1.0"
+---
+
+# Event Prospecting
+
+Take a conference URL → get a ranked list of people the AE should talk to, with a "why reach out" rationale per person.
+
+(rest of SKILL.md follows in subsequent tasks)
+```
+
+**Step 2: Add the 10-step pipeline section** (per the design doc)
+
+Adapt the structure from competitor-analysis SKILL.md. Each step states:
+- What it does
+- Tool calls allowed
+- Outputs
+
+**Step 3: Commit**
+
+```bash
+git add skills/event-prospecting/SKILL.md
+git commit -m "feat(event-prospecting): SKILL.md skeleton + frontmatter + 10-step pipeline"
+```
+
+---
+
+### Task C2: Add the ICP triage subagent prompt
+
+ICP triage is one tool call per company. We dispatch ~10 subagents each handling ~10 companies, batched in a single Agent fan-out.
+
+**Files:**
+- Create: `skills/event-prospecting/references/research-patterns.md`
+
+**Step 1: Reference company-research's research-patterns.md**
+
+The Plan→Research→Synthesize pattern is identical. Don't duplicate; reference and add the event-specific deltas.
+
+```markdown
+# Event-Prospecting — Research Patterns
+
+The deep-research pattern is identical to company-research's Plan→Research→Synthesize. See `/Users/jay/skills/skills/company-research/references/research-patterns.md` for the canonical pattern.
+
+This file documents the *deltas* for event-prospecting:
+
+## ICP Triage (Step 5 — fast pass)
+
+For each company in `seed_companies.txt`, run ONE tool call to fetch the homepage + extract a 1-line product description, then score against ICP. Output goes to `companies/{slug}.md` with frontmatter:
+
+\`\`\`yaml
+company_name: OpenAI
+website: https://openai.com
+product_description: "AI lab building safe AGI for everyone"
+icp_fit_score: 9
+icp_fit_reasoning: "AI agents need cloud browser infrastructure at scale; ChatGPT Agent shipped Mar 2026"
+triage_only: true   # NOT yet deep-researched
+\`\`\`
+
+Companies with `icp_fit_score < {threshold}` stay as triage stubs. Companies above the threshold get the full deep-research treatment in Step 7.
+
+## Deep Research (Step 7 — full pass)
+
+Identical to company-research Step 6. The ICP-fit companies (typically 20-40% of the seed list) get the full Plan→Research→Synthesize treatment with sub-questions tailored to the event context (e.g. "What is OpenAI doing with browser automation that's relevant to Stripe Sessions' agent track?").
+
+## Person Enrichment (Step 8 — speakers at ICP fits only)
+
+Per person:
+- `bb search "{name} {company} linkedin"` — verify role + harvest LinkedIn URL
+- `bb search "{name} podcast OR talk OR blog"` — last 6 months for hooks
+- `bb search "{name} github"` — open-source signal
+- `bb search "{name} site:x.com OR site:twitter.com"` — recent posts
+
+Generate a 3-bullet "why reach out" + DM opener per person. Output to `people/{slug}.md`.
+```
+
+**Step 2: Commit**
+
+```bash
+git add skills/event-prospecting/references/research-patterns.md
+git commit -m "docs(event-prospecting): ICP triage + deep research patterns"
+```
+
+---
+
+### Task C3: Add the example-research.md template (per-company .md format)
+
+**Files:**
+- Create: `skills/event-prospecting/references/example-research.md`
+
+**Step 1: Adapt company-research's example, add the `triage_only` and event-context fields**
+
+Copy `/Users/jay/skills/skills/company-research/references/example-research.md` and add a per-event section showing what the `event_context` frontmatter field contains.
+
+**Step 2: Commit**
+
+```bash
+git add skills/event-prospecting/references/example-research.md
+git commit -m "docs(event-prospecting): example .md format for company + person files"
+```
+
+---
+
+### Task C4: Add the workflow.md (subagent prompts)
+
+This is the big one — the workflow.md is what subagents read. Adapt competitor-analysis's workflow.md format.
+
+**Files:**
+- Create: `skills/event-prospecting/references/workflow.md`
+
+**Step 1: Write the table of contents + intro**
+
+```markdown
+# Event-Prospecting Workflow
+
+## Contents
+- [Discovery](#discovery) — recon + extract
+- [ICP Triage](#icp-triage) — fast company-level scoring
+- [Deep Research](#deep-research) — full Plan→Research→Synthesize on ICP fits
+- [Person Enrichment](#person-enrichment) — speakers at ICP-fit companies
+- [Compilation](#compilation) — HTML report
+```
+
+**Step 2: Write the ICP Triage subagent prompt block**
+
+Hard-cap at 1 tool call per company. Subagents must:
+- Run `node {SKILL_DIR}/scripts/extract_page.mjs "{company_url}"` ONLY
+- Score 0-10 against the user's ICP
+- Write `companies/{slug}.md` via heredoc
+- Stop after one call; never deep-research at this stage
+
+**Step 3: Write the Deep Research subagent prompt block**
+
+Full company-research pattern. Hard-cap at 5 tool calls per company.
+
+**Step 4: Write the Person Enrichment subagent prompt block**
+
+Hard-cap at 4 tool calls per person:
+1. `bb search "{name} {company} linkedin"` (always)
+2. `bb search "{name} podcast OR talk OR blog 2026"` (deep+)
+3. `bb search "{name} github"` (deeper)
+4. `bb search "{name} site:x.com"` (deeper)
+
+Each subagent handles ~5 people in batched tool calls.
+
+**Step 5: Commit**
+
+```bash
+git add skills/event-prospecting/references/workflow.md
+git commit -m "docs(event-prospecting): subagent workflow + tool-call caps"
+```
+
+---
+
+### Task C5: Write the orchestrator commands in SKILL.md
+
+The SKILL.md needs concrete commands for the main agent to dispatch subagent fan-outs. Match the structure in competitor-analysis SKILL.md.
+
+**Files:**
+- Modify: `skills/event-prospecting/SKILL.md`
+
+**Step 1: For each of the 10 steps, add the explicit command pattern**
+
+Each step block should look like:
+
+````markdown
+## Step 5: ICP Triage
+
+Dispatch one Agent batch — N subagents, each handling ~10 companies — with the prompt template at `references/workflow.md` → "ICP Triage" section.
+
+Read `seed_companies.txt`, split into N batches, and fan out:
+
+```bash
+# Pseudo-shell — actual fan-out is via the Agent tool in a single message
+for batch in $(split_into_batches seed_companies.txt 10); do
+  Agent(prompt: "ICP triage these 10 companies: $batch...")
+done
+```
+
+After all subagents complete, verify all `companies/*.md` files exist.
+````
+
+**Step 2: Add the Step 9 compile command**
+
+```bash
+node {SKILL_DIR}/scripts/compile_report.mjs {OUTPUT_DIR} --user-company {USER_SLUG} --open
+```
+
+**Step 3: Commit**
+
+```bash
+git commit -am "feat(event-prospecting): SKILL.md orchestrator commands per step"
+```
+
+---
+
+## Phase D — Person enrichment + HTML report
+
+Goal at end of Phase D: `node scripts/compile_report.mjs <output-dir> --user-company browserbase --open` produces a working `index.html` with person cards + clipboard buttons.
+
+### Task D1: Write enrich_person.mjs (helper for the subagent)
+
+The actual person enrichment runs as subagents (Bash-only) using prompts from workflow.md. But there's a small helper script that batches the search + parses results.
+
+**Files:**
+- Create: `skills/event-prospecting/scripts/enrich_person.mjs`
+
+**Step 1: Write the helper**
+
+```javascript
+#!/usr/bin/env node
+// enrich_person.mjs — given a person record, run a sequence of bb searches and
+// emit a structured enrichment record. Used by the per-person subagent.
+//
+// Usage: enrich_person.mjs --name "Greg Brockman" --company "OpenAI" --linkedin "https://..." --depth deep
+
+import { execFileSync } from 'child_process';
+
+function flag(name, def) {
+  const i = process.argv.indexOf(name);
+  return i !== -1 ? process.argv[i + 1] : def;
+}
+
+const name = flag('--name');
+const company = flag('--company', '');
+const linkedinIn = flag('--linkedin', '');
+const depth = flag('--depth', 'deep');
+
+if (!name) { console.error('--name required'); process.exit(1); }
+
+function bbSearch(query, n = 5) {
+  const out = execFileSync('bb', ['search', query, '--num-results', String(n)], {
+    encoding: 'utf-8', maxBuffer: 4 * 1024 * 1024, timeout: 20000,
+  });
+  return JSON.parse(out);
+}
+
+function harvestLinks(results) {
+  const links = { linkedin: linkedinIn || null, x: null, github: null, blog: null, podcast: null };
+  for (const r of results) {
+    const u = r.url || '';
+    if (!links.linkedin && /linkedin\\.com\\/in\\//.test(u)) links.linkedin = u;
+    if (!links.x && /(x|twitter)\\.com/.test(u)) links.x = u;
+    if (!links.github && /github\\.com/.test(u)) links.github = u;
+    if (!links.podcast && /(spotify|podcast|simplecast|transistor)/.test(u)) links.podcast = u;
+    if (!links.blog && /(medium|substack|hashnode|dev\\.to|\\.blog)/.test(u)) links.blog = u;
+  }
+  return links;
+}
+
+const out = { name, company, linkedin: linkedinIn, hooks: [], links: {} };
+
+// Lane 1 — LinkedIn verify (always)
+const r1 = bbSearch(`${name} ${company} linkedin`);
+out.links = harvestLinks(r1.results || []);
+
+// Lane 2 — Recent activity (deep+)
+if (depth === 'deep' || depth === 'deeper') {
+  const r2 = bbSearch(`"${name}" podcast OR talk OR blog 2026`);
+  out.recentActivity = (r2.results || []).slice(0, 3).map(r => ({ title: r.title, url: r.url }));
+}
+
+// Lane 3 — GitHub + X (deeper)
+if (depth === 'deeper') {
+  const r3 = bbSearch(`"${name}" github`);
+  const r4 = bbSearch(`"${name}" site:x.com OR site:twitter.com`);
+  out.links = { ...out.links, ...harvestLinks([...(r3.results || []), ...(r4.results || [])]) };
+}
+
+console.log(JSON.stringify(out, null, 2));
+```
+
+**Step 2: Test on a known person**
+
+```bash
+node skills/event-prospecting/scripts/enrich_person.mjs --name "Patrick Collison" --company "Stripe" --depth deep
+```
+
+Expected: JSON with linkedin URL, recent activity bullets.
+
+**Step 3: Commit**
+
+```bash
+git add skills/event-prospecting/scripts/enrich_person.mjs
+git commit -m "feat(event-prospecting): enrich_person.mjs harvests links + recent activity"
+```
+
+---
+
+### Task D2: Extend compile_report.mjs — copy from company-research, add person renderers
+
+Don't fork. Start by copying the company-research compile_report.mjs as a base, then add a `renderPersonCard()` and a person-first index renderer.
+
+**Files:**
+- Create: `skills/event-prospecting/scripts/compile_report.mjs` (copy + extend)
+- Create: `skills/event-prospecting/references/report-template.html` (copy + extend)
+
+**Step 1: Copy the base files**
+
+```bash
+cp skills/company-research/scripts/compile_report.mjs skills/event-prospecting/scripts/
+cp skills/company-research/references/report-template.html skills/event-prospecting/references/ 2>/dev/null || true
+```
+
+If company-research doesn't have a separate report-template.html, lift CSS from competitor-analysis's `references/report-template.html`.
+
+**Step 2: Add a `renderPersonCard()` function**
+
+```javascript
+function renderPersonCard(person, company) {
+  const links = person.links || {};
+  const linkPills = ['linkedin', 'x', 'github', 'blog', 'podcast']
+    .filter(k => links[k])
+    .map(k => `<a class="link-pill link-${k}" href="${escapeHtml(links[k])}" target="_blank">${k.toUpperCase()}</a>`)
+    .join(' ');
+
+  return `<div class="person-card" data-slug="${escapeHtml(person.slug)}">
+    <div class="card-header">
+      <h3>${escapeHtml(person.name)}</h3>
+      <span class="icp-badge icp-${company.icp_fit_score >= 8 ? 'high' : company.icp_fit_score >= 6 ? 'mid' : 'low'}">ICP ${company.icp_fit_score || '?'}</span>
+    </div>
+    <div class="card-meta">${escapeHtml(person.title || '')} · ${escapeHtml(person.company || '')}</div>
+    <div class="card-links">${linkPills}</div>
+    <ul class="card-why">
+      <li><strong>Why the company:</strong> ${escapeHtml(company.icp_fit_reasoning || '—')}</li>
+      <li><strong>Why the person:</strong> ${escapeHtml(person.role_reason || '—')}</li>
+      <li><strong>Hook:</strong> ${escapeHtml(person.hook || '—')}</li>
+    </ul>
+    <div class="card-actions">
+      <button class="btn-copy" data-clipboard="${escapeHtml(person.dm_opener || '')}">📋 Copy DM opener</button>
+      <button class="btn-research" data-clipboard="${escapeHtml(buildResearchPrompt(person, company))}">🔬 Research deeper</button>
+    </div>
+  </div>`;
+}
+
+function buildResearchPrompt(person, company) {
+  return `Use event-prospecting to deepen the brief on ${person.name} (${person.company}, ${person.linkedin || ''}). Source event: ${person.event_name || ''}. Existing notes: ${person.md_path}. Pull recent podcast appearances, GitHub activity, and any signals about ${company.icp_fit_reasoning || 'the company'}. Append findings to the same file.`;
+}
+```
+
+**Step 3: Add the index renderer that uses person cards**
+
+The new index.html should rank people by company ICP score, render N cards in a responsive grid.
+
+**Step 4: Add the clipboard JS**
+
+At the bottom of the rendered HTML:
+
+```html
+<script>
+document.addEventListener('click', e => {
+  const btn = e.target.closest('button[data-clipboard]');
+  if (!btn) return;
+  navigator.clipboard.writeText(btn.dataset.clipboard);
+  const orig = btn.textContent;
+  btn.textContent = '✓ Copied';
+  setTimeout(() => btn.textContent = orig, 1200);
+});
+</script>
+```
+
+**Step 5: Commit**
+
+```bash
+git add skills/event-prospecting/scripts/compile_report.mjs skills/event-prospecting/references/report-template.html
+git commit -m "feat(event-prospecting): person-card HTML report + clipboard buttons"
+```
+
+---
+
+### Task D3: Add the people.html and companies.html alternate views
+
+Same data, two more renderings.
+
+**Files:**
+- Modify: `skills/event-prospecting/scripts/compile_report.mjs`
+
+**Step 1: Add `renderPeopleGrid()` and `renderCompaniesTable()`**
+
+people.html: filterable grid with chips for company, role-bucket, ICP band.
+companies.html: ICP-ranked company table with attendees expandable per row.
+
+**Step 2: Test with a fixture**
+
+Create a tiny fixture dir with 3 companies + 5 people .md files. Run compile. Expect 3 HTML files written, no crashes.
+
+**Step 3: Commit**
+
+```bash
+git commit -am "feat(event-prospecting): people.html + companies.html alternate views"
+```
+
+---
+
+## Phase E — End-to-end validation
+
+Goal at end of Phase E: `event-prospecting https://stripesessions.com/speakers --user-company browserbase --depth deep` runs the full pipeline against Stripe Sessions and opens a working report.
+
+### Task E1: Wire profiles/browserbase.json (or copy from existing GTM skill)
+
+**Files:**
+- Create: `skills/event-prospecting/profiles/browserbase.json`
+
+**Step 1: Copy from a sibling skill if one exists**
+
+```bash
+cp /Users/jay/.agents/skills/account-positioning/profiles/browserbase.json skills/event-prospecting/profiles/ 2>/dev/null || \
+  cp skills/company-research/profiles/example.json skills/event-prospecting/profiles/browserbase.json
+```
+
+**Step 2: Edit if needed to match company-research's profile shape**
+
+**Step 3: Commit**
+
+```bash
+git add skills/event-prospecting/profiles/browserbase.json
+git commit -m "chore(event-prospecting): browserbase profile for testing"
+```
+
+---
+
+### Task E2: Dry-run end-to-end against Stripe Sessions
+
+This is the big test. Walk the full pipeline manually.
+
+**Step 1: Set up output dir**
+
+```bash
+OUT=/tmp/sf_e2e_$(date +%s)
+mkdir -p $OUT
+```
+
+**Step 2: Run recon + extract**
+
+```bash
+node skills/event-prospecting/scripts/recon.mjs https://stripesessions.com/speakers $OUT
+node skills/event-prospecting/scripts/extract_event.mjs $OUT --user-company browserbase
+```
+
+Expected:
+- recon.json: platform=next-data, 2 paths
+- people.jsonl: ~160 lines (after host filter)
+- seed_companies.txt: ~99 lines
+
+**Step 3: Spot-check ICP triage on 3 companies manually**
+
+```bash
+node skills/event-prospecting/scripts/extract_page.mjs https://openai.com
+node skills/event-prospecting/scripts/extract_page.mjs https://bridge.xyz
+node skills/event-prospecting/scripts/extract_page.mjs https://anthropic.com
+```
+
+Expect each to return clean title + meta + body. If any returns 502 / >1MB, recon needs to handle it.
+
+**Step 4: Spot-check person enrichment on 3 people**
+
+```bash
+node skills/event-prospecting/scripts/enrich_person.mjs --name "Greg Brockman" --company "OpenAI" --depth deep
+node skills/event-prospecting/scripts/enrich_person.mjs --name "Zach Abrams" --company "Bridge" --depth deep
+node skills/event-prospecting/scripts/enrich_person.mjs --name "Patrick Collison" --company "Stripe" --depth deep
+```
+
+Expect: each returns links + 1-3 recent activity items.
+
+**Step 5: Manually create 3 companies/*.md and 3 people/*.md to test compile**
+
+Use the templates from references/example-research.md. Then:
+
+```bash
+node skills/event-prospecting/scripts/compile_report.mjs $OUT --user-company browserbase --open
+```
+
+Expect: index.html opens with 3 person cards, 3 link pills each, copy buttons work.
+
+**Step 6: Document any bugs, fix, commit each fix**
+
+Issues that might surface:
+- recon.json path traversal regex breaks on edge cases
+- markdown extraction has stray entries
+- LinkedIn URL not picked up if profile has trailing slash variation
+- ICP score parsing fails if subagent writes a string instead of int
+
+Commit each fix as its own commit.
+
+---
+
+### Task E3: Run the full skill via Agent fan-out (final smoke test)
+
+**Step 1: Invoke the skill as a real Claude Code user would**
+
+In a new Claude Code session:
+
+```
+Use event-prospecting to find leads at https://stripesessions.com/speakers for browserbase.
+```
+
+Expected wall-clock: ~15 min. Expected output: `~/Desktop/stripesessions_prospects_2026-04-25-XXXX/` with index.html opened in browser.
+
+**Step 2: Audit the output**
+
+- 30+ ICP-fit companies with deep research
+- 50+ enriched people cards
+- All link pills clickable
+- Copy DM opener button works
+- 🔬 Research deeper button copies a sane prompt
+
+**Step 3: Capture any drift, commit fixes**
+
+Subagents will drift from the expected format. Mirror competitor-analysis's pattern: normalize at compile time rather than rejecting subagent output.
+
+**Step 4: Final commit**
+
+```bash
+git commit -am "feat(event-prospecting): v0.1 validated end-to-end on Stripe Sessions"
+```
+
+---
+
+### Task E4: PR + merge
+
+**Step 1: Push branch + open PR**
+
+```bash
+git push -u origin event-prospecting
+gh pr create --title "feat: event-prospecting skill v0.1" --body "$(cat docs/plans/2026-04-25-event-prospecting-design.md | head -40)"
+```
+
+**Step 2: Merge after self-review**
+
+---
+
+## Out-of-band notes
+
+- **Skill registration**: After merge, ensure the symlink at `~/.claude/skills/event-prospecting/` points at the new path so it's globally callable. competitor-analysis used the same pattern.
+- **Cursor Bugbot review** will likely catch issues — fix in a follow-up PR like the four findings on competitor-analysis (matrix.html user-leak, undefined CSS vars, spawnSync concurrency, loose startsWith).
+- **Sibling event-follow-up skill**: explicitly v0.2-or-later. Don't scope-creep into post-event handling.
+- **Tool-call caps**: copy the HARD CAP block from competitor-analysis workflow.md verbatim. Three lanes × 4 calls each = 12 calls per person max. The pipeline budgets time on this.
+
+---
+
+## Acceptance criteria
+
+| | |
+|---|---|
+| ✅ `node scripts/recon.mjs https://stripesessions.com/speakers` | Detects `next-data`, lists 2 speaker paths |
+| ✅ `node scripts/extract_event.mjs $OUT` | Writes ~160 people, ~99 companies after host filter |
+| ✅ Full pipeline wall-clock | ≤ 18 min on Stripe Sessions |
+| ✅ `index.html` | Renders with person cards, all link pills clickable |
+| ✅ Copy DM opener button | Copies sensible 2-3 sentence opener |
+| ✅ 🔬 Research deeper button | Copies a CC prompt that includes name, company, LinkedIn, .md path |
+| ✅ Skill loadable via Claude Code | `Use event-prospecting to ...` triggers correctly |
+| ✅ Cost vs naive design | ~45% cheaper (350 calls vs 600) |

--- a/docs/plans/2026-04-25-event-prospecting.md
+++ b/docs/plans/2026-04-25-event-prospecting.md
@@ -300,6 +300,39 @@ git commit -m "feat(event-prospecting): recon.mjs detects Next.js + locates spea
 
 ---
 
+### Task A5: Create references/event-platforms.md (was missing — gap fix)
+
+**Why:** Document per-platform extractor strategies so future contributors can add a new event platform without touching `recon.mjs` core code. Required by the design doc; missed in initial plan write.
+
+**Files:**
+- Create: `skills/event-prospecting/references/event-platforms.md`
+
+**Step 1: Add a TOC at the top** (skill-creator: required for files >100 lines)
+
+```markdown
+# Event-Prospecting — Platform Reference
+
+## Contents
+- [Detection Priority](#detection-priority) — order recon.mjs probes
+- [Next.js / `__NEXT_DATA__`](#nextjs--__next_data__) — Stripe Sessions class
+- [Sessionize](#sessionize) — public JSON API
+- [Lu.ma](#luma) — JSON-LD Event block
+- [Eventbrite](#eventbrite) — JSON-LD Event block
+- [Custom / Markdown Fallback](#custom--markdown-fallback) — last resort
+- [Adding a New Platform](#adding-a-new-platform) — contributor guide
+```
+
+**Step 2: Write each section with: detection signature, extraction strategy, sample output shape, known gotchas**
+
+**Step 3: Commit**
+
+```bash
+git add skills/event-prospecting/references/event-platforms.md
+git commit -m "docs(event-prospecting): per-platform extractor reference"
+```
+
+---
+
 ### Task A4: Add fallback platform detectors (markdown extraction)
 
 The Next.js detector covers Stripe-class events. We need at least the markdown fallback to handle "unknown" sites without crashing. Sessionize / Lu.ma / Eventbrite branches are stubs that just set the strategy field — actual extractors come in Phase B.
@@ -603,16 +636,35 @@ ICP triage is one tool call per company. We dispatch ~10 subagents each handling
 **Files:**
 - Create: `skills/event-prospecting/references/research-patterns.md`
 
-**Step 1: Reference company-research's research-patterns.md**
+**Step 1: Copy the canonical Plan→Research→Synthesize block from company-research VERBATIM** (skill-creator: skills must be self-contained; don't depend on a sibling skill's filesystem location at runtime)
 
-The Plan→Research→Synthesize pattern is identical. Don't duplicate; reference and add the event-specific deltas.
+```bash
+# Read the source so it's at hand
+cat /Users/jay/skills/skills/company-research/references/research-patterns.md
+```
+
+Copy the full Plan→Research→Synthesize section into the new file. Cite the source as a comment at the top:
+
+```markdown
+<!-- Plan→Research→Synthesize pattern adapted from company-research v1.1.0 (2026-04-25). -->
+<!-- Keep in sync if the canonical pattern there changes meaningfully. -->
+```
+
+**Step 1.5: Add a TOC at the top** (skill-creator: required for files >100 lines)
 
 ```markdown
 # Event-Prospecting — Research Patterns
 
-The deep-research pattern is identical to company-research's Plan→Research→Synthesize. See `/Users/jay/skills/skills/company-research/references/research-patterns.md` for the canonical pattern.
+## Contents
+- [Plan→Research→Synthesize](#planresearchsynthesize) — canonical pattern
+- [ICP Triage (Step 5)](#icp-triage-step-5--fast-pass) — fast company-level scoring
+- [Deep Research (Step 7)](#deep-research-step-7--full-pass) — full pattern on ICP fits
+- [Person Enrichment (Step 8)](#person-enrichment-step-8--speakers-at-icp-fits-only) — per-person lanes
+```
 
-This file documents the *deltas* for event-prospecting:
+**Step 2: Append the event-specific deltas**
+
+Below the copied canonical pattern:
 
 ## ICP Triage (Step 5 — fast pass)
 

--- a/skills/audit-agent-experience/LICENSE.txt
+++ b/skills/audit-agent-experience/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 jay
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/audit-agent-experience/SKILL.md
+++ b/skills/audit-agent-experience/SKILL.md
@@ -1,0 +1,344 @@
+---
+name: audit-agent-experience
+description: "Audit the developer experience of a product, SDK, docs site, or SKILL.md by dropping multiple Claude subagents at it with only a tiny task prompt and real tools (WebFetch, Bash, Write). Agents must discover the docs themselves, install deps, ask for credentials if needed, and attempt real execution. The skill captures each agent's trace — tool calls, retries, wall time, errors — and scores on Setup Friction, Speed, Efficiency, Error Recovery, and Doc Quality, then emits an HTML report with an A–F grade and concrete fixes. Use when the user asks to audit agent experience, test a skill, audit docs for agents, check if a SDK is agent-friendly, validate a SKILL.md, measure agent DX, or benchmark how painful onboarding is for an AI agent. Triggers: 'audit agent experience', 'test this skill', 'audit docs for agents', 'is my SDK agent-friendly', 'run a DX audit', 'agent experience test', 'test my docs', 'how do agents do with my product'."
+license: MIT
+metadata:
+  author: jay
+  version: "1.4.0"
+allowed-tools: Read WebFetch Write Bash AskUserQuestion Agent
+---
+
+# Audit Agent Experience
+
+Evaluate how well a product/SDK/docs surface works when an AI agent actually tries to onboard and do a realistic task — **starting from a short one-sentence prompt**, with nothing pasted in. The agent must find the docs, install what it needs, and attempt real work. That's the only honest test of agent DX.
+
+The skill spawns multiple subagents in parallel, captures each one's tool-call trace, and scores the experience using the same dimensions as the Skill Test Arena dashboard: Setup Friction, Speed, Efficiency, Error Recovery, Doc Quality.
+
+## Core principle
+
+**Do not spoonfeed.** The subagent gets a tiny prompt like *"Get started with Browserbase and run a browser session"*. It must discover the docs, choose the path, and hit real failures. A good doc survives this; a bad doc does not.
+
+## Workflow
+
+Execute these steps in order. Do not skip ahead.
+
+### Step 1 — Identify the target and define the abstract goal
+
+Resolve what the user is asking to audit:
+
+- **URL** (most common) — e.g., `https://docs.browserbase.com`. This is the *seed* the subagents start from.
+- **Repo / file path** — for SKILL.md audits or SDK repos.
+- **Product name** — if the user is vague ("test my product"), ask via `AskUserQuestion` for the URL or repo.
+
+**Research lightly.** 1 WebFetch max, enough to confirm: what is this product, and does it have a getting-started guide? You're identifying *that there is a flow to follow*, not extracting the steps. The whole point is to let the docs dictate the path.
+
+**Define ONE abstract goal, not a step-by-step checklist.** The goal should be at the level of "complete the onboarding" or "make the product do its primary thing once" — NOT a list of specific actions.
+
+Why: prescriptive checklists steer agents. If you tell them "navigate to example.com" but the docs' quickstart navigates to a different URL, the agent is torn between your instruction and the docs. That pollutes the test.
+
+Examples of good abstract goals:
+- Browserbase → *"Complete the Browserbase getting-started guide end-to-end. Success = you have code that runs a cloud browser session using whatever approach the docs recommend."*
+- Stripe → *"Complete Stripe's getting-started flow for making a test charge. Success = you have a charge ID or equivalent confirmation."*
+- Exa → *"Complete the Exa getting-started guide. Success = your code successfully calls the API and prints whatever the docs treat as a meaningful result."*
+- A SKILL.md → *"Follow the skill's instructions and produce a successful outcome for its advertised job."*
+
+Examples of BAD goals (too prescriptive — don't do this):
+- ~~"Navigate to https://example.com"~~ (steers — the docs may pick a different URL)
+- ~~"Use Playwright"~~ (the docs may recommend Stagehand or Selenium)
+- ~~"Print the page title"~~ (the docs may print session ID, response body, anything)
+
+The subagent will self-report against the abstract goal: *did I complete the onboarding as the docs described?* (yes / no / partial). The concrete sub-outcomes the agent *actually achieved* live in their trace under `primary_outcome_achieved`, not in a pre-defined checklist.
+
+If the target has no clear getting-started flow (rare — even a README is a flow), ask the user what "done" means before continuing.
+
+### Step 2 — Gather audit config via AskUserQuestion
+
+Use `AskUserQuestion` in a **single call with 4 questions**. Options: max 4 per question.
+
+1. **Test depth** (single-select, header: `"Depth"`):
+   - `5 agents (Recommended)` — balanced coverage
+   - `3 agents` — quick sanity check
+   - `10 agents` — thorough, higher cost
+
+2. **Programming languages** (multiSelect, header: `"Languages"`): pick up to 4 — `Python`, `TypeScript`, `Go`, `Shell/Bash` (let user deselect).
+
+3. **Personas** (multiSelect, header: `"Personas"`):
+   - `Standard (Recommended)` — neutral baseline, no behavioral flavoring. Just "do the task." Best for unbiased measurement.
+   - `Pragmatic` — just get it working, fastest path
+   - `Thorough` — read the docs end-to-end before coding
+   - `Skeptical` — verify claims the docs make
+
+(The prior `Minimal-context` persona has been merged into `Standard` — Standard agents naturally minimize unnecessary reading without the performance theatre of "as little reading as possible".)
+
+4. **Execution mode** (single-select, header: `"Exec mode"`):
+   - `Allow Bash (Recommended)` — subagents can run `npm install`, `curl`, etc. on your machine. Most realistic.
+   - `Draft-only` — subagents may fetch docs and write code but won't execute anything. Safer.
+
+After the user answers, gather one more question about model choice:
+
+5. **Model** (single-select, header: `"Model"`):
+   - `Sonnet (Recommended)` — balanced cost/quality, default for most audits
+   - `Opus` — strongest reasoning, highest cost; good for dense/ambiguous docs
+   - `Haiku` — cheapest, fastest; good for checking if docs are agent-friendly to smaller models
+   - `Mixed comparison` — split agents across Opus + Sonnet + Haiku so you can see how doc quality varies by model size. Useful for "are my docs robust even to weaker models?"
+
+Pass the chosen model to each `Agent` invocation via the `model` parameter. If `Mixed`, distribute N agents roughly equally across the 3 models (round-robin by slot index) and record which model each agent used in the trace + report.
+
+After the user answers, you have: `depth` (N), `languages[]`, `personas[]`, `exec_mode`, `model`.
+
+**If `exec_mode = "Allow Bash"`**, follow up with a second AskUserQuestion asking about credentials:
+
+- **Credentials** (single-select, header: `"Credentials"`):
+  - `None — let agents block (friction test)` — agents hit the credential wall, counts as Setup Friction. Best for pure docs audits.
+  - `Provide once for auto-inject` — you'll paste keys; skill injects them so agents can execute end-to-end. Best for testing whether the code actually works.
+
+If user picks auto-inject, AskUserQuestion asks for the credential **values** — not the names. The skill then writes them to each workspace `.env` using **generic, product-agnostic names**:
+
+- Primary credential → `API_KEY`
+- Secondary (e.g. project/org ID) → `PROJECT_ID`
+- Third (e.g. webhook secret) → `SECRET`
+
+**Do NOT use product-specific names** like `BROWSERBASE_API_KEY`, `EXA_API_KEY`, `STRIPE_SECRET_KEY`. Those names steer the agent — they see `BROWSERBASE_API_KEY` in env and skip ever reading the docs to find out what env var the SDK actually expects. The generic name forces them to:
+
+1. Read the docs to discover the product's actual env var name (e.g. `BROWSERBASE_API_KEY`).
+2. Map the generic `API_KEY` value into whatever form the SDK requires — either re-export (`export BROWSERBASE_API_KEY=$API_KEY`) or pass inline in code (`new Browserbase({ apiKey: process.env.API_KEY })`).
+
+If an agent fails to figure out the mapping, that's a doc quality signal — the docs weren't clear about credential naming.
+
+### Step 3 — Safety check
+
+If `exec_mode = "Allow Bash"`, print a brief warning to chat before spawning: *"Agents may run real shell commands (npm install, curl, pip install, git clone) on this machine. Make sure you're in a directory you're okay with agents modifying. Continue in 5 seconds or Ctrl-C to abort."* — then continue.
+
+Do not run `sleep` — just proceed after printing. The user reads the warning before the agents start working.
+
+### Step 4 — Generate tiny prompts (no checklist)
+
+For each of N variants, produce a `(persona, language, prompt)` tuple. The prompt is **one or two sentences**, stating the abstract goal + language. **No sub-checklist, no prescriptive steps.**
+
+Template:
+
+```
+{persona_prefix} follow {product}'s getting-started guide using {language}. You've completed it when you've done whatever the guide treats as the primary successful outcome.
+```
+
+Examples:
+- Pragmatic × TypeScript → *"Get started with Browserbase using TypeScript (Node.js). Complete whatever the getting-started guide considers a successful first run."*
+- Thorough × Python → *"Read Exa's getting-started guide and follow it end-to-end using Python. You're done when the guide's expected outcome is achieved."*
+- Skeptical × Shell → *"Figure out how to complete Stripe's getting-started flow using bash/curl. Note anything in the docs that seems wrong as you go."*
+
+The subagent is NOT told what the success outcome is — they have to read the docs to figure that out. That's the point: if the docs are good, they'll convey it clearly. If the docs are bad, the agent won't know when they're done, which IS a finding.
+
+Read `references/prompt-variants.md` for the persona prefix library. Cross-product personas × languages, truncate to N. If cells < N, repeat with slight wording variation on the prefix.
+
+Never paste doc content into the prompt.
+
+### Step 5 — Spawn N subagents in parallel
+
+Read `references/subagent-brief.md` — the full brief each subagent receives. It tells them:
+- You are a real developer doing a real task
+- Use your real tools (`WebFetch`, `Bash` if allowed, `Write`)
+- If you need credentials, ask the user via a clear stop-and-ask message (the skill captures this as friction)
+- Return a structured trace at the end with tool calls, errors, timing estimates, completion status
+
+For each variant, invoke the `Agent` tool (subagent_type: `general-purpose`). Pass `model: "opus" | "sonnet" | "haiku"` per the user's choice. For `Mixed`, rotate models across the N slots deterministically (agent 1 → opus, agent 2 → sonnet, agent 3 → haiku, agent 4 → opus, …) and record the assigned model in the per-agent report row.
+
+All N calls in **one message** so they run in parallel.
+
+The subagent's prompt = the brief + their tiny task. The brief passes through `exec_mode` so the subagent knows whether Bash is available.
+
+### Step 6 — Parse structured traces AND keep the full prose
+
+Each subagent returns two things in one response:
+1. A fenced JSON trace at the end (structured self-report).
+2. All the prose before it — reasoning, tool output, and what the agent actually did.
+
+**Retain both.** Do not throw the prose away after extracting JSON. The prose is where you catch things the JSON self-report misses.
+
+Extract JSON using: `/```json\s*(\{[\s\S]*?\})\s*```\s*$/`. Mark malformed/missing as `errored` with a `raw_tail`. If >50% errored, warn and offer retry.
+
+Compute the top-line numbers from the JSON:
+- **Onboarding success rate** = fraction of agents with `onboarding_status = "completed"`.
+- **Docs-promise-match rate** = fraction of agents with `docs_promise_met = true`.
+
+### Step 6.25 — Annotate URL provenance per-WebFetch (inline in trace)
+
+**Subagents don't have search** — they guess URLs from training-data priors. Reports must show *per WebFetch call* where the URL came from, rendered as a small muted line directly under the tool input block in the trace. Do NOT put this at the top of the report as a general callout — it's only useful inline where the reader can correlate it to the specific call.
+
+Classify each `WebFetch` URL into one of four provenance categories and render with the matching label + color:
+
+- **`TRAINING PRIOR`** (violet) — URL is a guess from training data (product name + common doc-site conventions like `/introduction`, `/quickstart`, `/sdk/{lang}`). Typical for the first 1–2 WebFetch calls.
+- **`FROM LLMS.TXT`** (blue) — URL appears in the output of a prior `llms.txt` fetch in the same trace.
+- **`FROM PREV PAGE`** (green) — URL was listed in the output of a previous WebFetch or Bash tool call in the same trace.
+- **`GUESS · 404`** (amber) — URL was guessed but 404'd — this is the most interesting category for doc-quality scoring (the URL *should* exist by convention but doesn't).
+
+Classification heuristic:
+1. If the same trace earlier contained a successful `llms.txt` WebFetch whose output mentioned this URL → `FROM LLMS.TXT`
+2. Else if the same trace earlier contained any WebFetch/Bash output that mentioned this exact URL → `FROM PREV PAGE`
+3. Else if the subsequent tool_result has `err: true` with 404 content → `GUESS · 404`
+4. Else → `TRAINING PRIOR`
+
+Score interpretation:
+- **Lots of `TRAINING PRIOR` that succeed** = product is well-represented in training data (head start).
+- **Lots of `GUESS · 404`** = URL taxonomy drifts from common conventions → real doc-discoverability finding.
+- **`FROM LLMS.TXT` appearing often after `GUESS · 404`** = `llms.txt` is carrying the docs' discoverability. Credit it explicitly in the findings.
+
+### Step 6.5 — Narrative cross-agent review (CRITICAL)
+
+Before scoring, re-read the **full prose** from every agent. The JSON trace is the agent's self-report — an agent that hallucinated a wrong package name will also describe it correctly in its own trace. The truth lives in the tool output and the prose.
+
+Scan for these patterns across the N transcripts:
+
+1. **Convergent mistakes.** Did multiple agents try the same wrong thing? Wrong npm package name (e.g., `exa` vs `exa-js`), wrong endpoint, wrong env var, wrong import? If 3/3 agents used the wrong package, that's a **doc quality disaster** even if each "completed" the task. Agents don't invent identical wrong answers — shared training-data residue means the docs aren't overriding the model's wrong priors.
+
+2. **Hallucinated artifacts.** Compare each agent's `primary_outcome_achieved` claim against what their tool output actually shows. If they claim "printed the title" but no title-fetching tool call appears in their Bash output, they're confabulating. Likely means the doc was unclear enough that the agent pattern-matched instead of reading.
+
+3. **Inconsistent outcomes.** If 3 agents describe 3 different "successful" end-states, the docs don't clearly define success.
+
+4. **Silent workarounds.** Did agents patch a bug (missing `await`, wrong env var name, undocumented required parameter) that a human copy-paster wouldn't have? Flag these — they're invisible DX taxes only captured in prose.
+
+5. **Tool-output vs. narrative contradictions.** Sometimes an agent says "it worked" but the stderr from their Bash call says otherwise, and they failed to notice. Grep tool outputs in the prose for `error`, `404`, `401`, `deprecated`, `warning`.
+
+Write a 3–5 sentence **Narrative Review** summary and include it prominently in the final report. This often surfaces the highest-value findings of the whole audit.
+
+### Step 7 — Score the 5 Arena dimensions
+
+Read `references/evaluation-rubric.md` for full criteria. Score 0–100 based on aggregated evidence.
+
+**Onboarding success rate is the primary sanity check.** If <60% of agents completed onboarding, the docs fundamentally failed — no dimension should score above 60 regardless of other evidence.
+
+- **Setup Friction (25%)** — credential prompts, auth retries, install errors. Goal items in the "setup" phase failing = big hit.
+- **Speed (20%)** — total wall time, time-to-first-working-code.
+- **Efficiency (20%)** — tool calls per passed goal item, wasted calls.
+- **Error Recovery (15%)** — did errors block goal items, or did agents route around?
+- **Doc Quality (20%)** — did docs supply what was needed to pass the checklist?
+
+Weighted total → letter grade (90+ A, 75+ B, 60+ C, 45+ D, else F).
+
+### Step 8 — Synthesise findings
+
+Produce:
+
+- **Executive summary** — 2–3 sentences. Lead with the grade and the single biggest friction.
+- **What went well** — 3–5 bullets.
+- **What didn't** — 3–5 bullets.
+- **Common friction patterns** — anything hit by ≥2 agents (the high-signal fixes).
+- **Session timeline** — aggregate phases across agents (Research, Setup, Execution, Validation) with rough times.
+- **Tool call breakdown** — totals across all agents by tool type.
+- **Recommended fixes** — prioritised, each citing the doc section or SDK method and a specific rewrite.
+
+### Step 9 — Render the HTML report
+
+Read `references/report-template.html`. Fill placeholders:
+
+`{{TITLE}}`, `{{TARGET_REF}}`, `{{META}}`, `{{GRADE_LETTER}}`, `{{GRADE_CLASS}}`, `{{OVERALL_SCORE}}`, `{{AGENT_COUNT}}`, `{{COMPLETED_COUNT}}`, `{{STUCK_COUNT}}`, `{{ERRORED_COUNT}}`, `{{NARRATIVE_REVIEW_SECTION}}` (the 3–5 sentence cross-agent narrative summary from Step 6.5 — place this high in the report, right after the scorecard), `{{EXEC_SUMMARY}}`, `{{WENT_WELL_ITEMS}}`, `{{DIDNT_GO_WELL_ITEMS}}`, `{{DIMENSION_ROWS}}`, `{{TIMELINE_SECTION}}`, `{{TOOL_BREAKDOWN_SECTION}}`, `{{METRICS_GRID}}`, `{{PATTERNS_SECTION}}`, `{{FIXES_LIST}}`, `{{AGENT_TRACES_SECTION}}` (full collapsible per-agent trace cards — see format below), `{{AGENT_CARDS}}`.
+
+**`{{AGENT_TRACES_SECTION}}` format.** One `<details class="trace-card">` per agent. Each card's summary line MUST include the model used (e.g. `<span class="chip">opus</span>`) alongside persona/language chips. The card expands to show:
+
+1. **Event log (from `detailed_trace`)** — rendered in **compact Arena-style**: monospace rows with color-coded bracketed labels, minimal chrome, no dots or timeline lines. Each row is one line of text; Input/Output blocks appear as indented `<pre>` blocks directly under their tool call (always visible, not click-to-expand — users want to scan the flow).
+
+   The FIRST event in every log is the **prompt that was sent to that subagent**, rendered with the gold `[PROMPT]` label at timestamp `[setup]`. The full prompt is behind a small click-to-expand button (the only collapsible in the stream — prompts are long and users don't always need them).
+
+   Visual structure:
+
+   ```
+   [setup]     [PROMPT]       Task prompt sent to subagent   [▸ Show full prompt]
+   [+0ms]      [MILESTONE]    agent_started
+   [+100ms]    [THOUGHT]      I'll start by discovering the docs.
+   [+1.2s]     [TOOL_USE #1]   WebFetch
+                 Input: { "url": "...", "prompt": "..." }
+   [+3.4s]     [TOOL_RESULT #1]
+                 Output: # Example Product ...
+   [+4.5s]     [TOOL_USE #2]   Bash
+                 Input: { "command": "npm install ...", "description": "..." }
+   [+9.2s]     [TOOL_RESULT #2]
+                 Output: added 12 packages ...
+   [+12s]      [ERROR]         install · PEP 668 blocked · recovered
+   [+45s]      [RESULT ✓]      Session created, task done.
+   ```
+
+   CSS conventions (compact monospace, light background):
+   - Container: `.trace-timeline` — light gray background (`#fafaf9`), monospace font throughout, 0.78rem font-size, scrollable (max 640px)
+   - Each row: no grid, just inline text. `[time]` (muted) + `[LABEL]` (colored, bold) + body content
+   - Bracketed label color per type:
+     - `[PROMPT]`: gold
+     - `[MILESTONE]`: blue
+     - `[THOUGHT]`: violet (body text also italic + muted)
+     - `[TOOL USE]`: Browserbase orange
+     - `[TOOL RESULT]`: green (or red if errored)
+     - `[ERROR]`: red (body also red)
+     - `[RESULT ✓]`: green (body green, bold)
+   - Tool-name: orange + semibold
+   - Input/Output: visible inline as `.trace-io` blocks with colored left-border (orange for input, green for output, red for errors). `<pre>` block shows the **full** tool input as JSON — never abbreviate. For `WebFetch` specifically, that means showing *both* the `url` AND the `prompt` args — the `prompt` is what the agent asked the page's content to be distilled to, and it's critical signal for understanding agent intent. If the input is large, truncate the value (not the structure) with `…` inside the relevant string.
+   - Prompt block is the exception — it's collapsed by default (prompts are long). Its summary IS visible as a small "▸ Show full prompt" button.
+   - Never revert to dark background — clashes with rest of report.
+   - No grid, no dots, no vertical line — keep it text-flow.
+
+**The main agent keeps each subagent's prompt.** When spawning agents in Step 5, cache the full prompt text keyed by agent index so you can retrieve it for the report. Future-you (rendering) needs to look up what was sent to which agent.
+
+2. **Agent's final prose summary** — kept as a secondary scrollable box below the event log (this is the self-report; the trace is the ground truth).
+3. Tool calls summary grid (name, count, purpose) — quick reference
+4. Evidence (session ID, stdout, etc)
+5. Friction points
+6. Errors (if any)
+7. Positive moments
+
+The event log is the star of the show — this is what gives users the same "I can see exactly what the agent did and thought" experience as the Arena trace view. The prose summary is a narrative recap but the trace is the primary record.
+
+**Per-agent results table** must include a `Model` column when `model = Mixed`, so cross-model comparison is visible at a glance. When a single model was used, mention it once in the header `{{META}}` line instead.
+
+HTML-escape all user-supplied strings. Doc quotes go in `<code>` or `<blockquote>`.
+
+**All URLs must be clickable.** When the report references:
+- Relative doc paths (e.g. `/quickstart/playwright`) → wrap as `<a class="doc-link" href="{TARGET_BASE_URL}{path}" target="_blank" rel="noopener"><code>{path}</code></a>` where `{TARGET_BASE_URL}` is the audit target's origin (e.g. `https://docs.browserbase.com`)
+- Session/resource IDs (e.g. `f0ec58cc`) → link to the full resource URL (e.g. `https://browserbase.com/sessions/{full-id}`) with a `↗` suffix indicating external link
+- Full URLs appearing in prose → already linkable, just ensure they're wrapped in `<a>` not just `<code>`
+
+The CSS for these link classes:
+```css
+a.doc-link { text-decoration: none; color: inherit; }
+a.doc-link:hover code { background: #fff4ef; border-color: var(--brand); color: var(--brand); }
+a.session-link { color: #166534; text-decoration: none; }
+a.session-link:hover { text-decoration: underline; }
+```
+
+Rationale: a 404 finding is useless if the user can't click to verify. A session ID is useless if the user can't click through to the recording. Every URL-like string in the report should be one click away from verification.
+
+### Step 10 — Save and surface
+
+Save to `./audit-agent-experience-<slug>-<timestamp>.html` (cwd). Slug = lowercase target basename with non-alphanumerics → `-`. Timestamp = `YYYYMMDD-HHMMSS`.
+
+Print to chat:
+- Grade, overall score, and the single biggest fix.
+- Count summary: N agents, M completed, K stuck.
+- The full file path.
+
+Open via `Bash: open <path>` on macOS if `exec_mode` allowed it; otherwise just print the path.
+
+### Step 11 — Clean up workspaces
+
+If `exec_mode = "Allow Bash"` and you created per-agent subdirectories under `./dx-audit-tmp/` (or similar), delete that tree after the report is rendered:
+
+```bash
+rm -rf ./dx-audit-tmp/
+```
+
+Rationale: agents install node_modules, venvs, Go modules, etc. — often tens of MB per agent. Leaving them around pollutes the user's repo and wastes disk.
+
+**Exception:** if a subagent's `completion_status` is `stuck` or `errored`, leave that agent's subdir in place and note it in chat — the user may want to inspect the failing state. Delete only the completed / blocked-on-creds agents' dirs.
+
+If `exec_mode = "Draft-only"`, no cleanup is needed (no files were written outside the report).
+
+## Reference files
+
+- **`references/evaluation-rubric.md`** — 5-dimension scoring rubric (Arena methodology).
+- **`references/prompt-variants.md`** — Persona prefix library and core-task heuristics.
+- **`references/subagent-brief.md`** — Verbatim brief + trace JSON schema.
+- **`references/report-template.html`** — HTML template with placeholders.
+
+## Constraints
+
+- Never paste the target doc into the subagent's prompt — that's the whole point.
+- `exec_mode = Draft-only` must disable Bash execution in the subagent brief.
+- Never test a target the user didn't explicitly name.
+- If a subagent asks for credentials, **that counts as friction** in the score — don't "help" it by auto-providing. Let the agent hit the wall and record it.
+- Never write to files outside cwd except the HTML report.

--- a/skills/audit-agent-experience/references/evaluation-rubric.md
+++ b/skills/audit-agent-experience/references/evaluation-rubric.md
@@ -1,0 +1,160 @@
+# Evaluation Rubric — Arena Methodology
+
+Score each dimension 0–100 based on aggregated trace evidence. Ground every score in specific trace fields: `tool_calls`, `errors`, `retries`, `interruptions_asking_for_creds`, `completion_status`, `friction_points`.
+
+## Table of contents
+
+1. **Goal completion rate (primary sanity check)**
+2. Setup Friction (25%)
+3. Speed (20%)
+4. Efficiency (20%)
+5. Error Recovery (15%)
+6. Doc Quality (20%)
+7. Score-to-grade mapping
+8. Calibration notes
+
+---
+
+## 0. Onboarding success rate — the sanity floor
+
+Before scoring any dimension, compute two rates across all valid agents:
+
+```
+onboarding_success_rate = count(onboarding_status == "completed") / count(agents)
+docs_promise_met_rate   = count(docs_promise_met == true) / count(agents)
+```
+
+**Cap rule (based on onboarding_success_rate):**
+
+- ≥ 0.9 → no cap
+- ≥ 0.7 → cap any dimension at 85
+- ≥ 0.5 → cap any dimension at 70
+- < 0.5 → cap any dimension at 55 (docs fundamentally failed)
+
+Rationale: if agents couldn't complete onboarding, no amount of nice prose or fast fetches earns the docs an A.
+
+**docs_promise_met_rate is independent signal.** An agent can "complete" something (status = completed) but have `docs_promise_met = false` if the docs didn't clearly state what completion looks like. A low docs_promise_met_rate with a high onboarding_success_rate = "agents are succeeding in spite of the docs, not because of them." Flag this explicitly in the report.
+
+**Look at `primary_outcome_achieved` across agents.** If all 5 agents achieved slightly different outcomes, the docs are ambiguous about what success means — that's a doc quality issue. If they all converge on the same outcome, the docs are clear.
+
+**Narrative review findings (from Step 6.5) dominate over structured scores.** If the prose review surfaces convergent hallucinations (e.g., all agents used the wrong npm package) or systematic doc bugs invisible to the JSON self-report, cap Doc Quality at 50 regardless of other signals. An agent completing the task using a wrong-but-similar package isn't success — it means the docs left enough ambiguity for training-data priors to take over. That's a fundamental doc failure.
+
+**Model-mix analysis (when `model = Mixed`).** If the user ran a mixed-model audit, compare onboarding success + docs_promise_met + friction count across models:
+- If Opus succeeds but Haiku fails → the docs lean on reasoning the smaller model can't do. That's a doc clarity gap (docs should work for all capable agents, not just the best).
+- If Haiku and Sonnet both succeed but flag more friction than Opus → same finding at lower severity.
+- If all three succeed equally cleanly → the docs are robust. Rare and great signal.
+
+Flag the model-mix gap in the report's narrative review section: *"Haiku struggled at X where Opus breezed through — docs too reliant on model-level inference."*
+
+---
+
+## 1. Setup Friction (weight 25%)
+
+**Question:** How much ceremony stands between "I want to try this" and "I have code running"?
+
+**Signals:**
+- `interruptions_asking_for_creds` — every ask is friction.
+- `errors[].stage = "config"` — misconfig issues.
+- `errors[].message` containing `401`, `403`, `auth`, `unauthorized` — credential-related.
+- `friction_points[].phase = "setup"` — setup-stage pain.
+- Retries on install or first auth attempt.
+
+**Anchors:**
+- 90+: Zero credential friction (agent found keys, or none required). No auth retries. Install worked first try.
+- 70: One small friction — a credential prompt or a single retry.
+- 50: Multiple setup frictions — e.g., credential hunt + install conflict.
+- 30: Agent spent most of its effort just trying to get set up.
+- <20: Agent never got past setup.
+
+## 2. Speed (weight 20%)
+
+**Question:** How fast did agents get to working code?
+
+**Signals:**
+- `wall_time_estimate_sec` — total run time.
+- `time_to_first_working_code_sec` — time to a running snippet.
+- Relative to task complexity (a Stripe charge should take longer than a `curl`).
+
+**Anchors:**
+- 90+: Under 2 minutes to working code for a simple task.
+- 70: 2–5 minutes — reasonable.
+- 50: 5–10 minutes — noticeable drag.
+- 30: Over 10 minutes — painful.
+- <20: Never finished within the run.
+
+Adjust for task complexity. A payments flow is not a cloud browser session.
+
+## 3. Efficiency (weight 20%)
+
+**Question:** Did agents get there in a straight line, or did they wander?
+
+**Signals:**
+- Sum of `tool_calls[].count` across all agents — total work.
+- `code_attempts` — how many drafts before working.
+- `retries` — repeated failing calls.
+- `doc_pages_fetched` — if >5 pages for a simple task, docs are fragmented.
+- `completed_subtasks` / total `tool_calls` ratio.
+
+**Anchors:**
+- 90+: Under 10 tool calls for a simple task, zero wasted calls, single working draft.
+- 70: 10–20 calls, one retry or minor exploration.
+- 50: 20–40 calls, some wandering — agent wasn't sure where to look.
+- 30: 40+ calls — agent is thrashing.
+- <20: Pathological loop or massive exploration.
+
+## 4. Error Recovery (weight 15%)
+
+**Question:** When something broke, did the agent (and the docs) help each other recover?
+
+**Signals:**
+- `errors[].recovered` — recovery rate.
+- Whether errors led to `retries` that succeeded or to `completion_status` degradation.
+- Docs surfaces relevant error info when fetched after an error (check `friction_points` for "no troubleshooting" notes).
+- `friction_points[].severity = critical | high` at the execution phase.
+
+**Anchors:**
+- 90+: Zero errors, or all errors recovered cleanly with clear doc guidance.
+- 70: Errors happened but agents recovered — minor friction.
+- 50: Errors slowed progress noticeably; docs didn't help.
+- 30: Errors frequently fatal; docs silent on failure modes.
+- <20: Every error killed the run.
+
+## 5. Doc Quality (weight 20%)
+
+**Question:** Did the docs provide what agents needed, when they needed it?
+
+**Signals:**
+- `doc_pages_fetched` (fragmentation signal if high for a simple task).
+- `friction_points` mentioning broken examples, missing info, unclear sections.
+- `positive_moments` citing concrete doc wins.
+- Whether the code in docs was copy-pasteable and worked.
+- Presence/absence of a `llms.txt`, quickstart, or clear API reference.
+
+**Anchors:**
+- 90+: A single quickstart page + working code got the agent to done. Minimal fragmentation.
+- 70: Had to piece it together from 2–3 pages, but each was correct.
+- 50: Fragmented or stale in places — examples needed adaptation.
+- 30: Docs omit critical info (error handling, session lifecycle, etc.).
+- <20: Docs either wrong, absent, or actively misleading.
+
+## 6. Score-to-grade mapping
+
+```
+total = setup*0.25 + speed*0.20 + efficiency*0.20 + recovery*0.15 + doc*0.20
+```
+
+| Total   | Grade |
+|---------|-------|
+| 90–100  | A     |
+| 75–89   | B     |
+| 60–74   | C     |
+| 45–59   | D     |
+| 0–44    | F     |
+
+## 7. Calibration notes
+
+- **Don't inflate.** Every dimension at 80+ requires evidence. Default-to-B, move to A only with clear wins.
+- **Don't deflate.** An absent signal is not a bad signal — a dim with no complaints starts at 75, not 50.
+- **Weight severity.** One `critical` friction_point is worth 5 `low` ones.
+- **Cite evidence per dimension.** The report shows a one-line rationale per dim — always quote or reference a specific trace field.
+- **Blocked-on-credentials is not a failure of the docs** (unless the docs pretend credentials aren't needed). Score setup friction accordingly, but don't dock Doc Quality for an agent correctly refusing to invent keys.

--- a/skills/audit-agent-experience/references/prompt-variants.md
+++ b/skills/audit-agent-experience/references/prompt-variants.md
@@ -1,0 +1,103 @@
+# Prompt Variants
+
+The subagent gets **one or two sentences**. Do not paste docs. Do not list "rules". The realism of the audit depends on the prompt being as thin as a real developer's first thought.
+
+## Template
+
+```
+{persona_prefix} {product}'s getting-started guide using {language}. You've completed it when you've done whatever the guide treats as its primary successful outcome.
+```
+
+No checklist. No prescriptive steps. The agent reads the docs and decides what "done" means. Only `{persona_prefix}` and `{language}` vary between agents.
+
+## Persona prefixes
+
+### Standard (default, no persona flavoring)
+> Follow
+
+No adjectives, no role-play, no behavioral hint. Just the task. Use this as the neutral baseline — removes the Hawthorne effect of telling the agent "you are X type of developer" and lets you measure the docs against an agent doing its natural thing.
+
+### Pragmatic
+> Follow
+
+Behavioural hint: shortest path to working. Skips docs when possible. Flags friction bluntly.
+
+### Thorough
+> Read and then follow
+
+Behavioural hint: reads end-to-end before coding. Surfaces ambiguity. Catches docs that don't survive a close read.
+
+### Skeptical
+> Follow — note anything in the docs that seems wrong or unclear as you go while following
+
+Behavioural hint: verifies claims. Calls out marketing vs. code.
+
+### Minimal-context
+> With as little reading as possible, follow
+
+Behavioural hint: tries to use training-data intuition first, reads only when stuck. Exposes whether docs can pick up a lost agent.
+
+## Core task (single phrase — derived from the target)
+
+Pick **one** core task for the whole audit. All subagents do the same task — only persona and language change.
+
+Heuristics:
+
+- **SDK / product with docs site** → "use it to do its primary function once"
+  - Browserbase → "run a cloud browser session"
+  - Stripe → "charge a test card"
+  - Clerk → "sign up a user"
+  - Supabase → "insert a row and read it back"
+- **SKILL.md** → "use this skill to do its advertised job"
+- **API reference page** → "make one representative call and handle the response"
+- **Tutorial / guide** → "follow the guide to completion"
+- **README for library** → "install it and run the smallest meaningful example"
+
+If the target is ambiguous, ask the user via AskUserQuestion before Step 4.
+
+## Language tail
+
+Append after the core task:
+
+- Python → `using Python`
+- TypeScript → `using TypeScript (Node.js)`
+- Go → `using Go`
+- Shell/Bash → `using bash/curl only`
+
+## Final shape — examples
+
+Target: Browserbase (`https://docs.browserbase.com`)
+
+- **Pragmatic × TypeScript** → *"Follow Browserbase's getting-started guide using TypeScript (Node.js). You've completed it when you've done whatever the guide treats as its primary successful outcome."*
+- **Thorough × Python** → *"Read and then follow Browserbase's getting-started guide using Python. You've completed it when you've done whatever the guide treats as its primary successful outcome."*
+- **Skeptical × Go** → *"Follow Browserbase's getting-started guide using Go — note anything in the docs that seems wrong or unclear as you go. You've completed it when you've done whatever the guide treats as its primary successful outcome."*
+- **Minimal-context × Shell** → *"With as little reading as possible, follow Browserbase's getting-started guide using bash/curl only. You've completed it when you've done whatever the guide treats as its primary successful outcome."*
+
+Each agent figures out on its own what the success outcome is from the docs.
+
+## Cross-product rule
+
+Generate cells = |personas| × |languages|. Truncate or repeat to hit N:
+
+- If cells ≥ N → take the first N in row-major order (persona rotation, then language).
+- If cells < N → reuse cells in the same order; distinguish reruns by appending a slight task variation to the tail, e.g. `"and print the full error if anything fails"` or `"and also capture a screenshot if possible"`.
+
+## What NOT to do
+
+- Do **not** paste doc content, URL content, or code examples into the prompt.
+- Do **not** give a numbered list of rules ("1. Use only X. 2. Do Y...").
+- Do **not** say "simulate a newbie" or use theatrical persona role-play — it just invites model performance-for-performance's-sake. The **prefix alone** shapes behaviour enough.
+- Do **not** provide the answer in the prompt. If you find yourself writing "hint: use the Playwright quickstart at …", delete it.
+
+## Seed URL placement
+
+If the target's **name** alone might be ambiguous (e.g., "Clerk" could be many things), you may include the URL as the tail: `"…starting from https://clerk.com/docs"`. Prefer name-only when unambiguous.
+
+## Final check
+
+Before passing the prompt to the subagent:
+
+- [ ] Under ~30 words?
+- [ ] No checklist, no step-by-step, no doc content pasted in?
+- [ ] The success criterion is left implicit ("whatever the guide treats as its primary successful outcome") — not dictated?
+- [ ] Persona is expressed by the prefix, not by "you are simulating…"?

--- a/skills/audit-agent-experience/references/report-template.html
+++ b/skills/audit-agent-experience/references/report-template.html
@@ -1,0 +1,292 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Audit Agent Experience — {{TITLE}}</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --brand: #F03603;
+    --grade-a: #22c55e;
+    --grade-b: #3b82f6;
+    --grade-c: #eab308;
+    --grade-d: #f97316;
+    --grade-f: #ef4444;
+    --black: #100D0D;
+    --gray: #514F4F;
+    --muted-gray: #8a8787;
+    --border: #edebeb;
+    --bg: #F9F6F4;
+    --card: #ffffff;
+    --text: #100D0D;
+    --muted: #514F4F;
+    --blue-info: #4DA9E4;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif; background: var(--bg); color: var(--text); line-height: 1.6; font-size: 16px; }
+  .container { max-width: 960px; margin: 0 auto; padding: 2rem 1.5rem; }
+  code { font-family: 'Geist Mono', 'SF Mono', 'Fira Code', monospace; font-size: 0.8125em; background: #f6f5f5; padding: 0.125em 0.375em; border-radius: 2px; border: 1px solid var(--border); }
+  blockquote { border-left: 3px solid var(--border); padding: 0.5rem 0.875rem; color: var(--muted); font-style: italic; margin: 0.5rem 0; background: #fafaf9; border-radius: 0 3px 3px 0; }
+
+  /* Header */
+  header { margin-bottom: 2rem; display: flex; align-items: center; justify-content: space-between; gap: 1rem; flex-wrap: wrap; }
+  .header-left h1 { font-size: 1.5rem; font-weight: 600; margin-bottom: 0.25rem; color: var(--black); }
+  .header-left h1 a { color: var(--brand); text-decoration: none; }
+  .header-left h1 a:hover { text-decoration: underline; }
+  .header-left .meta { color: var(--muted); font-size: 0.875rem; word-break: break-all; }
+  .header-logo { flex-shrink: 0; }
+
+  /* Scorecard */
+  .scorecard { display: grid; grid-template-columns: auto 1fr; gap: 1.5rem; align-items: center; background: var(--card); border: 1px solid var(--border); border-radius: 6px; padding: 1.75rem 2rem; margin-bottom: 1.5rem; }
+  .grade-badge { width: 120px; height: 120px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-family: Inter, sans-serif; font-weight: 800; font-size: 4rem; line-height: 1; border: 4px solid; }
+  .grade-badge.grade-a { color: var(--grade-a); border-color: var(--grade-a); background: rgba(34,197,94,0.08); }
+  .grade-badge.grade-b { color: var(--grade-b); border-color: var(--grade-b); background: rgba(59,130,246,0.08); }
+  .grade-badge.grade-c { color: var(--grade-c); border-color: var(--grade-c); background: rgba(234,179,8,0.08); }
+  .grade-badge.grade-d { color: var(--grade-d); border-color: var(--grade-d); background: rgba(249,115,22,0.08); }
+  .grade-badge.grade-f { color: var(--grade-f); border-color: var(--grade-f); background: rgba(239,68,68,0.08); }
+  .scorecard .score-block .score-label { font-size: 0.6875rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted); font-weight: 600; margin-bottom: 0.25rem; }
+  .scorecard .score-block .score-value { font-size: 2rem; font-weight: 700; color: var(--black); font-variant-numeric: tabular-nums; margin-bottom: 0.25rem; }
+  .scorecard .score-block .score-sub { font-size: 0.875rem; color: var(--muted); }
+
+  /* Agent stat grid */
+  .stat-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 0.75rem; margin-bottom: 2rem; }
+  .stat { background: var(--card); border: 1px solid var(--border); border-radius: 4px; padding: 1rem 1.25rem; }
+  .stat .label { font-size: 0.6875rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted); font-weight: 600; margin-bottom: 0.25rem; }
+  .stat .value { font-size: 1.5rem; font-weight: 700; color: var(--black); font-variant-numeric: tabular-nums; }
+  .stat .value.ok { color: var(--grade-a); }
+  .stat .value.warn { color: var(--grade-d); }
+  .stat .value.bad { color: var(--grade-f); }
+
+  /* Section */
+  .section { margin-bottom: 2rem; }
+  .section h2 { font-size: 1rem; font-weight: 600; margin-bottom: 0.75rem; display: flex; align-items: center; gap: 0.5rem; color: var(--black); }
+  .section h2 .count { font-size: 0.6875rem; font-weight: 600; border-radius: 2px; padding: 0.125rem 0.5rem; border: 1px solid var(--border); background: #f6f5f5; color: var(--muted); }
+  .section-body { background: var(--card); border: 1px solid var(--border); border-radius: 4px; padding: 1.25rem 1.5rem; }
+
+  /* Executive summary */
+  .exec-summary { font-size: 1rem; line-height: 1.7; color: var(--text); }
+
+  /* Two-column lists */
+  .two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+  .two-col .col { background: var(--card); border: 1px solid var(--border); border-radius: 4px; padding: 1rem 1.25rem; }
+  .two-col .col h3 { font-size: 0.8125rem; font-weight: 600; margin-bottom: 0.75rem; text-transform: uppercase; letter-spacing: 0.05em; display: flex; align-items: center; gap: 0.5rem; }
+  .two-col .col.good h3 { color: var(--grade-a); }
+  .two-col .col.bad h3 { color: var(--grade-f); }
+  .two-col .col ul { list-style: none; display: flex; flex-direction: column; gap: 0.5rem; }
+  .two-col .col li { font-size: 0.875rem; padding-left: 1rem; position: relative; color: var(--text); }
+  .two-col .col.good li::before { content: '+'; position: absolute; left: 0; color: var(--grade-a); font-weight: 700; }
+  .two-col .col.bad li::before { content: '−'; position: absolute; left: 0; color: var(--grade-f); font-weight: 700; }
+
+  /* Dimension breakdown */
+  .dimension { background: var(--card); border: 1px solid var(--border); border-radius: 4px; padding: 1rem 1.25rem; margin-bottom: 0.5rem; }
+  .dimension-head { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 0.5rem; gap: 1rem; flex-wrap: wrap; }
+  .dimension-name { font-size: 0.9375rem; font-weight: 600; color: var(--black); }
+  .dimension-weight { font-size: 0.75rem; color: var(--muted); margin-left: 0.5rem; font-weight: 400; }
+  .dimension-score { font-family: Inter, sans-serif; font-variant-numeric: tabular-nums; font-weight: 700; font-size: 1.125rem; }
+  .dimension-bar-track { height: 6px; background: #f6f5f5; border-radius: 3px; overflow: hidden; margin-bottom: 0.5rem; }
+  .dimension-bar-fill { height: 100%; border-radius: 3px; transition: width 0.3s; }
+  .dimension-bar-fill.grade-a { background: var(--grade-a); }
+  .dimension-bar-fill.grade-b { background: var(--grade-b); }
+  .dimension-bar-fill.grade-c { background: var(--grade-c); }
+  .dimension-bar-fill.grade-d { background: var(--grade-d); }
+  .dimension-bar-fill.grade-f { background: var(--grade-f); }
+  .dimension-rationale { font-size: 0.875rem; color: var(--muted); }
+
+  /* Agent cards */
+  .agent-card { background: var(--card); border: 1px solid var(--border); border-radius: 4px; margin-bottom: 0.5rem; overflow: hidden; }
+  .agent-card.completed { border-left: 3px solid var(--grade-a); }
+  .agent-card.stuck { border-left: 3px solid var(--grade-d); }
+  .agent-card.wrong-result { border-left: 3px solid var(--grade-f); }
+  .agent-card.errored { border-left: 3px solid var(--muted-gray); }
+  .agent-card summary { padding: 0.875rem 1.25rem; cursor: pointer; display: flex; align-items: center; gap: 0.75rem; list-style: none; flex-wrap: wrap; }
+  .agent-card summary::-webkit-details-marker { display: none; }
+  .agent-card summary::before { content: '▶'; font-size: 0.5rem; color: var(--muted); transition: transform 0.15s; flex-shrink: 0; }
+  .agent-card[open] summary::before { transform: rotate(90deg); }
+  .agent-card .badge { font-size: 0.6875rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; padding: 2px 10px; border-radius: 2px; flex-shrink: 0; }
+  .agent-card .badge.completed { background: rgba(34,197,94,0.12); color: #166534; border: 1px solid rgba(34,197,94,0.3); }
+  .agent-card .badge.stuck { background: rgba(249,115,22,0.1); color: #9a3412; border: 1px solid rgba(249,115,22,0.25); }
+  .agent-card .badge.wrong-result { background: rgba(239,68,68,0.08); color: var(--grade-f); border: 1px solid rgba(239,68,68,0.2); }
+  .agent-card .badge.errored { background: rgba(138,135,135,0.1); color: var(--muted); border: 1px solid rgba(138,135,135,0.25); }
+  .agent-card .chip { font-family: 'Geist Mono', 'SF Mono', monospace; font-size: 0.75rem; padding: 1px 8px; border-radius: 2px; background: #f6f5f5; color: var(--text); border: 1px solid var(--border); }
+  .agent-card .turns { font-size: 0.75rem; color: var(--muted); margin-left: auto; font-variant-numeric: tabular-nums; }
+  .agent-card .body { padding: 0 1.25rem 1.25rem 1.25rem; border-top: 1px solid var(--border); padding-top: 0.875rem; }
+  .agent-card .body h4 { font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted); margin-top: 1rem; margin-bottom: 0.5rem; }
+  .agent-card .body h4:first-child { margin-top: 0; }
+  .agent-card .body ul { list-style: none; display: flex; flex-direction: column; gap: 0.5rem; }
+  .agent-card .body li { font-size: 0.875rem; }
+  .agent-card .body .confusion { padding: 0.5rem 0.75rem; background: rgba(239,68,68,0.04); border: 1px solid rgba(239,68,68,0.15); border-radius: 3px; }
+  .agent-card .body .confusion .section-tag { font-family: 'Geist Mono', 'SF Mono', monospace; font-size: 0.75rem; color: var(--grade-f); font-weight: 500; }
+  .agent-card .body .confusion .issue { margin-top: 0.25rem; color: var(--text); }
+  .agent-card .body .positive { padding: 0.5rem 0.75rem; background: rgba(34,197,94,0.05); border: 1px solid rgba(34,197,94,0.2); border-radius: 3px; color: var(--text); }
+  .agent-card .body .suggestion { padding: 0.5rem 0.75rem; background: rgba(77,169,228,0.06); border: 1px solid rgba(77,169,228,0.2); border-radius: 3px; color: #2a7ab5; }
+
+  /* Failure pattern cards */
+  .pattern { background: var(--card); border: 1px solid var(--border); border-radius: 4px; padding: 1rem 1.25rem; margin-bottom: 0.5rem; border-left: 3px solid var(--grade-d); }
+  .pattern-head { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 0.5rem; gap: 1rem; }
+  .pattern-section { font-family: 'Geist Mono', 'SF Mono', monospace; font-size: 0.8125rem; font-weight: 600; color: var(--text); }
+  .pattern-hits { font-size: 0.75rem; color: var(--grade-f); font-weight: 600; background: rgba(239,68,68,0.08); padding: 2px 8px; border-radius: 2px; white-space: nowrap; }
+  .pattern-body { font-size: 0.875rem; color: var(--text); }
+  .pattern-quotes { margin-top: 0.5rem; display: flex; flex-direction: column; gap: 0.375rem; }
+
+  /* Fix list */
+  .fix { background: var(--card); border: 1px solid var(--border); border-radius: 4px; padding: 1rem 1.25rem; margin-bottom: 0.5rem; }
+  .fix-head { display: flex; align-items: baseline; gap: 0.75rem; margin-bottom: 0.5rem; flex-wrap: wrap; }
+  .fix-num { font-family: 'Geist Mono', 'SF Mono', monospace; font-size: 0.8125rem; font-weight: 700; color: var(--brand); }
+  .fix-section { font-family: 'Geist Mono', 'SF Mono', monospace; font-size: 0.8125rem; color: var(--text); background: #f6f5f5; padding: 1px 8px; border-radius: 2px; border: 1px solid var(--border); }
+  .fix-priority { font-size: 0.6875rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; padding: 1px 8px; border-radius: 2px; }
+  .fix-priority.high { background: rgba(239,68,68,0.1); color: var(--grade-f); border: 1px solid rgba(239,68,68,0.25); }
+  .fix-priority.medium { background: rgba(234,179,8,0.12); color: #854d0e; border: 1px solid rgba(234,179,8,0.3); }
+  .fix-priority.low { background: rgba(77,169,228,0.1); color: #2a7ab5; border: 1px solid rgba(77,169,228,0.25); }
+  .fix-issue { font-size: 0.875rem; color: var(--muted); margin-bottom: 0.5rem; }
+  .fix-suggestion { font-size: 0.875rem; color: var(--text); padding: 0.625rem 0.875rem; background: rgba(77,169,228,0.06); border: 1px solid rgba(77,169,228,0.2); border-radius: 3px; }
+
+  /* Footer */
+  /* Metrics grid (quantitative) */
+  .metrics-grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 0.5rem; margin-bottom: 2rem; }
+  .metric { background: var(--card); border: 1px solid var(--border); border-radius: 4px; padding: 0.875rem 1rem; }
+  .metric .label { font-size: 0.625rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted); font-weight: 600; margin-bottom: 0.25rem; }
+  .metric .value { font-size: 1.25rem; font-weight: 700; color: var(--black); font-variant-numeric: tabular-nums; }
+  .metric .sub { font-size: 0.6875rem; color: var(--muted); margin-top: 0.125rem; }
+
+  /* Session timeline */
+  .timeline { background: var(--card); border: 1px solid var(--border); border-radius: 4px; padding: 1rem 1.25rem; }
+  .timeline-bar { display: flex; height: 28px; border-radius: 3px; overflow: hidden; margin-bottom: 0.875rem; }
+  .phase { display: flex; align-items: center; justify-content: center; font-size: 0.6875rem; font-weight: 600; color: #fff; text-transform: uppercase; letter-spacing: 0.05em; min-width: 40px; }
+  .phase.research { background: #3b82f6; }
+  .phase.setup { background: #10b981; }
+  .phase.execution { background: #8b5cf6; }
+  .phase.validation { background: #06b6d4; }
+  .phase.interrupt { background: #f59e0b; }
+  .timeline-rows { display: flex; flex-direction: column; gap: 0.375rem; }
+  .timeline-row { display: grid; grid-template-columns: 60px 110px 1fr; gap: 0.875rem; font-size: 0.8125rem; align-items: baseline; }
+  .timeline-row .dur { font-variant-numeric: tabular-nums; color: var(--muted); font-family: 'Geist Mono', 'SF Mono', monospace; font-size: 0.75rem; }
+  .timeline-row .phase-chip { font-size: 0.6875rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; padding: 2px 8px; border-radius: 2px; color: #fff; width: fit-content; }
+  .timeline-row .phase-chip.research { background: #3b82f6; }
+  .timeline-row .phase-chip.setup { background: #10b981; }
+  .timeline-row .phase-chip.execution { background: #8b5cf6; }
+  .timeline-row .phase-chip.validation { background: #06b6d4; }
+  .timeline-row .phase-chip.interrupt { background: #f59e0b; }
+
+  /* Tool call breakdown */
+  .tool-breakdown { background: var(--card); border: 1px solid var(--border); border-radius: 4px; padding: 1rem 1.25rem; display: flex; flex-direction: column; gap: 0.5rem; }
+  .tool-row { display: grid; grid-template-columns: 110px 1fr 50px; gap: 0.75rem; align-items: center; font-size: 0.8125rem; }
+  .tool-row .name { font-family: 'Geist Mono', 'SF Mono', monospace; color: var(--text); font-weight: 500; }
+  .tool-row .bar-track { height: 8px; background: #f6f5f5; border-radius: 2px; overflow: hidden; }
+  .tool-row .bar-fill { height: 100%; background: var(--brand); border-radius: 2px; }
+  .tool-row .count { text-align: right; font-variant-numeric: tabular-nums; font-weight: 600; color: var(--text); }
+
+  /* Error list on agent card */
+  .agent-card .body .error { padding: 0.5rem 0.75rem; background: rgba(239,68,68,0.06); border: 1px solid rgba(239,68,68,0.2); border-radius: 3px; font-size: 0.8125rem; }
+  .agent-card .body .error .stage { font-family: 'Geist Mono', 'SF Mono', monospace; font-size: 0.6875rem; color: var(--grade-f); text-transform: uppercase; letter-spacing: 0.05em; margin-right: 0.5rem; }
+  .agent-card .body .error .msg { color: var(--text); }
+  .agent-card .body .error .recovered { font-size: 0.6875rem; padding: 1px 6px; border-radius: 2px; margin-left: 0.5rem; }
+  .agent-card .body .error .recovered.yes { background: rgba(34,197,94,0.12); color: #166534; }
+  .agent-card .body .error .recovered.no { background: rgba(239,68,68,0.12); color: var(--grade-f); }
+
+  footer { margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--border); display: flex; align-items: center; justify-content: center; gap: 0.5rem; font-size: 0.75rem; color: var(--muted); }
+  footer a { color: var(--brand); text-decoration: none; font-weight: 500; }
+  footer a:hover { text-decoration: underline; }
+
+  @media (max-width: 720px) {
+    .scorecard { grid-template-columns: 1fr; justify-items: center; text-align: center; }
+    .stat-grid { grid-template-columns: repeat(2, 1fr); }
+    .metrics-grid { grid-template-columns: repeat(2, 1fr); }
+    .two-col { grid-template-columns: 1fr; }
+    .timeline-row { grid-template-columns: 50px 90px 1fr; }
+  }
+</style>
+</head>
+<body>
+
+<div class="container">
+
+  <header>
+    <div class="header-left">
+      <h1>Audit Agent Experience</h1>
+      <div class="meta">{{TARGET_REF}}</div>
+      <div class="meta" style="margin-top:0.25rem;">{{META}}</div>
+    </div>
+    <div class="header-logo" style="display:flex;align-items:center;gap:0.5rem;color:var(--muted);font-size:0.8125rem;font-weight:500;">
+      <span>audit-agent-experience</span>
+    </div>
+  </header>
+
+  <div class="scorecard">
+    <div class="grade-badge {{GRADE_CLASS}}">{{GRADE_LETTER}}</div>
+    <div class="score-block">
+      <div class="score-label">Overall DX Score</div>
+      <div class="score-value">{{OVERALL_SCORE}} / 100</div>
+      <div class="score-sub">Weighted across 5 dimensions · {{AGENT_COUNT}} agents tested</div>
+    </div>
+  </div>
+
+  <div class="stat-grid">
+    <div class="stat"><div class="label">Agents</div><div class="value">{{AGENT_COUNT}}</div></div>
+    <div class="stat"><div class="label">Completed</div><div class="value ok">{{COMPLETED_COUNT}}</div></div>
+    <div class="stat"><div class="label">Stuck</div><div class="value warn">{{STUCK_COUNT}}</div></div>
+    <div class="stat"><div class="label">Errored</div><div class="value bad">{{ERRORED_COUNT}}</div></div>
+  </div>
+
+  <div class="section">
+    <h2>Quantitative Metrics</h2>
+    {{METRICS_GRID}}
+  </div>
+
+  <div class="section">
+    <h2>Executive Summary</h2>
+    <div class="section-body">
+      <p class="exec-summary">{{EXEC_SUMMARY}}</p>
+    </div>
+  </div>
+
+  <div class="section">
+    <h2>What Agents Said</h2>
+    <div class="two-col">
+      <div class="col good">
+        <h3>What worked</h3>
+        <ul>{{WENT_WELL_ITEMS}}</ul>
+      </div>
+      <div class="col bad">
+        <h3>What didn't</h3>
+        <ul>{{DIDNT_GO_WELL_ITEMS}}</ul>
+      </div>
+    </div>
+  </div>
+
+  <div class="section">
+    <h2>Dimension Breakdown</h2>
+    {{DIMENSION_ROWS}}
+  </div>
+
+  <div class="section">
+    <h2>Session Timeline</h2>
+    {{TIMELINE_SECTION}}
+  </div>
+
+  <div class="section">
+    <h2>Tool Call Breakdown</h2>
+    {{TOOL_BREAKDOWN_SECTION}}
+  </div>
+
+  {{PATTERNS_SECTION}}
+
+  <div class="section">
+    <h2>Recommended Fixes</h2>
+    {{FIXES_LIST}}
+  </div>
+
+  <div class="section">
+    <h2>Per-agent Runs <span class="count">{{AGENT_COUNT}}</span></h2>
+    {{AGENT_CARDS}}
+  </div>
+
+</div>
+
+<footer>
+  Generated by <a href="https://github.com/jay/audit-agent-experience">audit-agent-experience</a>
+</footer>
+
+</body>
+</html>

--- a/skills/audit-agent-experience/references/subagent-brief.md
+++ b/skills/audit-agent-experience/references/subagent-brief.md
@@ -1,0 +1,158 @@
+# Subagent Brief
+
+The brief wraps the tiny task prompt. Fill `{{EXEC_MODE}}` and `{{TASK_PROMPT}}`. Nothing else.
+
+## Template
+
+```
+You are an AI agent being benchmarked on how well you can onboard to a product using only its public documentation and your real tools. Your goal is to actually attempt the task below end-to-end.
+
+Task:
+{{TASK_PROMPT}}
+
+You are succeeding when you complete whatever the product's getting-started guide treats as "done" — its primary successful outcome. The docs tell you what that is; you decide what counts as success based on them, and honestly report whether you got there.
+
+Do NOT assume the success criterion is any particular action. Read the docs, infer what the guide is trying to accomplish, attempt it, and tell me whether you succeeded.
+
+Rules of engagement:
+- Use your real tools: WebFetch to read docs, Read/Write for files, {{EXEC_MODE_TOOLS}}.
+- Discover the docs yourself. Do NOT expect the docs to be pasted into this prompt — there are none attached.
+- {{CREDENTIALS_RULE}}
+- Work in the current directory; do not cd elsewhere. Clean up temp files you create.
+- If a step fails, try once more with a different approach before giving up. Do not loop indefinitely.
+- Stay on-task: you are not allowed to browse unrelated docs or explore the web outside what the task requires.
+
+Execution mode: {{EXEC_MODE}}
+{{EXEC_MODE_NOTE}}
+
+As you work, internally track:
+- Every tool call you make (name + 1-line purpose).
+- Every error you hit (short message + whether you recovered).
+- Every page you fetched from the target's documentation.
+- Every credential/config prompt you issued to the user.
+- Roughly how long the agent-reasoning portion took (seconds — your best estimate).
+- Whether you achieved the end-state the task asked for.
+
+## Output format
+
+Write your working thoughts, attempts, and final outcome in free prose. Then — at the very end — emit exactly one fenced JSON code block matching this schema. Nothing after it.
+
+```json
+{
+  "persona": "<persona-label>",
+  "language": "<language-label>",
+  "task_prompt": "<the one-sentence task you received>",
+  "onboarding_status": "completed | partial | stuck | blocked-on-credentials",
+  "primary_outcome_achieved": "<one short sentence describing what you actually did — e.g. 'Created a cloud browser session, navigated to browserbase.com, took a screenshot, closed.'>",
+  "success_criterion_from_docs": "<one sentence stating what the docs themselves define as 'you've completed the getting-started guide' — extract this from the docs verbatim if possible>",
+  "docs_promise_met": <true | false — does your primary_outcome_achieved match the success_criterion_from_docs?>,
+  "evidence": "<concrete proof — stdout line, file path, session ID, printed result, etc>",
+  "wall_time_estimate_sec": <integer seconds, rough>,
+  "time_to_first_working_code_sec": <integer or null>,
+  "tool_calls": [
+    {"tool": "WebFetch", "count": 4, "purpose": "fetched docs pages"},
+    {"tool": "Bash", "count": 7, "purpose": "npm install, ran script"},
+    {"tool": "Write", "count": 1, "purpose": "created index.ts"}
+  ],
+  "doc_pages_fetched": <integer>,
+  "errors": [
+    {"stage": "install | config | execution | doc-fetch", "message": "<short>", "recovered": true}
+  ],
+  "retries": <integer total retries across all steps>,
+  "interruptions_asking_for_creds": <integer count of times you stopped to ask user for a credential>,
+  "code_attempts": <integer number of distinct code files/snippets you produced>,
+  "completed_subtasks": [
+    "fetched quickstart",
+    "installed deps",
+    "wrote minimal script",
+    "ran successfully with real credentials"
+  ],
+  "detailed_trace": [
+    {"t_ms": 0, "type": "milestone", "message": "agent_started"},
+    {"t_ms": 800, "type": "assistant_thought", "message": "I'll start by discovering the docs."},
+    {"t_ms": 1200, "type": "tool_use", "n": 1, "tool": "WebFetch", "input": {"url": "https://docs.example.com", "prompt": "What is this?"}},
+    {"t_ms": 3400, "type": "tool_result", "n": 1, "output": "# Example Product\n\nGet started by..."},
+    {"t_ms": 4000, "type": "assistant_thought", "message": "Now I need to install the SDK."},
+    {"t_ms": 4500, "type": "tool_use", "n": 2, "tool": "Bash", "input": {"command": "npm install example-sdk", "description": "Install SDK"}},
+    {"t_ms": 9200, "type": "tool_result", "n": 2, "output": "added 12 packages, audited 13 packages..."},
+    {"t_ms": 12000, "type": "error", "n": 3, "stage": "install", "message": "PEP 668 blocked system pip", "recovered": true},
+    {"t_ms": 45000, "type": "result", "success": true, "summary": "Session created, task done."}
+  ],
+  "friction_points": [
+    {
+      "severity": "critical | high | medium | low",
+      "phase": "setup | config | execution | teardown",
+      "quote_or_section": "<short quote from doc, or section name, or absence note>",
+      "issue": "<what hurt and why>"
+    }
+  ],
+  "positive_moments": [
+    "<one-liner noting a concrete thing the docs or product did well>"
+  ]
+}
+```
+
+## Detailed trace — required field
+
+`detailed_trace` is an ordered array of every significant event during your run: milestones, your own reasoning steps, every tool call with its input, every tool result (truncate output to ~500 chars if very long), errors, and the final result. This mirrors how a real trace viewer shows an agent run — the user should be able to follow exactly what you did and why.
+
+Event types (use `type` field):
+- `milestone` — stage markers (e.g. `"agent_started"`, `"sdk_installed"`, `"first_code_written"`, `"first_run_attempted"`)
+- `assistant_thought` — your own reasoning/narration between tool calls. One per distinct thought. Be genuine — this is the "thinking out loud" between actions.
+- `tool_use` — every tool call. Include `n` (1-indexed sequence), `tool` (name), `input` (full input args as an object).
+- `tool_result` — every tool result. Include matching `n`, `output` (trimmed to ≤500 chars with `...` if truncated). If the result was an error, also include `error: true`.
+- `error` — any error that wasn't already covered by a `tool_result` (e.g. a thrown runtime error, an assertion failure). Include `stage`, `message`, `recovered` (bool).
+- `result` — final outcome. Include `success` (bool) and `summary` (one-liner).
+
+Timestamps: `t_ms` = milliseconds since you started the task. You don't have real timestamps — estimate based on how long each step felt. It's fine to round to the nearest 100ms. The ordering is what matters most; the spacing just gives a visual sense of pacing.
+
+**Redact credentials.** If a tool input or result contains a raw API key, token, or secret value, replace it with `[REDACTED]` before writing it into the trace.
+
+## Final checks before you output
+
+- The JSON block is the LAST thing in your response.
+- **`success_criterion_from_docs` is extracted from the docs, not invented.** Quote or paraphrase what the getting-started guide says the end-state is ("you should see…", "the session is now running…", "you've successfully made your first charge", etc). If the docs never say what success looks like, that's itself a finding — state `"docs do not define a success criterion"` and set `docs_promise_met: false`.
+- `onboarding_status = "completed"` only when you believe you reached the docs' success criterion.
+- `"blocked-on-credentials"` if the only thing stopping you is missing keys.
+- `docs_promise_met` is independent of `onboarding_status` — the docs might set a bar you met (true) or might have been silent/misleading (false) even if you "completed" something.
+- `friction_points` cite specific passages, absences, or errors — not vague complaints.
+- If nothing went wrong, `friction_points` may be `[]`. If nothing stood out, `positive_moments` may be `[]`.
+- `wall_time_estimate_sec` is your best estimate of how long this would take a real agent doing real tool calls.
+```
+
+## Placeholders to fill
+
+- `{{TASK_PROMPT}}` — the one-sentence task (from prompt-variants). Abstract, no steps.
+- `{{CREDENTIALS_RULE}}` — depends on whether the user opted to auto-inject credentials:
+
+  **If credentials = None (friction test):**
+  > If the task needs credentials (API keys, tokens), STOP and ask the user in one clear message. That ask counts as friction — do not try to fake or skip it. Even in draft-only mode, you must still issue the credential request — mark it in your trace and continue drafting what you can.
+
+  **If credentials = Auto-inject (user provided):**
+  > Credentials have been provided in your workspace `.env` file under **generic, product-agnostic names** (`API_KEY`, and optionally `PROJECT_ID` / `SECRET`). The names `API_KEY` / `PROJECT_ID` / `SECRET` are NOT what the product's SDK necessarily expects — they are just neutral containers for the values.
+  >
+  > To use them: (1) read the product's docs to find out what env var / config option the SDK actually expects (e.g. the docs might say "set `FOOBAR_API_KEY`"). (2) Then either re-export in shell (`export FOOBAR_API_KEY=$API_KEY`) before running, or pass directly in code (`new Foo({ apiKey: process.env.API_KEY })`). You must not assume a specific env var name — discover it from the docs.
+  >
+  > Do NOT log, echo, or print the raw credential values. If you hit an auth error despite having credentials, record it in `errors[]` with stage="config" — that's real friction (and usually a doc-clarity issue). `interruptions_asking_for_creds` should be 0 since the values are provided; but if you can't figure out the mapping from the docs, record that as a friction_point.
+
+## Exec mode resolution
+
+Fill placeholders based on user's `exec_mode`:
+
+- `exec_mode = "Allow Bash (Recommended)"`:
+  - `{{EXEC_MODE}}` → `Allow Bash (real execution on host machine)`
+  - `{{EXEC_MODE_TOOLS}}` → `Bash to install deps and run code`
+  - `{{EXEC_MODE_NOTE}}` → `You may run npm, pip, curl, git clone, node, python, etc. Be conservative — don't modify files outside cwd unless the task requires it.`
+
+- `exec_mode = "Draft-only"`:
+  - `{{EXEC_MODE}}` → `Draft-only (no shell execution)`
+  - `{{EXEC_MODE_TOOLS}}` → `but NOT Bash`
+  - `{{EXEC_MODE_NOTE}}` → `Do not run any Bash commands. Draft the code you would run, list the commands you would execute, and score the docs based on what you could gather from WebFetch alone.`
+
+## Notes for the skill driver (you, the parent)
+
+- Invoke each Agent in parallel (one message, multiple Agent calls).
+- Use `subagent_type: "general-purpose"`.
+- Parse the last fenced JSON block with regex: `/```json\s*(\{[\s\S]*?\})\s*```\s*$/`.
+- If parsing fails, mark trace `errored` with a `raw_tail` (last 500 chars) for debugging.
+- If a subagent stops to ask for credentials, its `completion_status` should be `"blocked-on-credentials"`. The ask itself is captured in `interruptions_asking_for_creds` — do not interactively answer during the run.

--- a/skills/event-prospecting/.gitignore
+++ b/skills/event-prospecting/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+*.log
+.DS_Store

--- a/skills/event-prospecting/SKILL.md
+++ b/skills/event-prospecting/SKILL.md
@@ -147,21 +147,51 @@ Expected: roughly 0.4-0.6× the speaker count (most events have ~2 speakers per 
 
 **Fast pass — one tool call per company, no deep research.** Score every company in `seed_companies.txt` against the user's ICP and write a thin triage stub to `companies/{slug}.md`. Companies with `icp_fit_score >= --icp-threshold` (default 6) advance to Step 7's deep research; the rest stay as triage stubs.
 
-**Dispatch pattern**: split `seed_companies.txt` into batches of ~10 and fan out N subagents in a single Agent batch. Each subagent runs the prompt from `references/workflow.md` → "ICP Triage Subagent". Hard cap: **1 tool call per company** (just `extract_page.mjs` on the homepage), enforced via the `# bb call N/1` comment pattern.
+**Dispatch pattern**: split `seed_companies.txt` into batches of ~10 and fan out N subagents in a SINGLE Agent batch (multiple Agent tool calls in one message). Each subagent runs the prompt from `references/workflow.md` → "ICP Triage" section. Hard cap: **1 tool call per company** (just `extract_page.mjs` on the homepage), enforced via the `# bb call N/1` comment pattern.
 
 ```bash
-# Split seed_companies.txt into ~10-company batches
-split -l 10 {OUTPUT_DIR}/seed_companies.txt {OUTPUT_DIR}/_batch_triage_
+# Build batch files: each batch line is "name|website" so subagents have homepage URLs
+# (seed_companies.txt only has names; we need URLs from people.jsonl)
+node -e '
+const fs = require("fs");
+const people = fs.readFileSync("{OUTPUT_DIR}/people.jsonl", "utf-8").split("\n").filter(Boolean).map(JSON.parse);
+const seed = fs.readFileSync("{OUTPUT_DIR}/seed_companies.txt", "utf-8").split("\n").filter(Boolean);
+const url = {};
+for (const p of people) if (p.company && !url[p.company]) url[p.company] = p.companyUrl || p.website || "";
+const lines = seed.map(c => `${c}|${url[c] || ""}`);
+fs.writeFileSync("{OUTPUT_DIR}/_seed_with_urls.txt", lines.join("\n") + "\n");
+'
 
-# Count batches → number of subagents to dispatch
+# Split into ~10-company batches
+split -l 10 {OUTPUT_DIR}/_seed_with_urls.txt {OUTPUT_DIR}/_batch_triage_
+
+# Count batches → number of subagents to dispatch (cap at 6 per message; second wave for the rest)
 ls {OUTPUT_DIR}/_batch_triage_* | wc -l
 ```
 
-Then in a single message, dispatch one Agent call per batch. Each Agent gets the prompt from `references/workflow.md` → "ICP Triage Subagent" with these substitutions:
-- `{SKILL_DIR}` → full literal skill path
+Then in a single message, dispatch one Agent call per batch (up to 6 in parallel; subsequent waves after the first returns). Each Agent gets the prompt from `references/workflow.md` → "ICP Triage" with these substitutions before sending:
+- `{SKILL_DIR}` → full literal skill path (e.g. `/Users/jay/skills/skills/event-prospecting`)
 - `{OUTPUT_DIR}` → full literal output path
 - `{USER_COMPANY}`, `{USER_PRODUCT}`, `{ICP_DESCRIPTION}` → from the loaded profile
-- `{COMPANY_LIST}` → contents of `_batch_triage_aa` (or whichever batch this subagent owns)
+- `{EVENT_NAME}` → `recon.json` `.title`
+- `{COMPANY_LIST}` → contents of the batch file (e.g. `cat {OUTPUT_DIR}/_batch_triage_aa`)
+- `{TOTAL}` → number of lines in this batch (substitute into `# bb call N/{TOTAL}`)
+
+**Agent dispatch (skeleton, repeat per batch in one message)**:
+
+```
+Agent(
+  description: "ICP triage batch aa",
+  prompt: <ICP Triage prompt from workflow.md with all placeholders substituted>,
+  subagent_type: "general-purpose"
+)
+Agent(
+  description: "ICP triage batch ab",
+  prompt: <same prompt template, COMPANY_LIST swapped to batch ab>,
+  subagent_type: "general-purpose"
+)
+... up to 6 per message
+```
 
 After all subagents return, verify every company in `seed_companies.txt` has a corresponding `companies/{slug}.md`:
 
@@ -194,22 +224,38 @@ Expected: 20-40% of `seed_companies.txt`. If the survival rate is < 10%, the thr
 
 Full Plan→Research→Synthesize on ICP-fit companies only. Hard cap: **5 tool calls per company** (homepage extract + 2-3 sub-question searches + 1-2 supplementary fetches). Subagents OVERWRITE the existing `companies/{slug}.md` triage stub with the richer deep-research version (frontmatter `triage_only: false`).
 
-**Dispatch pattern**: split `icp_fits.txt` into batches of ~5 (deep mode default) and fan out one Agent per batch. Each Agent gets the prompt from `references/workflow.md` → "Deep Research Subagent" with these substitutions:
-- `{SKILL_DIR}`, `{OUTPUT_DIR}`, `{USER_COMPANY}`, `{USER_PRODUCT}`, `{ICP_DESCRIPTION}`, `{EVENT_NAME}` (from `recon.json` title)
-- `{COMPANY_LIST}` → contents of the batch file
+**Dispatch pattern**: split `icp_fits.txt` into batches of ~5 (deep mode default) and fan out one Agent per batch in a SINGLE message (up to 6 Agents per message). Each Agent gets the prompt from `references/workflow.md` → "Deep Research" with these substitutions:
+- `{SKILL_DIR}`, `{OUTPUT_DIR}`, `{USER_COMPANY}`, `{USER_PRODUCT}`, `{ICP_DESCRIPTION}`
+- `{EVENT_NAME}` (from `recon.json` `.title`), `{EVENT_CONTEXT}` (track / topic, manually inferred from the event homepage)
+- `{COMPANY_LIST}` → contents of the batch file (each line `slug|website`)
 
 ```bash
-# Build {company-slug, website} pairs by reading frontmatter from each triage stub
+# Build {company-slug|website} pairs by reading frontmatter from each triage stub
 while read slug; do
   website=$(awk '/^website:/{print $2; exit}' {OUTPUT_DIR}/companies/${slug}.md)
   echo "${slug}|${website}"
 done < {OUTPUT_DIR}/icp_fits.txt > {OUTPUT_DIR}/_deep_targets.txt
 
-# Split into ~5-company batches
+# Split into ~5-company batches (deep mode)
 split -l 5 {OUTPUT_DIR}/_deep_targets.txt {OUTPUT_DIR}/_batch_deep_
+ls {OUTPUT_DIR}/_batch_deep_* | wc -l
 ```
 
-Then in a single message, dispatch one Agent call per batch with the "Deep Research Subagent" prompt.
+**Agent dispatch (skeleton, repeat per batch in one message)**:
+
+```
+Agent(
+  description: "Deep research batch aa",
+  prompt: <Deep Research prompt from workflow.md with all placeholders substituted; COMPANY_LIST = cat _batch_deep_aa>,
+  subagent_type: "general-purpose"
+)
+Agent(
+  description: "Deep research batch ab",
+  prompt: <same template, COMPANY_LIST = cat _batch_deep_ab>,
+  subagent_type: "general-purpose"
+)
+... up to 6 per message; second wave after the first returns
+```
 
 After all subagents return, verify the deep-research files exist and have `triage_only: false`:
 
@@ -257,11 +303,28 @@ console.error(`Enriching ${keep.length} of ${lines.length} speakers`);
 split -l 5 {OUTPUT_DIR}/_people_to_enrich.jsonl {OUTPUT_DIR}/_batch_people_
 ```
 
-Then in a single message, dispatch one Agent call per batch with the prompt from `references/workflow.md` → "Person Enrichment Subagent". Each subagent's prompt should include:
+Then in a single message, dispatch one Agent call per batch (up to 6 per message) with the prompt from `references/workflow.md` → "Person Enrichment". Each subagent's prompt should include:
 - `{SKILL_DIR}`, `{OUTPUT_DIR}`, `{DEPTH}` (`deep` | `deeper`)
 - `{USER_COMPANY}`, `{USER_PRODUCT}`, `{ICP_DESCRIPTION}`
-- `{EVENT_NAME}` (from `recon.json` title)
+- `{EVENT_NAME}` (from `recon.json` `.title`)
+- `{LANES}` → `2` for deep mode, `4` for deeper mode (substituted into `# bb call N/{LANES}`)
 - `{PEOPLE_BATCH}` → contents of `_batch_people_aa` (each line a JSON record from `people.jsonl`)
+
+**Agent dispatch (skeleton, repeat per batch in one message)**:
+
+```
+Agent(
+  description: "Person enrichment batch aa",
+  prompt: <Person Enrichment prompt from workflow.md with all placeholders substituted; PEOPLE_BATCH = cat _batch_people_aa>,
+  subagent_type: "general-purpose"
+)
+Agent(
+  description: "Person enrichment batch ab",
+  prompt: <same template, PEOPLE_BATCH = cat _batch_people_ab>,
+  subagent_type: "general-purpose"
+)
+... up to 6 per message
+```
 
 After all subagents return, verify the people files exist:
 

--- a/skills/event-prospecting/SKILL.md
+++ b/skills/event-prospecting/SKILL.md
@@ -1,0 +1,306 @@
+---
+name: event-prospecting
+description: |
+  Event prospecting skill. Takes a conference / event speakers URL,
+  extracts the people, filters their companies against the user's
+  ICP, then deep-researches only the speakers at ICP-fit companies.
+  Outputs a person-first HTML report where each card answers "why
+  should the AE talk to this person?" with all public links and a
+  one-click DM opener.
+  Use when the user wants to: (1) find leads at a specific
+  conference, (2) prep for an event, (3) research event speakers,
+  (4) build a target list from a sponsor/exhibitor page,
+  (5) scrape conference speakers and rank by ICP fit.
+  Triggers: "find leads at {event}", "research speakers at",
+  "prospect this conference", "stripe sessions leads",
+  "ai engineer summit prospects", "event prospecting",
+  "scrape conference speakers", "who should I meet at".
+license: MIT
+compatibility: Requires bb CLI (@browserbasehq/cli) and BROWSERBASE_API_KEY env var. Also requires browse CLI (@browserbasehq/browse-cli) for JS-heavy pages.
+allowed-tools: Bash Agent AskUserQuestion
+metadata:
+  author: browserbase
+  version: "0.1.0"
+---
+
+# Event Prospecting
+
+Take a conference URL → get a ranked list of people the AE should talk to, with a "why reach out" rationale per person.
+
+**Required**: `BROWSERBASE_API_KEY` env var, `bb` CLI installed (`@browserbasehq/cli`), and `browse` CLI installed (`@browserbasehq/browse-cli`) for JS-heavy speaker pages (most modern event sites).
+
+**Path rules**: Always use the full literal path in all Bash commands — NOT `~` or `$HOME` (both trigger "shell expansion syntax" approval prompts). Resolve the home directory once and use it everywhere. When constructing subagent prompts, replace `{SKILL_DIR}` with the full literal path (typically `/Users/jay/skills/skills/event-prospecting`).
+
+**Output directory**: All event prospecting output goes to `~/Desktop/{event_slug}_prospects_{YYYY-MM-DD-HHMM}/`. Final deliverable is `index.html` (person-first card grid), with `companies.html` and `people.html` alternate views, plus `results.csv` for cold-outbound import.
+
+**CRITICAL — Tool restrictions (applies to main agent AND all subagents)**:
+- All web searches: use `bb search`. NEVER use WebSearch.
+- All page content extraction: use `node {SKILL_DIR}/scripts/extract_page.mjs "<url>"`. This script fetches via `bb fetch`, parses title + meta tags + visible body text, and automatically falls back to `bb browse` when the page is JS-rendered or over 1MB. NEVER hand-roll a `bb fetch | sed` pipeline. NEVER use WebFetch.
+- All research output: subagents write **one markdown file per company OR per person** to `{OUTPUT_DIR}/companies/{slug}.md` or `{OUTPUT_DIR}/people/{slug}.md` using bash heredoc. NEVER use the Write tool or `python3 -c`. See `references/example-research.md` for both file formats.
+- Report compilation: use `node {SKILL_DIR}/scripts/compile_report.mjs {OUTPUT_DIR} --user-company {USER_SLUG} --open`.
+- **Subagents must use ONLY the Bash tool. No other tools allowed.**
+- **HARD TOOL-CALL CAPS**: ICP triage = 1 call/company; deep research = 5 calls/company; person enrichment = 4 calls/person. See `references/workflow.md` for enforcement detail.
+
+**CRITICAL — Anti-hallucination rules (applies to main agent AND all subagents)**:
+- NEVER infer `product_description`, `industry`, or a person's `role_reason` from a site's fonts, framework, design system, or typography. These are cosmetic and say nothing about what the company sells or what the person does.
+- NEVER let the user's own ICP leak into a target's description. If you don't know what the target does, write `Unknown` — do not pattern-match them onto the ICP.
+- `product_description` MUST quote or paraphrase a specific phrase from `extract_page.mjs` output. If none of TITLE/META/OG/HEADINGS/BODY yield a recognizable product statement, write `Unknown — homepage content not accessible` and cap `icp_fit_score` at 3.
+- A person's `hook` MUST quote or paraphrase a specific finding from a `bb search` result (podcast title, blog headline, GitHub repo, talk abstract). If no public signal exists in the last 6 months, fall back to event-context (their talk title at this event).
+
+**CRITICAL — Minimize permission prompts**:
+- Subagents MUST batch ALL file writes into a SINGLE Bash call using chained heredocs. One Bash call = one permission prompt.
+- Batch ALL searches and ALL fetches into single Bash calls using `&&` chaining.
+
+## Pipeline Overview
+
+Follow these 10 steps in order. Do not skip steps or reorder.
+
+0. **Setup** — output dir + clean slate
+1. **Load profile** — read `profiles/{user_slug}.json`
+2. **Recon** — detect event platform
+3. **Extract people** — `people.jsonl`
+4. **Group by company** — `seed_companies.txt`
+5. **ICP triage** — fast company-level scoring (1 call/company)
+6. **Filter** — companies with `icp_fit_score >= --icp-threshold`
+7. **Deep research** — full Plan→Research→Synthesize on ICP fits
+8. **Enrich speakers** — at ICP-fit companies only
+9. **Compile report** — HTML + CSV, open in browser
+
+---
+
+## Step 0: Setup Output Directory
+
+Before starting, create the output directory on the user's Desktop. Filename pattern matches sibling skills:
+
+```bash
+EVENT_SLUG=stripesessions   # derive from URL hostname (e.g. stripesessions.com → stripesessions)
+TIMESTAMP=$(date +%Y-%m-%d-%H%M)
+OUTPUT_DIR=/Users/jay/Desktop/${EVENT_SLUG}_prospects_${TIMESTAMP}
+mkdir -p "$OUTPUT_DIR/companies" "$OUTPUT_DIR/people"
+```
+
+Use the full literal home path — never `~` or `$HOME`. Pass `{OUTPUT_DIR}` as the full literal path to all subagent prompts.
+
+## Step 1: Load User Profile
+
+The profile defines the ICP that ICP triage and deep research score against. Load from `{SKILL_DIR}/profiles/{user_slug}.json` (interchangeable across all GTM skills — same shape as company-research).
+
+```bash
+USER_SLUG=browserbase   # from --user-company flag
+test -f {SKILL_DIR}/profiles/${USER_SLUG}.json || {
+  echo "Profile not found: profiles/${USER_SLUG}.json"
+  echo "Build one first via the company-research skill (Step 1)."
+  exit 1
+}
+cat {SKILL_DIR}/profiles/${USER_SLUG}.json
+```
+
+If the profile is missing, **fail loudly** and point the user at company-research to build one.
+
+The profile yields: `user_company`, `user_product`, `icp_description`. These get embedded verbatim in every subagent prompt downstream.
+
+## Step 2: Recon
+
+Detect the event platform and extraction strategy. One command:
+
+```bash
+node {SKILL_DIR}/scripts/recon.mjs {EVENT_URL} {OUTPUT_DIR}
+```
+
+Writes `{OUTPUT_DIR}/recon.json` with `platform`, `strategy`, and (for Next.js) `nextDataPaths`. See `references/event-platforms.md` for the platform catalog and detection priority.
+
+Expected outcomes:
+- Stripe Sessions class (Next.js): `platform: "next-data"`, 1-3 paths
+- Sessionize: `platform: "sessionize"`
+- Lu.ma / Eventbrite: `platform: "luma" | "eventbrite"`
+- Anything else: `platform: "custom"`, `strategy: "markdown"` (best-effort fallback)
+
+## Step 3: Extract People
+
+```bash
+node {SKILL_DIR}/scripts/extract_event.mjs {OUTPUT_DIR} --user-company {USER_SLUG}
+```
+
+Reads `recon.json`, dispatches to the platform-specific extractor, writes `people.jsonl` (one speaker per line) and `seed_companies.txt` (deduped companies).
+
+The `--user-company` flag also drops the host-org's own employees (a Stripe-hosted event drops Stripe employees) and the user's own employees from the speaker list — those aren't prospects.
+
+Sanity-check the output:
+```bash
+wc -l {OUTPUT_DIR}/people.jsonl {OUTPUT_DIR}/seed_companies.txt
+head -3 {OUTPUT_DIR}/people.jsonl
+```
+
+If `people.jsonl` is empty or under ~10 lines, recon picked the wrong platform — see `references/event-platforms.md` and re-run with adjusted strategy.
+
+## Step 4: Group by Company
+
+`extract_event.mjs` emits `seed_companies.txt` already (one company per line, deduped, sorted). This step is informational — verify the count looks reasonable before fanning out:
+
+```bash
+wc -l {OUTPUT_DIR}/seed_companies.txt
+```
+
+Expected: roughly 0.4-0.6× the speaker count (most events have ~2 speakers per company on average, some companies send 5+, many send 1).
+
+## Step 5: ICP Triage
+
+**Fast pass — one tool call per company, no deep research.** Score every company in `seed_companies.txt` against the user's ICP and write a thin triage stub to `companies/{slug}.md`. Companies with `icp_fit_score >= --icp-threshold` (default 6) advance to Step 7's deep research; the rest stay as triage stubs.
+
+**Dispatch pattern**: split `seed_companies.txt` into batches of ~10 and fan out N subagents in a single Agent batch. Each subagent runs the prompt from `references/workflow.md` → "ICP Triage Subagent". Hard cap: **1 tool call per company** (just `extract_page.mjs` on the homepage), enforced via the `# bb call N/1` comment pattern.
+
+```bash
+# Split seed_companies.txt into ~10-company batches
+split -l 10 {OUTPUT_DIR}/seed_companies.txt {OUTPUT_DIR}/_batch_triage_
+
+# Count batches → number of subagents to dispatch
+ls {OUTPUT_DIR}/_batch_triage_* | wc -l
+```
+
+Then in a single message, dispatch one Agent call per batch. Each Agent gets the prompt from `references/workflow.md` → "ICP Triage Subagent" with these substitutions:
+- `{SKILL_DIR}` → full literal skill path
+- `{OUTPUT_DIR}` → full literal output path
+- `{USER_COMPANY}`, `{USER_PRODUCT}`, `{ICP_DESCRIPTION}` → from the loaded profile
+- `{COMPANY_LIST}` → contents of `_batch_triage_aa` (or whichever batch this subagent owns)
+
+After all subagents return, verify every company in `seed_companies.txt` has a corresponding `companies/{slug}.md`:
+
+```bash
+ls {OUTPUT_DIR}/companies/*.md | wc -l
+# Should equal `wc -l {OUTPUT_DIR}/seed_companies.txt`
+```
+
+Clean up the batch files: `rm {OUTPUT_DIR}/_batch_triage_*`.
+
+## Step 6: Filter by ICP Threshold
+
+Read each `companies/*.md` frontmatter, keep those with `icp_fit_score >= 6` (or whatever `--icp-threshold` is). Write the surviving company slugs to `{OUTPUT_DIR}/icp_fits.txt`:
+
+```bash
+THRESHOLD=6   # from --icp-threshold flag
+for f in {OUTPUT_DIR}/companies/*.md; do
+  score=$(awk '/^icp_fit_score:/{print $2; exit}' "$f")
+  if [ -n "$score" ] && [ "$score" -ge "$THRESHOLD" ]; then
+    basename "$f" .md
+  fi
+done > {OUTPUT_DIR}/icp_fits.txt
+
+wc -l {OUTPUT_DIR}/icp_fits.txt
+```
+
+Expected: 20-40% of `seed_companies.txt`. If the survival rate is < 10%, the threshold may be too high or the ICP description too narrow — surface a warning to the user.
+
+## Step 7: Deep Research
+
+Full Plan→Research→Synthesize on ICP-fit companies only. Hard cap: **5 tool calls per company** (homepage extract + 2-3 sub-question searches + 1-2 supplementary fetches). Subagents OVERWRITE the existing `companies/{slug}.md` triage stub with the richer deep-research version (frontmatter `triage_only: false`).
+
+**Dispatch pattern**: split `icp_fits.txt` into batches of ~5 (deep mode default) and fan out one Agent per batch. Each Agent gets the prompt from `references/workflow.md` → "Deep Research Subagent" with these substitutions:
+- `{SKILL_DIR}`, `{OUTPUT_DIR}`, `{USER_COMPANY}`, `{USER_PRODUCT}`, `{ICP_DESCRIPTION}`, `{EVENT_NAME}` (from `recon.json` title)
+- `{COMPANY_LIST}` → contents of the batch file
+
+```bash
+# Build {company-slug, website} pairs by reading frontmatter from each triage stub
+while read slug; do
+  website=$(awk '/^website:/{print $2; exit}' {OUTPUT_DIR}/companies/${slug}.md)
+  echo "${slug}|${website}"
+done < {OUTPUT_DIR}/icp_fits.txt > {OUTPUT_DIR}/_deep_targets.txt
+
+# Split into ~5-company batches
+split -l 5 {OUTPUT_DIR}/_deep_targets.txt {OUTPUT_DIR}/_batch_deep_
+```
+
+Then in a single message, dispatch one Agent call per batch with the "Deep Research Subagent" prompt.
+
+After all subagents return, verify the deep-research files exist and have `triage_only: false`:
+
+```bash
+grep -l "triage_only: false" {OUTPUT_DIR}/companies/*.md | wc -l
+# Should equal wc -l icp_fits.txt
+```
+
+## Step 8: Enrich Speakers (at ICP fits only)
+
+Per person at an ICP-fit company: harvest LinkedIn URL, recent activity (podcast / blog / talk / GitHub / X), and write `people/{slug}.md`. Hard cap: **4 tool calls per person**, three lanes:
+
+1. `bb search "{name} {company} linkedin"` (always)
+2. `bb search "{name} podcast OR talk OR blog 2026"` (deep+)
+3. `bb search "{name} github"` (deeper)
+4. `bb search "{name} site:x.com OR site:twitter.com"` (deeper)
+
+Quick mode: skip Step 8 entirely. Deep mode: lanes 1-2. Deeper mode: lanes 1-4.
+
+**Dispatch pattern**: filter `people.jsonl` to keep only people whose `.company` is in `icp_fits.txt`, batch the result into groups of ~5 people per subagent, fan out in a single Agent batch.
+
+```bash
+# Filter people.jsonl to ICP-fit companies only
+node -e '
+const fs = require("fs");
+const fits = new Set(fs.readFileSync("{OUTPUT_DIR}/icp_fits.txt", "utf-8").split("\n").filter(Boolean));
+// Map slug → original company name via the triage stub frontmatter
+const slug2name = {};
+for (const slug of fits) {
+  const md = fs.readFileSync(`{OUTPUT_DIR}/companies/${slug}.md`, "utf-8");
+  const m = md.match(/^company_name:\s*(.+)$/m);
+  if (m) slug2name[slug] = m[1].trim();
+}
+const wantNames = new Set(Object.values(slug2name).map(s => s.toLowerCase()));
+const lines = fs.readFileSync("{OUTPUT_DIR}/people.jsonl", "utf-8").split("\n").filter(Boolean);
+const keep = lines.filter(l => {
+  const p = JSON.parse(l);
+  return p.company && wantNames.has(p.company.toLowerCase());
+});
+fs.writeFileSync("{OUTPUT_DIR}/_people_to_enrich.jsonl", keep.join("\n") + "\n");
+console.error(`Enriching ${keep.length} of ${lines.length} speakers`);
+'
+
+# Split into ~5-person batches
+split -l 5 {OUTPUT_DIR}/_people_to_enrich.jsonl {OUTPUT_DIR}/_batch_people_
+```
+
+Then in a single message, dispatch one Agent call per batch with the prompt from `references/workflow.md` → "Person Enrichment Subagent". Each subagent's prompt should include:
+- `{SKILL_DIR}`, `{OUTPUT_DIR}`, `{DEPTH}` (`deep` | `deeper`)
+- `{USER_COMPANY}`, `{USER_PRODUCT}`, `{ICP_DESCRIPTION}`
+- `{EVENT_NAME}` (from `recon.json` title)
+- `{PEOPLE_BATCH}` → contents of `_batch_people_aa` (each line a JSON record from `people.jsonl`)
+
+After all subagents return, verify the people files exist:
+
+```bash
+ls {OUTPUT_DIR}/people/*.md | wc -l
+# Should equal wc -l _people_to_enrich.jsonl
+```
+
+## Step 9: Compile Report
+
+Generate the person-first HTML index, alternate views, and CSV in one command:
+
+```bash
+node {SKILL_DIR}/scripts/compile_report.mjs {OUTPUT_DIR} --user-company {USER_SLUG} --open
+```
+
+This generates:
+- `{OUTPUT_DIR}/index.html` — person-first ranked card grid (opens in browser)
+- `{OUTPUT_DIR}/people.html` — filterable speaker grid (alternate view)
+- `{OUTPUT_DIR}/companies.html` — ICP-ranked company table with attendees
+- `{OUTPUT_DIR}/results.csv` — cold-outbound-ready spreadsheet
+
+Then present a summary in chat:
+
+```
+## Event Prospecting Complete — {Event Name}
+
+- **Total speakers extracted**: {count}
+- **Unique companies**: {count}
+- **ICP fits (score ≥ {threshold})**: {count}
+- **Speakers enriched**: {count}
+- **Score distribution** (companies):
+  - Strong fit (8-10): {count}
+  - Partial fit (5-7): {count}
+  - Weak fit (1-4): {count}
+- **Report opened in browser**: {OUTPUT_DIR}/index.html
+```
+
+Show the **top 5 people cards** as a markdown table sorted by company ICP score, then offer to:
+- Dig deeper into a specific person (uses the 🔬 Research deeper button → CC prompt)
+- Adjust `--icp-threshold` and re-run Steps 6-9
+- Export the CSV to a CRM

--- a/skills/event-prospecting/SKILL.md
+++ b/skills/event-prospecting/SKILL.md
@@ -150,15 +150,22 @@ Expected: roughly 0.4-0.6× the speaker count (most events have ~2 speakers per 
 **Dispatch pattern**: split `seed_companies.txt` into batches of ~10 and fan out N subagents in a SINGLE Agent batch (multiple Agent tool calls in one message). Each subagent runs the prompt from `references/workflow.md` → "ICP Triage" section. Hard cap: **1 tool call per company** (just `extract_page.mjs` on the homepage), enforced via the `# bb call N/1` comment pattern.
 
 ```bash
-# Build batch files: each batch line is "name|website" so subagents have homepage URLs
-# (seed_companies.txt only has names; we need URLs from people.jsonl)
+# Build batch files: each batch line is "name|guessed_homepage|slug".
+# extract_event.mjs only emits company NAMES (no URLs), so we slugify and guess
+# https://{slug-without-spaces}.com as the canonical homepage. The triage subagent
+# is allowed to write product_description: "Unknown — homepage content not accessible"
+# and cap score at 3 if the guessed URL 404s — that's the documented fallback in
+# workflow.md (rule 3 of the ICP Triage prompt). Burning a real bb search to
+# discover the URL would bust the 1-call-per-company HARD CAP.
 node -e '
 const fs = require("fs");
-const people = fs.readFileSync("{OUTPUT_DIR}/people.jsonl", "utf-8").split("\n").filter(Boolean).map(JSON.parse);
+const slugify = (s) => (s || "").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
 const seed = fs.readFileSync("{OUTPUT_DIR}/seed_companies.txt", "utf-8").split("\n").filter(Boolean);
-const url = {};
-for (const p of people) if (p.company && !url[p.company]) url[p.company] = p.companyUrl || p.website || "";
-const lines = seed.map(c => `${c}|${url[c] || ""}`);
+const lines = seed.map(c => {
+  const slug = slugify(c);
+  const guessedHost = c.toLowerCase().replace(/[^a-z0-9]/g, "");
+  return `${c}|https://${guessedHost}.com|${slug}`;
+});
 fs.writeFileSync("{OUTPUT_DIR}/_seed_with_urls.txt", lines.join("\n") + "\n");
 '
 

--- a/skills/event-prospecting/profiles/browserbase.json
+++ b/skills/event-prospecting/profiles/browserbase.json
@@ -1,0 +1,16 @@
+{
+  "company": "Browserbase",
+  "website": "https://www.browserbase.com",
+  "product": "Cloud browser infrastructure for AI agents and automation. Headless Chrome-as-a-service with stealth mode, captcha solving, proxies, session recording. Ships with Stagehand (agent framework) and Director (AI workflow builder). Integrates via SDK, MCP, or Playwright/Puppeteer. Scales from 1 to thousands of concurrent browsers.",
+  "existing_customers": ["Ramp", "Amplitude", "Numeral", "Firecrawl"],
+  "competitors": ["Browserless", "Apify", "BrowserCloud", "BrowserTree", "Notte", "Hyperbrowser", "Anchor Browser", "Steel.dev", "ScrapingBee"],
+  "use_cases": [
+    "Browser agents / AI agents that interact with the web",
+    "Web scraping at scale with stealth + proxies",
+    "Workflow automation (replacing manual SaaS clicking)",
+    "E2E testing in the cloud (Playwright cloud)",
+    "Data extraction — job boards, real estate, news, ecommerce, price monitoring, lead gen",
+    "Vertical automation — fintech, insurance, healthcare, legal, supply chain, GTM"
+  ],
+  "researched_at": "2026-04-23"
+}

--- a/skills/event-prospecting/profiles/example.json
+++ b/skills/event-prospecting/profiles/example.json
@@ -1,0 +1,9 @@
+{
+  "company": "",
+  "website": "",
+  "product": "",
+  "existing_customers": [],
+  "competitors": [],
+  "use_cases": [],
+  "researched_at": ""
+}

--- a/skills/event-prospecting/references/event-platforms.md
+++ b/skills/event-prospecting/references/event-platforms.md
@@ -1,0 +1,203 @@
+# Event-Prospecting — Platform Reference
+
+## Contents
+- [Detection Priority](#detection-priority) — order recon.mjs probes
+- [Next.js / `__NEXT_DATA__`](#nextjs--__next_data__) — Stripe Sessions class
+- [Sessionize](#sessionize) — public JSON API
+- [Lu.ma](#luma) — JSON-LD Event block
+- [Eventbrite](#eventbrite) — JSON-LD Event block
+- [Custom / Markdown Fallback](#custom--markdown-fallback) — last resort
+- [Adding a New Platform](#adding-a-new-platform) — contributor guide
+
+---
+
+## Detection Priority
+
+`recon.mjs` probes the event URL once via `browse goto` + `browse eval`, then chooses the first matching platform from this list:
+
+1. **Next.js / `__NEXT_DATA__`** — `document.getElementById('__NEXT_DATA__')` returns a `<script>` tag.
+2. **Sessionize** — `<meta name="generator">` content matches `/sessionize/i`.
+3. **Lu.ma** — `location.hostname` matches `/lu\.ma/`.
+4. **Eventbrite** — `<meta property="og:site_name">` matches `/eventbrite/i`.
+5. **JSON-LD Event** — at least one `<script type="application/ld+json">` block has `@type === 'Event'`.
+6. **Custom / markdown fallback** — none of the above; the extractor uses `browse get markdown` and parses speaker blocks heuristically.
+
+The order matters: Next.js sites often *also* embed JSON-LD, so probing `__NEXT_DATA__` first gives us the structured data path before falling back to JSON-LD heuristics.
+
+---
+
+## Next.js / `__NEXT_DATA__`
+
+**Detection signature**
+
+```js
+!!document.getElementById('__NEXT_DATA__')
+```
+
+This script tag is emitted by every `getServerSideProps` / `getStaticProps` Next.js page. Its `textContent` is a JSON blob containing every prop hydrated into the React tree at build/request time — including the speaker list for an event microsite.
+
+**Extraction strategy** — `next-data-eval`
+
+`recon.mjs` walks the parsed JSON looking for arrays whose elements are objects with both a `name`-ish key AND a `linkedin` substring somewhere. It records the JSON path of every such array (e.g. `.props.pageProps.featuredSpeakers.speakers.items`) into `recon.nextDataPaths`. The Phase B extractor then runs ONE `browse eval` to harvest those arrays and union them into a single people list.
+
+**Sample output shape** (Stripe Sessions 2026)
+
+```json
+{
+  "platform": "next-data",
+  "strategy": "next-data-eval",
+  "nextDataPaths": [
+    ".props.pageProps.featuredSpeakers.speakers.items",
+    ".props.pageProps.moreSpeakers.speakers.items"
+  ]
+}
+```
+
+A typical speaker object inside one of those arrays:
+
+```json
+{
+  "name": "Patrick Collison",
+  "title": "CEO and Co-founder",
+  "companyName": "Stripe",
+  "linkedInProfile": "https://www.linkedin.com/in/patrickcollison/",
+  "bio": "..."
+}
+```
+
+**Known gotchas**
+
+- The walker also matches `talks[N].speakers` arrays (a denormalized re-listing of the same speakers per session). `recon.mjs` filters those out via regex so we don't double-count.
+- Some Next sites lazy-load speakers AFTER hydration. The 2.5s `browse wait timeout` is usually enough; if a site fails extraction, bump the wait to 5s before declaring it a different platform.
+- Field names vary across sites (`companyName` vs `company` vs `org`, `linkedInProfile` vs `linkedinUrl`). The Phase B extractor normalizes via fallback chains.
+
+---
+
+## Sessionize
+
+**Detection signature**
+
+```html
+<meta name="generator" content="Sessionize.com">
+```
+
+**Extraction strategy** — `sessionize-api` *(stub in v0.1; full implementation in a future phase)*
+
+Sessionize exposes a public read-only JSON API at `https://sessionize.com/api/v2/{event_id}/view/Speakers`. The event ID is in the page URL or embedded JS. v0.1 of `recon.mjs` only sets `strategy: "sessionize-api"` and emits the URL — no API discovery yet.
+
+**Sample output shape**
+
+```json
+{
+  "platform": "sessionize",
+  "strategy": "sessionize-api"
+}
+```
+
+**Known gotchas**
+
+- Some Sessionize-hosted pages bury the event ID behind a custom domain. We may need to scan the page for `sessionize.com/api/v2/...` URLs and pull the ID from there.
+- The Sessionize API returns a flat speaker list — much cleaner than scraping Next.js, when it works.
+
+---
+
+## Lu.ma
+
+**Detection signature**
+
+```js
+/lu\.ma/.test(location.hostname)
+```
+
+Lu.ma always serves on `lu.ma` (or rarely a custom CNAME); the hostname check is decisive.
+
+**Extraction strategy** — `json-ld` *(stub in v0.1)*
+
+Lu.ma embeds an `Event` JSON-LD block with attendee/speaker info, but the volume of structured data is event-dependent. v0.1 sets `strategy: "json-ld"` and defers actual extraction to Phase B+. The fallback markdown extractor handles Lu.ma pages reasonably well in the meantime.
+
+**Sample output shape**
+
+```json
+{
+  "platform": "luma",
+  "strategy": "json-ld"
+}
+```
+
+**Known gotchas**
+
+- Lu.ma often gates the full attendee list behind a login. Public-facing pages usually only show "featured" speakers, not the full list.
+- Some Lu.ma events are private; `recon.mjs` should NOT crash if `__NEXT_DATA__` isn't present and JSON-LD is empty — it falls through to the markdown strategy.
+
+---
+
+## Eventbrite
+
+**Detection signature**
+
+```html
+<meta property="og:site_name" content="Eventbrite">
+```
+
+**Extraction strategy** — `json-ld` *(stub in v0.1)*
+
+Eventbrite emits standard `Event` JSON-LD on every public event page. Speakers are usually only in the prose body, not the structured data — Eventbrite is more of an RSVP platform than a speaker-directory platform. We may need to combine JSON-LD parsing with markdown extraction of the description body.
+
+**Sample output shape**
+
+```json
+{
+  "platform": "eventbrite",
+  "strategy": "json-ld"
+}
+```
+
+**Known gotchas**
+
+- Eventbrite event pages are heavy — `bb fetch` may return >1MB and trigger the size guard. Use `browse get markdown` instead.
+- Most Eventbrite events do NOT publish a speaker list at all. This platform is low-yield for prospecting.
+
+---
+
+## Custom / Markdown Fallback
+
+**Detection signature**
+
+None of the above match. `recon.mjs` sets `platform: "custom"` and `strategy: "markdown"`.
+
+**Extraction strategy** — `markdown`
+
+The Phase B extractor calls `browse get markdown`, splits the output on heading boundaries (`####`, `###`, `##`), and treats each block as a candidate speaker:
+- Line 1: name (must start with capital letter)
+- Line 2: title/role
+- Line 3: company
+- Anywhere in the block: `linkedin.com/in/{handle}`
+
+This is a best-effort fallback. Coverage is typically 60-80% of the actual speaker list; field accuracy is lower than the structured paths.
+
+**Sample output shape**
+
+```json
+{
+  "platform": "custom",
+  "strategy": "markdown"
+}
+```
+
+**Known gotchas**
+
+- Many static event sites use cards (not headings) for speakers. The heading-split heuristic misses those entirely.
+- "Section title" lines (`## Speakers`, `## Schedule`) get parsed as candidate speakers and need to be filtered downstream by checking for the LinkedIn pattern.
+- If markdown extraction yields zero people, the pipeline should surface a "platform unsupported" error rather than emit an empty `people.jsonl`.
+
+---
+
+## Adding a New Platform
+
+1. **Add a detection branch** in `recon.mjs` `probe()` after the existing ones. Pick a cheap signal (a meta tag, hostname, or a specific script tag) that's distinctive.
+2. **Pick a strategy name** — kebab-case verb-phrase like `sessionize-api` or `json-ld-events`.
+3. **Add an extractor branch** in `extract_event.mjs` that handles the new strategy.
+4. **Add a section to this file** with: detection signature, extraction strategy, sample output shape, known gotchas.
+5. **Drop a fixture** under `scripts/__fixtures__/{platform}-snapshot.json` capturing the expected `recon.json` shape so future refactors don't silently break extraction.
+
+Keep the detection branches small. If a platform needs more than ~20 lines of detection logic, factor it out into `scripts/detectors/{platform}.mjs` and import.

--- a/skills/event-prospecting/references/example-research.md
+++ b/skills/event-prospecting/references/example-research.md
@@ -1,0 +1,192 @@
+# Example Research Files
+
+Event-prospecting writes TWO kinds of markdown files:
+
+1. **Company files** — one per company in `seed_companies.txt`, written to `{OUTPUT_DIR}/companies/{slug}.md`. Comes in two flavors: triage stubs (Step 5) and deep-research files (Step 7).
+2. **Person files** — one per speaker at an ICP-fit company, written to `{OUTPUT_DIR}/people/{slug}.md`. Created in Step 8.
+
+The YAML frontmatter contains structured fields for report compilation. The body contains human-readable research.
+
+`{OUTPUT_DIR}` is the per-run Desktop directory set up by the main agent in Step 0 (e.g., `/Users/jay/Desktop/stripesessions_prospects_2026-04-25-2030/`).
+
+---
+
+## Company File — Triage Stub (Step 5 output)
+
+Every company in `seed_companies.txt` gets one of these. It captures a 1-call, ICP-only assessment.
+
+```markdown
+---
+company_name: OpenAI
+website: https://openai.com
+product_description: AI lab building safe AGI; ChatGPT, GPT API, ChatGPT Agent
+icp_fit_score: 9
+icp_fit_reasoning: AI agents at scale need cloud browser infrastructure; ChatGPT Agent shipped Mar 2026
+triage_only: true
+event_context: Stripe Sessions 2026 — featured speaker on AI track
+---
+
+## Triage Notes
+Homepage: "ChatGPT, GPT API, and ChatGPT Agent — AI tools and APIs for everyone."
+Score 9 because ChatGPT Agent ships browser-using AI agents at consumer scale — the canonical fit for browser infrastructure.
+```
+
+**Required fields**: `company_name`, `website`, `icp_fit_score`, `icp_fit_reasoning`, `triage_only: true`.
+
+---
+
+## Company File — Deep Research (Step 7 output)
+
+When a company's `icp_fit_score >= --icp-threshold`, Step 7's deep research overwrites the triage stub with this richer version. `triage_only` flips to `false`.
+
+```markdown
+---
+company_name: OpenAI
+website: https://openai.com
+product_description: Foundational AI lab; products span ChatGPT (consumer chat), GPT API (developer access), and ChatGPT Agent (browser-using autonomous agent)
+industry: AI / Foundation Models
+target_audience: Consumers, developers, enterprise — multi-segment
+key_features: ChatGPT Agent | GPT-5 API | Sora video | enterprise data residency
+icp_fit_score: 9
+icp_fit_reasoning: ChatGPT Agent (Mar 2026) is a browser-using agent at consumer scale — directly addresses the "agents need a browser" wedge. Plus enterprise customers ship internal agents on top of GPT API.
+employee_estimate: 3000+
+funding_info: $11.3B raised; reported $300B valuation 2026
+headquarters: San Francisco, CA
+triage_only: false
+event_context: Stripe Sessions 2026 — Greg Brockman featured speaker, Agents track
+event_relevance: Three OpenAI speakers across the Agents and Infra tracks; ChatGPT Agent demo expected at the event
+---
+
+## Product
+Foundational AI lab. Three product surfaces: ChatGPT (consumer/team chat), GPT API (developer platform), ChatGPT Agent (autonomous browsing agent that completes multi-step tasks). Recently shipped Sora 2 for video.
+
+## Research Findings
+- **[high]** ChatGPT Agent launched Mar 2026 — autonomous web-browsing agent that books, shops, and researches on user's behalf (source: openai.com/index/chatgpt-agent)
+- **[high]** Stripe Sessions 2026 keynote includes Greg Brockman on the Agents track (source: stripesessions.com/speakers)
+- **[medium]** Hiring across "Agent Reliability" team — 12 open roles for browser-automation engineers (source: openai.com/careers, search 2026-04)
+- **[medium]** Reported partnership exploration with infrastructure providers for agent runtime (source: The Information, 2026-03)
+
+## Event Relevance
+Three speakers at Stripe Sessions across Agents and Infra tracks. ChatGPT Agent is the canonical use-case for browser-infrastructure-as-a-product. Pitch angle: durability + scale guarantees the in-house Browserbase-equivalent can't easily match.
+```
+
+**Additional fields vs the stub**: `industry`, `target_audience`, `key_features` (pipe-separated), `employee_estimate`, `funding_info`, `headquarters`, `event_relevance`.
+
+**Body sections**: `## Product`, `## Research Findings`, `## Event Relevance`.
+
+---
+
+## Person File (Step 8 output)
+
+Only created for speakers at ICP-fit companies (those whose company file has `triage_only: false` after Step 7).
+
+```markdown
+---
+name: Greg Brockman
+slug: greg-brockman
+company: OpenAI
+company_slug: openai
+title: President & Co-founder
+links:
+  linkedin: https://www.linkedin.com/in/thegdb/
+  x: https://x.com/gdb
+  github: https://github.com/gdb
+  blog: null
+  podcast: https://lexfridman.com/greg-brockman/
+hook: Recent Lex Fridman conversation on agent reliability — direct fit for the browser-infrastructure durability story
+dm_opener: |
+  Hey Greg — caught your Lex conversation on agent reliability and the
+  "agents are bottlenecked on the browser" framing landed hard. We run
+  the cloud-browser layer that ChatGPT Agent's competitors are shipping
+  on. Worth a 15-min walkthrough before Sessions?
+role_reason: Co-founder, sets infrastructure direction across product surfaces
+event_name: Stripe Sessions 2026
+event_context: Panelist, Agents track ("From demo to dependable: making agents reliable")
+icp_fit_score: 9
+icp_fit_reasoning: AI agents at scale need cloud browser infrastructure; ChatGPT Agent shipped Mar 2026
+enriched_at: 2026-04-25T20:30:00Z
+---
+
+## Why reach out
+- **Why the company**: ChatGPT Agent is the canonical browser-infra customer — see `companies/openai.md`
+- **Why the person**: Co-founder; sets infra direction; specifically called out agent reliability on Lex (Mar 2026)
+- **Hook**: Lex Fridman conversation on agent reliability (45 min, dropped 2026-03-12)
+
+## Public links
+- LinkedIn: https://www.linkedin.com/in/thegdb/
+- X: https://x.com/gdb
+- GitHub: https://github.com/gdb (OpenAI / personal)
+- Podcast: https://lexfridman.com/greg-brockman/
+
+## Recent activity
+- **[high]** Lex Fridman podcast episode on agent reliability, Mar 2026 (source: lexfridman.com/greg-brockman)
+- **[medium]** GitHub activity: contributed to openai/chatgpt-agent-evals (source: github.com/gdb)
+- **[medium]** X thread on "the bottleneck for agents is the browser, not the model" — Apr 2026 (source: x.com/gdb)
+```
+
+**Required fields**: `name`, `slug`, `company`, `links` (object), `hook`, `dm_opener`, `role_reason`, `event_name`, `event_context`, `icp_fit_score`.
+
+**Body sections**: `## Why reach out` (3 bullets that mirror the card), `## Public links`, `## Recent activity` (findings list with confidence levels).
+
+---
+
+## Field Rules
+
+### Company files
+
+- `key_features`: pipe-separated (`|`) list, NOT a JSON array
+- `icp_fit_score`: integer 1-10
+- `icp_fit_reasoning`: one line, references specific findings
+- `triage_only`: boolean (`true` for stubs, `false` after deep research)
+- `event_context`: how this company shows up at the event (sponsor tier, speaker count, track topics)
+- Filename: `{OUTPUT_DIR}/companies/{slug}.md` where slug is lowercase, hyphenated
+
+### Person files
+
+- `links`: YAML object with keys `linkedin`, `x`, `github`, `blog`, `podcast`. Use `null` when not found, not empty string.
+- `hook`: one sentence, sourced from a specific finding (event-context, recent activity, or company-context). Never inferred from memory.
+- `dm_opener`: 2-3 sentences, multi-line YAML string with `|` pipe. References the hook, names a wedge tie-in, ends with a soft CTA.
+- `icp_fit_score` is INHERITED from the corresponding `companies/{company_slug}.md` — keeps cards rankable in the index.
+- Filename: `{OUTPUT_DIR}/people/{slug}.md` where slug is the lowercased + hyphenated person name (e.g. `greg-brockman.md`).
+
+### Both
+
+- One file per entity. If a subagent encounters a duplicate, OVERWRITE with richer data (e.g. Step 7 overwrites Step 5's triage stub for the same company).
+
+---
+
+## Writing via Bash Heredoc
+
+Subagents write these files using bash heredoc to avoid security prompts. Use the full literal `{OUTPUT_DIR}` path — no `~` or `$HOME`:
+
+```bash
+cat << 'PERSON_MD' > /Users/jay/Desktop/stripesessions_prospects_2026-04-25-2030/people/greg-brockman.md
+---
+name: Greg Brockman
+slug: greg-brockman
+...
+---
+
+## Why reach out
+...
+PERSON_MD
+```
+
+Use `'PERSON_MD'` (quoted) as the delimiter to prevent shell variable expansion. Use `'COMPANY_MD'` for company files.
+
+**IMPORTANT**: Write ALL files in a SINGLE Bash call using chained heredocs to minimize permission prompts. One subagent batch (~5 people) = one Bash invocation = one permission prompt.
+
+```bash
+cat << 'PERSON_MD' > {OUTPUT_DIR}/people/greg-brockman.md
+---
+...
+---
+PERSON_MD
+cat << 'PERSON_MD' > {OUTPUT_DIR}/people/sam-altman.md
+---
+...
+---
+PERSON_MD
+```
+
+Chained heredocs in one bash call. The subagent reports back ONLY a count, never raw content.

--- a/skills/event-prospecting/references/report-template.html
+++ b/skills/event-prospecting/references/report-template.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Company Research — {{COMPANY_NAME}}</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --brand: #F03603;
+    --high: #90C94D;
+    --medium: #F4BA41;
+    --low: #F03603;
+    --blue: #4DA9E4;
+    --black: #100D0D;
+    --gray: #514F4F;
+    --border: #edebeb;
+    --bg: #F9F6F4;
+    --card: #ffffff;
+    --text: #100D0D;
+    --muted: #514F4F;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif; background: var(--bg); color: var(--text); line-height: 1.6; font-size: 16px; }
+  .container { max-width: 1060px; margin: 0 auto; padding: 2rem 1.5rem; }
+
+  /* Header */
+  header { margin-bottom: 2rem; display: flex; align-items: center; justify-content: space-between; }
+  .header-left h1 { font-size: 1.5rem; font-weight: 600; margin-bottom: 0.25rem; color: var(--black); }
+  .header-left .meta { color: var(--muted); font-size: 0.875rem; }
+
+  /* Summary bar */
+  .summary { display: flex; gap: 0.75rem; margin-bottom: 2rem; flex-wrap: wrap; }
+  .stat { background: var(--card); border: 1px solid var(--border); border-radius: 4px; padding: 1rem 1.25rem; flex: 1; min-width: 120px; }
+  .stat .label { font-size: 0.6875rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted); font-weight: 600; margin-bottom: 0.25rem; }
+  .stat .value { font-size: 1.5rem; font-weight: 700; color: var(--black); }
+  .stat .value.high { color: var(--high); }
+  .stat .value.medium { color: var(--medium); }
+  .stat .value.low { color: var(--low); }
+
+  /* Score distribution bar */
+  .score-bar { background: var(--card); border: 1px solid var(--border); border-radius: 4px; padding: 1rem 1.25rem; margin-bottom: 2rem; }
+  .score-bar .bar-track { height: 8px; background: #f6f5f5; border-radius: 4px; overflow: hidden; margin-top: 0.5rem; display: flex; }
+  .score-bar .bar-segment { height: 100%; }
+  .score-bar .bar-segment.high { background: var(--high); }
+  .score-bar .bar-segment.medium { background: var(--medium); }
+  .score-bar .bar-segment.low { background: var(--low); }
+  .score-bar .legend { display: flex; gap: 1.5rem; margin-top: 0.5rem; font-size: 0.75rem; color: var(--muted); }
+  .score-bar .legend span::before { content: ''; display: inline-block; width: 8px; height: 8px; border-radius: 2px; margin-right: 4px; vertical-align: middle; }
+  .score-bar .legend .l-high::before { background: var(--high); }
+  .score-bar .legend .l-medium::before { background: var(--medium); }
+  .score-bar .legend .l-low::before { background: var(--low); }
+
+  /* Table */
+  .results-table { width: 100%; border-collapse: collapse; background: var(--card); border: 1px solid var(--border); border-radius: 4px; overflow: hidden; margin-bottom: 2rem; }
+  .results-table th { text-align: left; font-size: 0.6875rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted); font-weight: 600; padding: 0.75rem 1rem; border-bottom: 1px solid var(--border); background: #fafafa; }
+  .results-table td { padding: 0.625rem 1rem; border-bottom: 1px solid var(--border); font-size: 0.875rem; vertical-align: top; }
+  .results-table tr:last-child td { border-bottom: none; }
+  .results-table tr:hover { background: #fdfcfb; }
+  .results-table a { color: var(--brand); text-decoration: none; font-weight: 500; }
+  .results-table a:hover { text-decoration: underline; }
+
+  /* Score badge */
+  .score { display: inline-block; font-size: 0.8125rem; font-weight: 700; padding: 2px 10px; border-radius: 2px; min-width: 32px; text-align: center; }
+  .score.high { background: rgba(144,201,77,0.12); color: #5a8a1a; border: 1px solid rgba(144,201,77,0.3); }
+  .score.medium { background: rgba(244,186,65,0.12); color: #9a7520; border: 1px solid rgba(244,186,65,0.3); }
+  .score.low { background: rgba(240,54,3,0.08); color: var(--low); border: 1px solid rgba(240,54,3,0.2); }
+
+  /* Reasoning text */
+  .reasoning { color: var(--muted); font-size: 0.8125rem; max-width: 300px; }
+
+  /* Footer */
+  footer { margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--border); display: flex; align-items: center; justify-content: center; gap: 0.5rem; font-size: 0.75rem; color: var(--muted); }
+  footer a { color: var(--brand); text-decoration: none; font-weight: 500; }
+  footer a:hover { text-decoration: underline; }
+</style>
+</head>
+<body>
+
+<div class="container">
+  <header>
+    <div class="header-left">
+      <h1>{{TITLE}}</h1>
+      <div class="meta">{{META}}</div>
+    </div>
+    <a href="https://browserbase.com" target="_blank" rel="noopener" style="display:flex;align-items:center;gap:0.5rem;text-decoration:none;color:var(--muted);font-size:0.8125rem;font-weight:500;">
+      <span>Powered by Browserbase</span>
+      <svg width="32" height="32" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg"><rect width="100" height="100" rx="8" fill="#F03603"/><path d="M36 72.2222V27.7778H51.2381C57.5873 27.7778 62.6667 32.8571 62.6667 39.2063V41.746C62.6667 44.6667 61.5873 47.3968 59.7461 49.3651C62.2858 51.4603 63.9366 54.6349 63.9366 58.254V60.7936C63.9366 67.1428 58.8572 72.2222 52.508 72.2222H36ZM42.3493 65.873H52.508C55.3651 65.873 57.5873 63.6508 57.5873 60.7936V58.254C57.5873 55.3968 55.3651 53.1746 52.508 53.1746H42.3493V65.873ZM42.3493 46.8254H51.2381C54.0953 46.8254 56.3175 44.6032 56.3175 41.746V39.2063C56.3175 36.3492 54.0953 34.127 51.2381 34.127H42.3493V46.8254Z" fill="white"/></svg>
+    </a>
+  </header>
+
+  <div class="summary">
+    <div class="stat"><div class="label">Companies</div><div class="value">{{TOTAL}}</div></div>
+    <div class="stat"><div class="label">Strong Fit (8-10)</div><div class="value high">{{HIGH_COUNT}}</div></div>
+    <div class="stat"><div class="label">Partial Fit (5-7)</div><div class="value medium">{{MEDIUM_COUNT}}</div></div>
+    <div class="stat"><div class="label">Weak Fit (1-4)</div><div class="value low">{{LOW_COUNT}}</div></div>
+  </div>
+
+  <div class="score-bar">
+    <div style="display:flex;justify-content:space-between;align-items:baseline;">
+      <span style="font-size:0.875rem;font-weight:500;">Score Distribution</span>
+      <span style="font-size:0.875rem;font-weight:600;color:var(--high);">{{HIGH_PCT}}% strong fit</span>
+    </div>
+    <div class="bar-track">
+      <div class="bar-segment high" style="width:{{HIGH_PCT}}%"></div>
+      <div class="bar-segment medium" style="width:{{MEDIUM_PCT}}%"></div>
+      <div class="bar-segment low" style="width:{{LOW_PCT}}%"></div>
+    </div>
+    <div class="legend">
+      <span class="l-high">Strong (8-10)</span>
+      <span class="l-medium">Partial (5-7)</span>
+      <span class="l-low">Weak (1-4)</span>
+    </div>
+  </div>
+
+  <table class="results-table">
+    <thead>
+      <tr>
+        <th>Score</th>
+        <th>Company</th>
+        <th>Product</th>
+        <th>Industry</th>
+        <th>Fit Reasoning</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{TABLE_ROWS}}
+    </tbody>
+  </table>
+</div>
+
+<footer>
+  <svg width="16" height="16" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg"><rect width="100" height="100" rx="8" fill="#F03603"/><path d="M36 72.2222V27.7778H51.2381C57.5873 27.7778 62.6667 32.8571 62.6667 39.2063V41.746C62.6667 44.6667 61.5873 47.3968 59.7461 49.3651C62.2858 51.4603 63.9366 54.6349 63.9366 58.254V60.7936C63.9366 67.1428 58.8572 72.2222 52.508 72.2222H36ZM42.3493 65.873H52.508C55.3651 65.873 57.5873 63.6508 57.5873 60.7936V58.254C57.5873 55.3968 55.3651 53.1746 52.508 53.1746H42.3493V65.873ZM42.3493 46.8254H51.2381C54.0953 46.8254 56.3175 44.6032 56.3175 41.746V39.2063C56.3175 36.3492 54.0953 34.127 51.2381 34.127H42.3493V46.8254Z" fill="white"/></svg>
+  Generated by <a href="https://github.com/anthropics/skills">company-research</a> · Powered by <a href="https://browserbase.com">Browserbase</a>
+</footer>
+
+</body>
+</html>

--- a/skills/event-prospecting/references/research-patterns.md
+++ b/skills/event-prospecting/references/research-patterns.md
@@ -1,0 +1,280 @@
+<!-- Plan→Research→Synthesize pattern adapted from company-research v1.1.0 (2026-04-25). -->
+<!-- Source: /Users/jay/skills/skills/company-research/references/research-patterns.md -->
+<!-- Keep in sync if the canonical pattern there changes meaningfully. -->
+
+# Event-Prospecting — Research Patterns
+
+## Contents
+- [Plan→Research→Synthesize](#planresearchsynthesize) — canonical pattern (verbatim from company-research)
+- [Self-Research (User's Company)](#self-research-users-company) — done by company-research, consumed here as a profile
+- [Target Company Research](#target-company-research) — sub-question templates
+- [Finding Format](#finding-format) — schema for accumulated facts
+- [Research Loop Rules](#research-loop-rules) — how to stop hallucinating
+- [Depth Mode Behavior](#depth-mode-behavior) — quick / deep / deeper
+- [Synthesis Instructions](#synthesis-instructions) — turn findings into frontmatter
+- [ICP Triage (Step 5 — fast pass)](#icp-triage-step-5--fast-pass) — event-specific
+- [Deep Research (Step 7 — full pass)](#deep-research-step-7--full-pass) — event-specific
+- [Person Enrichment (Step 8 — speakers at ICP fits only)](#person-enrichment-step-8--speakers-at-icp-fits-only) — event-specific
+
+---
+
+## Plan→Research→Synthesize
+
+This reference defines two research contexts:
+1. **Self-Research** — Deep research on the user's own company to build a strong ICP foundation. (For event-prospecting, this is done once by `company-research` and persisted in `profiles/{slug}.json`. Event-prospecting reads the profile at Step 1.)
+2. **Target Research** — Research each ICP-fit company using Plan→Research→Synthesize.
+
+Both use the same 3-phase pattern but with different sub-questions and goals.
+
+## Self-Research (User's Company)
+
+This is the most important research in the pipeline. Every downstream decision depends on it.
+
+### Sub-Questions
+- "What does {company} sell and what specific problem does it solve?"
+- "Who are {company}'s existing customers? What industries, company sizes, and use cases?"
+- "Who are {company}'s competitors and what differentiates them?"
+- "What pricing model does {company} use and who is the typical buyer persona?"
+- "What use cases and pain points does {company}'s marketing emphasize?"
+
+### Page Discovery
+Discover site pages dynamically — do NOT hardcode paths like `/about` or `/customers`:
+1. Fetch `bb fetch --allow-redirects "{company website}/sitemap.xml"` — primary source, has ALL pages
+2. Scan sitemap URLs for keywords: `customer`, `case-stud`, `pricing`, `about`, `use-case`, `blog`, `docs`, `industry`, `solution`
+3. Optionally fetch `bb fetch --allow-redirects "{company website}/llms.txt"` for page descriptions
+4. Pick the 3-5 most relevant URLs from the sitemap and fetch those
+5. Sitemap is the source of truth. llms.txt is bonus context but often incomplete.
+
+### External Research
+- Search: `"{company} customers use cases reviews"`
+- Search: `"{company} alternatives competitors vs"`
+- Fetch 1-2 of the most informative third-party results (G2, blog posts, comparisons)
+
+### Synthesis Output
+From all findings, produce a company profile:
+- **Company**: name
+- **Product**: what they sell, how it works, key capabilities (2-3 sentences, specific)
+- **Existing Customers**: named customers or customer types found
+- **Competitors**: who they compete with, key differentiators
+- **Use Cases**: broad list of use cases the product serves (NOT tied to one vertical)
+
+Do NOT include ICP, pitch angle, or sub-verticals in the profile. Those are per-run targeting decisions made in Step 2 after the profile is confirmed. The profile is a general-purpose company fact sheet that works regardless of which vertical you target next.
+
+### Why This Matters
+A thin profile produces generic search queries, weak lead scoring, and cookie-cutter emails. A rich profile with specific customers, competitors, and use cases produces targeted queries, accurate scoring, and emails that reference real pain points.
+
+---
+
+## Target Company Research
+
+### Sub-Question Templates
+
+Generate sub-questions from these categories based on the ICP and enrichment fields requested. Not every category applies to every company — pick the most relevant.
+
+### Priority 1 (Always ask)
+- **Product/Market**: "What does {company} sell and who are their customers?"
+- **ICP Fit**: "How does {company}'s product/market relate to {sender's ICP description}?"
+
+### Priority 2 (Ask in deep/deeper)
+- **Tech Stack**: "What technologies, frameworks, or infrastructure does {company} use?"
+- **Growth Signals**: "Has {company} raised funding, launched products, or expanded recently?"
+- **Pain Points**: "What challenges might {company} face that {sender's product} addresses?"
+
+### Priority 3 (Ask in deeper only)
+- **Decision Makers**: "Who leads engineering, product, or growth at {company}?"
+- **Competitive Landscape**: "Who are {company}'s competitors and how are they differentiated?"
+- **Customers/Case Studies**: "Who are {company}'s notable customers and what results do they highlight?"
+
+### Search Query Patterns
+
+For each sub-question, generate 2-3 search query variations:
+
+```
+# Product/Market
+"{company name} what they do"
+"{company name} product features customers"
+
+# Tech Stack
+"{company name} tech stack engineering blog"
+"{company name} careers software engineer" (job posts reveal stack)
+
+# Growth Signals
+"{company name} funding round 2025 2026"
+"{company name} launch announcement"
+"{company name} hiring"
+
+# Pain Points
+"{company name} challenges {relevant domain}"
+"{company name} {problem sender solves}"
+
+# Decision Makers
+"{company name} VP engineering CTO LinkedIn"
+"{company name} head of growth product"
+```
+
+## Finding Format
+
+Each finding is a self-contained factual statement tied to a source:
+
+```json
+{
+  "subQuestion": "What does Acme sell and who are their customers?",
+  "fact": "Acme provides checkout optimization for Shopify stores, serving mid-market DTC brands with $5M-$50M revenue",
+  "sourceUrl": "https://acme.com/about",
+  "sourceTitle": "About Acme - Checkout Optimization",
+  "confidence": "high"
+}
+```
+
+**Confidence levels**:
+- `high`: Directly stated on the company's own website or official press
+- `medium`: Inferred from job postings, third-party articles, or indirect signals
+- `low`: Speculative based on industry/category, or from outdated sources
+
+## Research Loop Rules
+
+1. **Process sub-questions by priority** — Priority 1 first, then 2, then 3
+2. **3-5 findings per sub-question, then move on** — Don't exhaust a topic
+3. **Use parallel tool calls** — Search multiple queries simultaneously when possible
+4. **Rephrase, don't retry** — If a search returns poor results, try different keywords
+5. **Fetch selectively** — Don't fetch every URL from search results. Pick the 1-2 most relevant based on title and URL
+6. **Stop at step limit** — Respect the depth mode's step budget per company
+7. **Homepage first** — Always fetch the company's homepage before branching to other pages
+8. **Deduplicate findings** — Don't record the same fact twice from different sources
+
+## Depth Mode Behavior
+
+### Quick Mode (100+ leads)
+- **Skip Phase A** — No sub-question decomposition
+- **Phase B**: Fetch the company homepage. Run 1-2 supplementary searches if homepage data is thin.
+- **Phase C**: Extract available data, score ICP, write email from what's available
+- **Budget**: 2-3 total tool calls per company
+- **Trade-off**: Fast and cheap, but emails may be less personalized
+
+### Deep Mode (25-50 leads)
+- **Phase A**: Decompose into 2-3 sub-questions (Priority 1 + selected Priority 2)
+- **Phase B**: For each sub-question, run 2-3 searches + fetch 1-2 URLs. Target 3-5 findings per sub-question.
+- **Phase C**: Synthesize from all findings. ICP reasoning references specific evidence. Email uses the most specific/compelling finding.
+- **Budget**: 5-8 total tool calls per company
+- **Trade-off**: Good balance of depth and scale
+
+### Deeper Mode (10-25 leads)
+- **Phase A**: Decompose into 4-5 sub-questions (Priority 1 + 2 + selected Priority 3)
+- **Phase B**: Research exhaustively. Fetch multiple pages per company (homepage, about, blog, careers, product pages). Target 3-5 findings per sub-question.
+- **Phase C**: Synthesize with cited evidence. ICP reasoning is detailed. Email references multiple specific signals.
+- **Budget**: 10-15 total tool calls per company
+- **Trade-off**: High quality intelligence, but slow and expensive
+
+## Synthesis Instructions
+
+After the research loop completes for a company, synthesize findings into the output record:
+
+### ICP Scoring
+Score 1-10 using ALL accumulated findings as evidence:
+- **8-10**: Strong match. Multiple high-confidence findings confirm right industry, company stage, and clear pain point alignment. The pitch angle directly addresses a visible need supported by evidence.
+- **5-7**: Partial match. Some findings suggest relevance but key signals are missing or low-confidence. Adjacent industry or unclear pain point.
+- **1-4**: Weak match. Findings indicate wrong segment, too large/small, or no apparent connection to sender's product.
+
+Write `icp_fit_reasoning` referencing specific findings: "Series A fintech (from Crunchbase), uses Selenium for scraping (from job posting), expanding to EU market (from blog) — strong fit for browser infrastructure."
+
+### Email Personalization
+Use the **richest, most specific** findings for email context:
+- Opening: Use the most concrete finding (a specific product feature, a recent launch, a job posting)
+- Bridge: Connect a finding about their challenges/stack to the sender's pitch angle
+- If only low-confidence findings exist, keep the email shorter and more general — don't fabricate specificity
+
+### Enrichment Fields
+Map findings to enrichment fields:
+- `product_description` → from Product/Market findings
+- `industry` → inferred from Product/Market
+- `employee_estimate` → from LinkedIn search or careers page findings
+- `funding_info` → from Growth Signals findings
+- `headquarters` → from company homepage or about page
+- `target_audience` → from Product/Market findings
+- `key_features` → from product page findings
+
+If a field has no supporting findings, leave it empty rather than guessing.
+
+### Anti-Hallucination Rules
+
+Apply these at synthesis time. They exist because the failure mode — especially on Framer/Next.js landing pages with little server-rendered copy — is for the subagent to pattern-match visual cues onto the sender's ICP and fabricate a plausible-sounding description:
+
+1. **Typography is not a product.** Never infer `product_description`, `industry`, or `target_audience` from fonts, design system, framework choice (Framer, Next.js, React), or site polish. "Framer-built" and "uses Geist Mono" are observations about tooling, not signals of what the company sells.
+2. **No ICP leakage.** If the homepage is thin and external search turns up nothing, do NOT default the target's description toward the sender's ICP. Manufacturing AI ≠ browser automation just because both use AI.
+3. **Quote, don't paraphrase from memory.** `product_description` must quote or closely paraphrase a specific phrase from `extract_page.mjs` output (TITLE / META_DESCRIPTION / OG_DESCRIPTION / HEADINGS / BODY) or from an external search result. If no such phrase exists, write `Unknown — homepage content not accessible`.
+4. **Cap scores on thin evidence.** If `product_description` is `Unknown`, set `icp_fit_score` ≤ 3 and `icp_fit_reasoning: Insufficient evidence — homepage returned no readable content`. Do not justify a higher score on inferred signals alone.
+
+---
+
+## ICP Triage (Step 5 — fast pass)
+
+For each company in `seed_companies.txt`, run ONE tool call to fetch the homepage + extract a 1-line product description, then score against the ICP. Output goes to `companies/{slug}.md` with frontmatter:
+
+```yaml
+company_name: OpenAI
+website: https://openai.com
+product_description: "AI lab building safe AGI for everyone"
+icp_fit_score: 9
+icp_fit_reasoning: "AI agents need cloud browser infrastructure at scale; ChatGPT Agent shipped Mar 2026"
+triage_only: true   # NOT yet deep-researched
+event_context: "Stripe Sessions 2026 — featured speaker on AI track"
+```
+
+Companies with `icp_fit_score < {threshold}` (default 6) stay as triage stubs and never get deep-researched. Companies above the threshold advance to Step 7.
+
+**Hard cap: 1 tool call per company.** The only allowed call is `node {SKILL_DIR}/scripts/extract_page.mjs "{company_homepage}"`. Anti-hallucination rule applies in full: if the homepage is JS-rendered and `extract_page.mjs` returns empty BODY, write `product_description: Unknown — homepage content not accessible` and cap the score at 3. Do NOT do a second search to "save" the company — the budget is one call.
+
+The triage subagent batches its 10 `extract_page.mjs` calls and 10 heredoc writes into a SINGLE Bash invocation using `&&` chaining and pipe-separated heredocs. One Bash call = one permission prompt.
+
+## Deep Research (Step 7 — full pass)
+
+Identical to company-research's target research. The ICP-fit companies (typically 20-40% of the seed list) get the full Plan→Research→Synthesize treatment with sub-questions tailored to the event context.
+
+**Hard cap: 5 tool calls per company.** Budget breakdown for deep mode:
+- 1 call: `extract_page.mjs` on the homepage (re-extract; the triage version was scraped down to a 1-liner)
+- 2-3 calls: `bb search` for sub-questions from Priority 1 + 2 (product, tech stack, growth signals)
+- 1-2 calls: `extract_page.mjs` on the most relevant search results (case study, blog post, careers page)
+
+Event-context tweaks the sub-questions. Instead of generic "What does {company} do?", the subagent asks "What is {company} doing with browser automation that's relevant to **Stripe Sessions' agent track**?" — the event name and any track/topic info from `recon.json` is woven into Priority 2 sub-questions.
+
+The deep-research subagent OVERWRITES the triage stub with the richer file (frontmatter `triage_only: false`). The compile step looks at `triage_only` to decide rendering.
+
+## Person Enrichment (Step 8 — speakers at ICP fits only)
+
+Per person at an ICP-fit company:
+- `bb search "{name} {company} linkedin"` — verify role + harvest LinkedIn URL (always)
+- `bb search "{name} podcast OR talk OR blog 2026"` — last 6 months for hooks (deep+)
+- `bb search "{name} github"` — open-source signal (deeper)
+- `bb search "{name} site:x.com OR site:twitter.com"` — recent posts (deeper)
+
+**Hard cap: 4 tool calls per person.** Deep mode runs lanes 1-2 (max 2 calls). Deeper mode runs lanes 1-4 (max 4 calls). Quick mode skips Step 8 entirely.
+
+Each person yields a `people/{slug}.md` with frontmatter:
+
+```yaml
+name: Greg Brockman
+slug: greg-brockman
+company: OpenAI
+title: President & Co-founder
+links:
+  linkedin: https://www.linkedin.com/in/thegdb/
+  x: https://x.com/gdb
+  github: https://github.com/gdb
+  blog: null
+  podcast: https://lexfridman.com/greg-brockman/
+hook: "Recent Lex Fridman interview on agent reliability — direct fit for browser-infra durability story"
+dm_opener: "Hey Greg — saw your Lex Fridman convo on agent reliability..."
+role_reason: "Co-founder, sets infra direction"
+event_name: "Stripe Sessions 2026"
+event_context: "Panelist on Agents track"
+icp_fit_score: 9   # inherited from companies/openai.md
+```
+
+The `dm_opener` is 2-3 sentences, references the `hook`, names a Browserbase-style tie-in (or whatever the user's product wedge is from the profile), and ends with a soft CTA. It's what the AE pastes into LinkedIn. Generated from accumulated findings — never from memory or visual inference.
+
+The `hook` source priority (run sequentially, stop at first hit):
+1. **Event-context**: their talk title or panel topic at this event (always available, lowest-effort, often best for cold opener)
+2. **Recent activity** (last 6 months): podcast / talk / blog / GitHub / LinkedIn post — surfaced by lanes 2-4
+3. **Company-context**: signal from their company's recent news (funding, product launch) — pulled from the `companies/{slug}.md` deep-research file
+
+If lane 1 succeeds, the subagent can skip lanes 2-4 in deep mode. In deeper mode, run all four lanes regardless to give the report richer link pills.

--- a/skills/event-prospecting/references/workflow.md
+++ b/skills/event-prospecting/references/workflow.md
@@ -40,14 +40,18 @@ CONTEXT:
 - Event name: {EVENT_NAME}
 - Output directory: {OUTPUT_DIR}    ← write company files HERE, full literal path
 
-COMPANIES TO TRIAGE (one per line — name and homepage URL):
+COMPANIES TO TRIAGE (one per line — `name|guessed_homepage|slug`):
 {COMPANY_LIST}
+
+The guessed_homepage is a heuristic (`https://{lowercased company name without spaces}.com`). For most companies it's correct. For a few it 404s — that's expected and the fallback is documented in rule 3 below.
+
+The slug is the canonical filename to write to: `{OUTPUT_DIR}/companies/{slug}.md`. Use it verbatim — do not re-slugify the name yourself or you'll create duplicate files.
 
 TOOL RULES — CRITICAL, FOLLOW EXACTLY:
 1. You may ONLY use the Bash tool. No exceptions.
 2. The ONLY allowed extraction call is:
      node {SKILL_DIR}/scripts/extract_page.mjs "<homepage_url>" --max-chars 2000
-3. HARD TOOL-CALL CAP: ONE call per company. If a homepage returns FETCH_OK: false with empty BODY, write product_description: "Unknown — homepage content not accessible" and cap icp_fit_score at 3. DO NOT attempt a second call to "save" the company.
+3. HARD TOOL-CALL CAP: ONE call per company. If a homepage returns FETCH_OK: false with empty BODY (e.g. the guessed URL 404s), write product_description: "Unknown — homepage content not accessible" and cap icp_fit_score at 3. DO NOT attempt a second call to "save" the company.
 4. ENFORCEMENT — at the start of EVERY Bash call, prepend a comment like `# bb call N/{TOTAL}` where N counts up and TOTAL is the number of companies in your batch. Example for a 10-company batch:
      # bb call 1/10
      node {SKILL_DIR}/scripts/extract_page.mjs "https://openai.com" --max-chars 2000

--- a/skills/event-prospecting/references/workflow.md
+++ b/skills/event-prospecting/references/workflow.md
@@ -1,0 +1,392 @@
+# Event-Prospecting Workflow
+
+Subagent prompt templates and tool-call governance for every fan-out step in the pipeline. The main agent in `SKILL.md` dispatches Agent batches that load these prompts; each subagent must obey the HARD TOOL-CALL CAPS below or the run is invalidated.
+
+## Contents
+- [Discovery](#discovery) — recon + extract (NOT fanned out; main agent runs these directly)
+- [ICP Triage](#icp-triage) — fast company-level scoring (1 call/company hard cap)
+- [Deep Research](#deep-research) — full Plan→Research→Synthesize on ICP fits (5 calls/company hard cap)
+- [Person Enrichment](#person-enrichment) — speakers at ICP-fit companies (4 calls/person hard cap)
+- [Compilation](#compilation) — HTML + CSV via `compile_report.mjs`
+- [Wave Management](#wave-management) — sizing, parallelism, error handling
+
+---
+
+## Discovery
+
+Recon + extract are deterministic single-process scripts run by the main agent. NOT fanned out. See SKILL.md Steps 2-4 for the orchestrator commands. This section exists only to document the artifacts the downstream subagents consume:
+
+- `{OUTPUT_DIR}/recon.json` — platform + extraction strategy (read by `extract_event.mjs`)
+- `{OUTPUT_DIR}/people.jsonl` — one JSON-encoded speaker per line (read by Step 8 batching)
+- `{OUTPUT_DIR}/seed_companies.txt` — deduped, sorted company names (read by Step 5 batching)
+
+---
+
+## ICP Triage
+
+**HARD TOOL-CALL CAP: 1 tool call per company.** The only allowed call is `extract_page.mjs` on the company homepage. NO follow-up searches, NO sitemap discovery, NO secondary fetches. If the homepage returns thin content, write `Unknown` and cap the score at 3 — that is the correct behavior, not a failure.
+
+**ENFORCEMENT** — at the start of every Bash call, prepend a comment like `# bb call N/1` so the cap is visible in tool output. If a subagent emits more than `K` calls for a batch of `K` companies, the main agent's compile step will detect the over-budget run from the call log and flag it.
+
+**Subagent prompt template** — substitute the curly-brace placeholders before dispatching:
+
+```
+You are an ICP triage subagent for the event-prospecting skill. For each company in your batch, run ONE tool call to fetch the homepage, then score it against the user's ICP and write a triage stub to {OUTPUT_DIR}/companies/{slug}.md.
+
+CONTEXT:
+- User's company: {USER_COMPANY}
+- User's product: {USER_PRODUCT}
+- ICP description: {ICP_DESCRIPTION}
+- Event name: {EVENT_NAME}
+- Output directory: {OUTPUT_DIR}    ← write company files HERE, full literal path
+
+COMPANIES TO TRIAGE (one per line — name and homepage URL):
+{COMPANY_LIST}
+
+TOOL RULES — CRITICAL, FOLLOW EXACTLY:
+1. You may ONLY use the Bash tool. No exceptions.
+2. The ONLY allowed extraction call is:
+     node {SKILL_DIR}/scripts/extract_page.mjs "<homepage_url>" --max-chars 2000
+3. HARD TOOL-CALL CAP: ONE call per company. If a homepage returns FETCH_OK: false with empty BODY, write product_description: "Unknown — homepage content not accessible" and cap icp_fit_score at 3. DO NOT attempt a second call to "save" the company.
+4. ENFORCEMENT — at the start of EVERY Bash call, prepend a comment like `# bb call N/{TOTAL}` where N counts up and TOTAL is the number of companies in your batch. Example for a 10-company batch:
+     # bb call 1/10
+     node {SKILL_DIR}/scripts/extract_page.mjs "https://openai.com" --max-chars 2000
+5. BANNED TOOLS: WebFetch, WebSearch, Write, Read, Glob, Grep — ALL BANNED. Use ONLY Bash.
+6. NEVER use ~ or $HOME — full literal paths only.
+
+ANTI-HALLUCINATION RULES:
+- NEVER infer product_description from fonts, framework, or design system. Typography is not a product.
+- NEVER let the user's ICP leak into the target's description. If you don't know what the target does, write "Unknown".
+- product_description MUST quote or closely paraphrase a phrase from extract_page.mjs output (TITLE / META_DESCRIPTION / OG_DESCRIPTION / HEADINGS / BODY). If none yield a recognizable product statement, write "Unknown — homepage content not accessible" and cap icp_fit_score at 3.
+
+ICP SCORING RUBRIC (event-aware):
+- 8-10: Strong match. Homepage clearly states a product/audience that aligns with {ICP_DESCRIPTION}. Bonus if their event presence (talk topic, sponsor tier) suggests they're working in the user's wedge.
+- 5-7: Partial match. Adjacent industry, OR clear product but unclear pain-point alignment.
+- 1-4: Weak match. Wrong segment, or homepage too thin to assess (cap at 3 if Unknown).
+
+OUTPUT — write ALL company files in a SINGLE Bash call using chained heredocs:
+
+# bb call 1/{TOTAL}
+node {SKILL_DIR}/scripts/extract_page.mjs "{url1}" --max-chars 2000 && \
+# bb call 2/{TOTAL}
+node {SKILL_DIR}/scripts/extract_page.mjs "{url2}" --max-chars 2000 && \
+... && \
+cat << 'COMPANY_MD' > {OUTPUT_DIR}/companies/{slug1}.md
+---
+company_name: {name1}
+website: {url1}
+product_description: {description1}
+icp_fit_score: {score1}
+icp_fit_reasoning: {reasoning1}
+triage_only: true
+event_context: {EVENT_NAME} — {how they show up at the event, e.g. "speaker on Agents track"}
+---
+
+## Triage Notes
+{1-2 sentences citing the homepage phrase that drove the score}
+COMPANY_MD
+cat << 'COMPANY_MD' > {OUTPUT_DIR}/companies/{slug2}.md
+---
+...
+---
+
+...
+COMPANY_MD
+
+Use 'COMPANY_MD' (quoted) as the heredoc delimiter to prevent shell variable expansion.
+
+Report back ONLY: "ICP triage batch: {scored}/{total} companies, score distribution: high={N} mid={N} low={N}".
+Do NOT return raw homepage content or per-company reasoning to the main conversation.
+```
+
+---
+
+## Deep Research
+
+**HARD TOOL-CALL CAP: 5 tool calls per company.** Budget breakdown:
+- 1 call: `extract_page.mjs` on the homepage
+- 2-3 calls: `bb search` for sub-questions (Priority 1 + selected Priority 2)
+- 1-2 calls: `extract_page.mjs` on the most relevant search results (case study / blog / careers)
+
+**ENFORCEMENT** — at the start of every Bash call, prepend `# bb call N/{TOTAL}` where TOTAL is `5 × batch_size`. A 5-company batch caps at 25 total tool calls. The main agent's compile step monitors this from the call log.
+
+**Subagent prompt template**:
+
+```
+You are a deep-research subagent for the event-prospecting skill. For each ICP-fit company in your batch, follow the Plan→Research→Synthesize pattern from references/research-patterns.md and OVERWRITE the existing triage stub at {OUTPUT_DIR}/companies/{slug}.md with the deep-research version.
+
+CONTEXT:
+- User's company: {USER_COMPANY}
+- User's product: {USER_PRODUCT}
+- ICP description: {ICP_DESCRIPTION}
+- Event name: {EVENT_NAME}
+- Event context: {EVENT_CONTEXT}   ← e.g. "AI track / Agents / Infra"
+- Output directory: {OUTPUT_DIR}
+
+COMPANIES TO RESEARCH (one per line, slug|website format):
+{COMPANY_LIST}
+
+TOOL RULES — CRITICAL:
+1. You may ONLY use the Bash tool. No exceptions.
+2. All searches:  bb search "..." --num-results 10
+3. All page extractions:  node {SKILL_DIR}/scripts/extract_page.mjs "URL" --max-chars 3000
+   (handles JSON envelope, meta tags, JS-render fallback to bb browse)
+   DO NOT hand-roll a `bb fetch | sed` pipeline. Use raw `bb fetch` only for sitemap.xml / llms.txt.
+4. HARD TOOL-CALL CAP: 5 calls per company. Budget:
+     1× extract_page on homepage
+     2-3× bb search on sub-questions
+     1-2× extract_page on the best search result
+   DO NOT exceed 5 calls per company. If you've burned the budget, synthesize from what you have.
+5. ENFORCEMENT — at the start of EVERY Bash call, prepend a comment like `# bb call N/5 (company: {slug})`. Reset N to 1 for each company in the batch.
+6. BATCH all writes: write ALL deep-research files in a SINGLE Bash call using chained heredocs.
+7. BANNED TOOLS: WebFetch, WebSearch, Write, Read, Glob, Grep — ALL BANNED.
+8. NEVER use ~ or $HOME — full literal paths.
+
+ANTI-HALLUCINATION RULES (same as research-patterns.md):
+- Typography is not a product.
+- No ICP leakage — if homepage is thin and search yields nothing, write "Unknown" and cap score at 3.
+- product_description MUST quote/paraphrase a phrase from extract_page.mjs output or a search result.
+
+RESEARCH PATTERN per company (deep mode):
+
+Phase A — Plan:
+Decompose into 2-3 sub-questions. Always include "What does {company} do?" (Priority 1). Add 1-2 from Priority 2 chosen for event-context relevance. EXAMPLE for an Agents-track company:
+  - "What does {company} sell and who are their customers?"
+  - "What is {company} doing with browser automation or AI agents that's relevant to {EVENT_NAME}'s {EVENT_CONTEXT}?"
+  - "Has {company} raised funding, launched products, or expanded recently?"
+
+Phase B — Research Loop:
+1. # bb call 1/5 — extract_page on homepage
+2. # bb call 2/5 — bb search for Priority 1 sub-question
+3. # bb call 3/5 — bb search for event-context sub-question
+4. # bb call 4/5 — extract_page on the most relevant search result
+5. # bb call 5/5 — (optional) one more search OR fetch if budget remains
+Accumulate findings: factual statement + source URL + confidence level (high/medium/low).
+
+Phase C — Synthesize:
+1. Score ICP fit 1-10 using the rubric (high-confidence findings + event relevance lift the score; thin evidence caps at 3).
+2. Fill enrichment fields: product_description, industry, target_audience, key_features, employee_estimate, funding_info, headquarters.
+3. Write event_relevance: how the company shows up at the event (speaker count, track, sponsor tier, demo).
+4. Reference specific findings in icp_fit_reasoning.
+
+OUTPUT — overwrite the triage stub. ALL files in a SINGLE Bash call:
+
+cat << 'COMPANY_MD' > {OUTPUT_DIR}/companies/{slug}.md
+---
+company_name: {name}
+website: {url}
+product_description: {description}
+industry: {industry}
+target_audience: {audience}
+key_features: {feature1} | {feature2} | {feature3}
+icp_fit_score: {score}
+icp_fit_reasoning: {reasoning, references findings}
+employee_estimate: {estimate}
+funding_info: {funding}
+headquarters: {location}
+triage_only: false
+event_context: {EVENT_NAME} — {how they show up}
+event_relevance: {speaker count, track, demo expectations}
+---
+
+## Product
+{2-3 sentences specific, sourced}
+
+## Research Findings
+- **[{confidence}]** {fact} (source: {url})
+- ...
+
+## Event Relevance
+{how this company connects to {EVENT_NAME}; pitch angle for AE conversation at the event}
+COMPANY_MD
+
+Report back ONLY: "Deep research batch: {researched}/{total} companies, {findings_count} total findings, avg ICP score {N.N}".
+```
+
+---
+
+## Person Enrichment
+
+**HARD TOOL-CALL CAP: 4 tool calls per person.** Lanes:
+1. `bb search "{name} {company} linkedin"` — always (deep + deeper)
+2. `bb search "{name} podcast OR talk OR blog 2026"` — deep + deeper
+3. `bb search "{name} github"` — deeper only
+4. `bb search "{name} site:x.com OR site:twitter.com"` — deeper only
+
+Deep mode: lanes 1-2 (max 2 calls/person). Deeper mode: lanes 1-4 (max 4 calls/person).
+
+**ENFORCEMENT** — every Bash call prepends `# bb call N/{LANES} (person: {slug})`, where LANES is 2 (deep) or 4 (deeper). Reset N to 1 for each person.
+
+**Subagent prompt template**:
+
+```
+You are a person-enrichment subagent for the event-prospecting skill. For each person in your batch, run 2-4 bb searches to harvest LinkedIn + recent activity + GitHub + X presence, generate a hook + DM opener, and write {OUTPUT_DIR}/people/{slug}.md.
+
+CONTEXT:
+- User's company: {USER_COMPANY}
+- User's product: {USER_PRODUCT}
+- ICP description: {ICP_DESCRIPTION}
+- Event name: {EVENT_NAME}
+- Depth mode: {DEPTH}    ← `deep` (2 lanes) or `deeper` (4 lanes)
+- Output directory: {OUTPUT_DIR}
+
+PEOPLE TO ENRICH (one JSON record per line):
+{PEOPLE_BATCH}
+
+Each record has fields:
+  { "name": "...", "title": "...", "company": "...", "linkedin": "...", "slug": "...", "bio": "..." }
+
+TOOL RULES — CRITICAL:
+1. You may ONLY use the Bash tool. No exceptions.
+2. All searches:  bb search "..." --num-results 5
+3. HARD TOOL-CALL CAP per person:
+     deep mode:    2 calls (lanes 1 + 2)
+     deeper mode:  4 calls (lanes 1 + 2 + 3 + 4)
+   DO NOT exceed the cap. If a lane fails (no useful result), DO NOT compensate by running a fifth call.
+4. ENFORCEMENT — at the start of EVERY Bash call, prepend a comment like `# bb call N/{LANES} (person: {slug})`. Reset N to 1 for each person in the batch.
+5. BATCH all writes: write ALL people files in a SINGLE Bash call using chained heredocs.
+6. BANNED TOOLS: WebFetch, WebSearch, Write, Read, Glob, Grep — ALL BANNED.
+7. NEVER use ~ or $HOME — full literal paths.
+
+ANTI-HALLUCINATION RULES:
+- A person's `hook` MUST quote or paraphrase a SPECIFIC finding from a bb search result. NEVER infer from "they look senior" or "their company is AI-y".
+- If lanes 2-4 yield no public signal in the last 6 months, fall back to event-context (their talk title from the bio field). Event-context is always available and beats a fabricated hook.
+- The DM opener MUST reference the hook verbatim. If the hook is event-context, name the talk title. Do NOT name a podcast or blog post the person didn't actually appear in.
+
+LANE PROMPTS (run only the lanes for your DEPTH):
+
+Lane 1 (always):
+  # bb call 1/{LANES} (person: {slug})
+  bb search "\"{name}\" \"{company}\" linkedin" --num-results 5
+  → harvest LinkedIn URL + verify current title
+
+Lane 2 (deep + deeper):
+  # bb call 2/{LANES} (person: {slug})
+  bb search "\"{name}\" podcast OR talk OR blog 2026" --num-results 5
+  → harvest most-recent activity. If a podcast/blog/talk URL appears, that's a candidate hook.
+
+Lane 3 (deeper only):
+  # bb call 3/{LANES} (person: {slug})
+  bb search "\"{name}\" github" --num-results 5
+  → harvest github.com/{handle} URL if present
+
+Lane 4 (deeper only):
+  # bb call 4/{LANES} (person: {slug})
+  bb search "\"{name}\" site:x.com OR site:twitter.com" --num-results 5
+  → harvest x.com/{handle} URL + most recent post topic if shown
+
+HOOK SOURCE PRIORITY (run sequentially, stop at first hit):
+1. Recent activity (lane 2): podcast title / blog headline / talk title from the last 6 months. THIS IS THE BEST HOOK — concrete, dated, public.
+2. Event-context: their talk title or panel topic at {EVENT_NAME} (extracted from the bio field passed in the JSON record). ALWAYS available, even when external search yields nothing.
+3. Company-context: pull from {OUTPUT_DIR}/companies/{company_slug}.md `event_relevance` line (read via `awk` from the existing file; this is allowed because the file is local, not a tool call).
+
+DM OPENER FORMAT:
+2-3 sentences:
+  - sentence 1: reference the hook explicitly
+  - sentence 2: 1-line wedge tie-in to {USER_PRODUCT}
+  - sentence 3: soft CTA ("worth a 15-min walkthrough?", "open to a quick chat?", etc.)
+NEVER salesy. NEVER reference Browserbase by name unless the user's profile says to. Use the user's wedge framing from {USER_PRODUCT}.
+
+OUTPUT — write ALL people files in a SINGLE Bash call using chained heredocs:
+
+cat << 'PERSON_MD' > {OUTPUT_DIR}/people/{slug}.md
+---
+name: {full name}
+slug: {slug}
+company: {company}
+company_slug: {company_slug}
+title: {title}
+links:
+  linkedin: {url or null}
+  x: {url or null}
+  github: {url or null}
+  blog: {url or null}
+  podcast: {url or null}
+hook: {1 sentence, sourced}
+dm_opener: |
+  {sentence 1: hook reference}
+  {sentence 2: wedge tie-in}
+  {sentence 3: soft CTA}
+role_reason: {why this person matters at the company}
+event_name: {EVENT_NAME}
+event_context: {their role at the event — talk title, panel topic, sponsor employee, etc.}
+icp_fit_score: {inherited from companies/{company_slug}.md}
+icp_fit_reasoning: {inherited}
+enriched_at: {ISO timestamp}
+---
+
+## Why reach out
+- **Why the company**: {1 line, references companies/{company_slug}.md}
+- **Why the person**: {role_reason restated as 1 line}
+- **Hook**: {hook, with source URL inline}
+
+## Public links
+{bullet list of every harvested link, one per line}
+
+## Recent activity
+- **[{confidence}]** {finding} (source: {url})
+- ...
+PERSON_MD
+
+Report back ONLY: "Person enrichment batch: {enriched}/{total} people, {hook_count_event} event-context hooks + {hook_count_recent} recent-activity hooks".
+```
+
+---
+
+## Compilation
+
+After all subagents complete, the main agent runs the compile step ONCE. NOT fanned out. From SKILL.md Step 9:
+
+```bash
+node {SKILL_DIR}/scripts/compile_report.mjs {OUTPUT_DIR} --user-company {USER_SLUG} --open
+```
+
+The compile script:
+1. Reads every `companies/*.md` and `people/*.md`
+2. Joins people to their company files (via `company_slug` frontmatter)
+3. Sorts people by inherited `icp_fit_score` desc
+4. Renders:
+   - `index.html` — person-first card grid (the primary deliverable)
+   - `people.html` — filterable speaker grid (alternate view, with chips for company / role bucket / ICP band)
+   - `companies.html` — ICP-ranked company table with attendees expandable per row
+   - `results.csv` — flat one-row-per-person spreadsheet for cold-outbound import
+5. Opens `index.html` in the default browser (`--open` flag)
+
+The compile step does NOT mutate any `.md` files. All HTML is generated fresh from the markdown sources every run, so re-running compile after a manual edit to a `.md` file regenerates the report.
+
+---
+
+## Wave Management
+
+### Key Principle: Maximize Parallelism, Minimize Prompts
+
+Launch as many subagents as possible in a single Agent fan-out (up to ~6 Agent calls per message). Each subagent MUST batch all its Bash operations into a single call to minimize permission prompts. One subagent batch = one Bash call = one permission prompt.
+
+### Sizing Formula
+
+```
+seed_companies = wc -l seed_companies.txt
+icp_fits      = wc -l icp_fits.txt    (typically 20-40% of seed)
+people_to_enrich = wc -l _people_to_enrich.jsonl  (typically 1.5-2.5× icp_fits)
+
+triage_subagents  = ceil(seed_companies / 10)        # 10 companies/subagent, 1 call each
+deep_subagents    = ceil(icp_fits / 5)               # 5 companies/subagent, 5 calls each
+person_subagents  = ceil(people_to_enrich / 5)       # 5 people/subagent, 2-4 calls each
+```
+
+For Stripe Sessions (99 seed → ~30 ICP fits → ~50 people):
+- Triage: 10 subagents × 10 calls = 100 calls (matches the cost model: 99 calls)
+- Deep research: 6 subagents × 25 calls = 150 calls
+- Person enrichment: 10 subagents × ~10 calls = 100 calls
+- Total: ~350 tool calls, matches the design doc cost model.
+
+### Wave Cadence
+
+Dispatch all subagents for a given step in **a single Agent fan-out message** (up to 6 per message; if more needed, run a second wave after the first completes). Do NOT serialize subagents that can run in parallel.
+
+### Error Handling
+
+- If a single subagent fails, log the error and continue. The compile step ignores missing files gracefully.
+- If >50% of subagents in a wave fail, pause and surface to the user before continuing.
+- If `extract_page.mjs` returns FETCH_OK: false with empty BODY, the triage subagent should write `product_description: Unknown — homepage content not accessible` and cap score at 3 (NOT skip the company — the file must exist for compile to render the row).
+- The HARD TOOL-CALL CAP is non-negotiable. If a subagent exceeds its budget, the run is invalidated for that batch (compile step warns; user can re-dispatch).

--- a/skills/event-prospecting/scripts/__fixtures__/stripe-snapshot.json
+++ b/skills/event-prospecting/scripts/__fixtures__/stripe-snapshot.json
@@ -1,0 +1,10 @@
+{
+  "title": "Stripe Sessions 2026 | Speakers",
+  "hasNextData": true,
+  "nextDataLen": 439761,
+  "speakerArrayPaths": [
+    ".props.pageProps.featuredSpeakers.speakers.items",
+    ".props.pageProps.moreSpeakers.speakers.items"
+  ],
+  "totalSpeakers": 240
+}

--- a/skills/event-prospecting/scripts/compile_report.mjs
+++ b/skills/event-prospecting/scripts/compile_report.mjs
@@ -1,0 +1,692 @@
+#!/usr/bin/env node
+
+// Compiles per-company + per-person markdown research files into a person-first
+// HTML report (index.html), plus people.html and companies.html alternate views.
+//
+// Reads:
+//   <research-dir>/companies/*.md  — one per company (frontmatter + body)
+//   <research-dir>/people/*.md     — one per ICP-fit speaker (frontmatter + body)
+//   <research-dir>/*.md            — also accepted at top-level (legacy / company-research format)
+//
+// Writes:
+//   <research-dir>/index.html      — person-first, ICP-ranked card grid (default landing)
+//   <research-dir>/people.html     — filterable people grid (chips: company, role, ICP band)
+//   <research-dir>/companies.html  — ICP-ranked company table with expandable attendees
+//   <research-dir>/companies/<slug>.html — individual company research pages
+//   <research-dir>/results.csv     — scored spreadsheet
+//
+// Usage: node compile_report.mjs <research-dir> [--user-company <slug>] [--template <path>] [--open]
+
+import { readdirSync, readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const args = process.argv.slice(2);
+
+if (args.includes('--help') || args.includes('-h') || args.length === 0) {
+  console.error(`Usage: node compile_report.mjs <research-dir> [--user-company <slug>] [--template <path>] [--open]
+
+Reads companies/*.md and people/*.md from <research-dir>, generates:
+  - index.html      — person-first card grid (ranked by company ICP)
+  - people.html     — filterable people grid
+  - companies.html  — ICP-ranked company table with expandable attendees
+  - companies/<slug>.html — individual company research pages
+  - results.csv     — scored spreadsheet
+
+Options:
+  --user-company <slug>  User's company slug (for the 'Research deeper' prompt)
+  --template <path>      Path to report-template.html (default: auto-detect)
+  --open                 Open index.html in browser after generation
+  --help, -h             Show this help message`);
+  process.exit(args.includes('--help') || args.includes('-h') ? 0 : 1);
+}
+
+const dir = args[0];
+const shouldOpen = args.includes('--open');
+const templateIdx = args.indexOf('--template');
+const userCompanyIdx = args.indexOf('--user-company');
+const userCompany = userCompanyIdx !== -1 ? args[userCompanyIdx + 1] : '';
+let templatePath = templateIdx !== -1 ? args[templateIdx + 1] : null;
+
+// Auto-detect template
+if (!templatePath) {
+  const candidates = [
+    join(__dirname, '..', 'references', 'report-template.html'),
+    join(__dirname, 'report-template.html'),
+  ];
+  templatePath = candidates.find(p => existsSync(p));
+  if (!templatePath) {
+    console.error('Error: Could not find report-template.html. Use --template to specify path.');
+    process.exit(1);
+  }
+}
+
+const template = readFileSync(templatePath, 'utf-8');
+
+// ----- Frontmatter / body parsing (shared) ---------------------------------
+
+function parseFrontmatter(content) {
+  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!fmMatch) return null;
+  const fields = {};
+  const lines = fmMatch[1].split('\n');
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    // Multi-line YAML pipe scalar:  key: |
+    //                                 line one
+    //                                 line two
+    const pipeMatch = line.match(/^([a-zA-Z_][\w]*)\s*:\s*\|\s*$/);
+    if (pipeMatch) {
+      const key = pipeMatch[1];
+      const buf = [];
+      i++;
+      while (i < lines.length && /^\s{2,}/.test(lines[i])) {
+        buf.push(lines[i].replace(/^\s{2}/, ''));
+        i++;
+      }
+      fields[key] = buf.join('\n').trim();
+      continue;
+    }
+    // Nested block (e.g. links: with indented children)
+    const nestedHeadMatch = line.match(/^([a-zA-Z_][\w]*)\s*:\s*$/);
+    if (nestedHeadMatch && i + 1 < lines.length && /^\s{2,}\S/.test(lines[i + 1])) {
+      const key = nestedHeadMatch[1];
+      const child = {};
+      i++;
+      while (i < lines.length && /^\s{2,}\S/.test(lines[i])) {
+        const c = lines[i].trim();
+        const idx = c.indexOf(':');
+        if (idx > 0) {
+          const ck = c.slice(0, idx).trim();
+          const cv = c.slice(idx + 1).trim().replace(/^["']|["']$/g, '');
+          child[ck] = (cv === 'null' || cv === '') ? null : cv;
+        }
+        i++;
+      }
+      fields[key] = child;
+      continue;
+    }
+    const idx = line.indexOf(':');
+    if (idx > 0) {
+      const key = line.slice(0, idx).trim();
+      const val = line.slice(idx + 1).trim().replace(/^["']|["']$/g, '');
+      if (key) fields[key] = val;
+    }
+    i++;
+  }
+  return fields;
+}
+
+function parseBody(content) {
+  const bodyMatch = content.match(/^---\n[\s\S]*?\n---\n([\s\S]*)/);
+  return bodyMatch ? bodyMatch[1].trim() : '';
+}
+
+function escapeHtml(str) {
+  return (str || '').toString().replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+function escapeAttr(str) {
+  return escapeHtml(str).replace(/\n/g, '&#10;');
+}
+
+function scoreClass(score) {
+  const s = parseInt(score) || 0;
+  if (s >= 8) return 'high';
+  if (s >= 5) return 'medium';
+  return 'low';
+}
+
+function icpBand(score) {
+  const s = parseInt(score) || 0;
+  if (s >= 8) return 'high';
+  if (s >= 6) return 'mid';
+  return 'low';
+}
+
+function slugify(s) {
+  return (s || '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+function roleBucket(title) {
+  const t = (title || '').toLowerCase();
+  if (/(ceo|founder|co-?founder|president|chief)/.test(t)) return 'Founder/CXO';
+  if (/(vp|vice president|head of|director)/.test(t)) return 'VP/Director';
+  if (/(engineer|developer|programmer|architect|sre|devops)/.test(t)) return 'Engineering';
+  if (/(product|pm|product manager)/.test(t)) return 'Product';
+  if (/(design|ux|ui)/.test(t)) return 'Design';
+  if (/(market|growth|content)/.test(t)) return 'Marketing';
+  if (/(sales|account|revenue|gtm)/.test(t)) return 'Sales/GTM';
+  if (/(research|scientist|ml|ai)/.test(t)) return 'Research/AI';
+  return 'Other';
+}
+
+function mdToHtml(md) {
+  const lines = md.split('\n');
+  const out = [];
+  let inList = false;
+  let paraLines = [];
+
+  function flushPara() {
+    if (paraLines.length > 0) {
+      let text = escapeHtml(paraLines.join(' ').trim());
+      text = text.replace(/\*\*\[(\w+)\]\*\*/g, '<span class="confidence $1">[$1]</span>');
+      text = text.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+      if (text) out.push(`<p>${text}</p>`);
+      paraLines = [];
+    }
+  }
+
+  function closeList() {
+    if (inList) { out.push('</ul>'); inList = false; }
+  }
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    if (!trimmed) {
+      flushPara();
+      closeList();
+      continue;
+    }
+
+    if (trimmed.startsWith('## ')) {
+      flushPara(); closeList();
+      out.push(`<h2>${escapeHtml(trimmed.slice(3))}</h2>`);
+      continue;
+    }
+    if (trimmed.startsWith('### ')) {
+      flushPara(); closeList();
+      out.push(`<h3>${escapeHtml(trimmed.slice(4))}</h3>`);
+      continue;
+    }
+
+    if (trimmed.startsWith('- ')) {
+      flushPara();
+      if (!inList) { out.push('<ul>'); inList = true; }
+      let text = escapeHtml(trimmed.slice(2));
+      text = text.replace(/\*\*\[(\w+)\]\*\*/g, '<span class="confidence $1">[$1]</span>');
+      text = text.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+      out.push(`<li>${text}</li>`);
+      continue;
+    }
+
+    closeList();
+    paraLines.push(trimmed);
+  }
+
+  flushPara();
+  closeList();
+  return out.join('\n');
+}
+
+// ----- Read companies + people --------------------------------------------
+
+function readMdDir(p) {
+  if (!existsSync(p)) return [];
+  let entries = [];
+  try { entries = readdirSync(p); } catch { return []; }
+  return entries.filter(f => f.endsWith('.md')).sort().map(f => {
+    const content = readFileSync(join(p, f), 'utf-8');
+    const fields = parseFrontmatter(content);
+    if (!fields) return null;
+    const body = parseBody(content);
+    const slug = f.replace('.md', '');
+    return { ...fields, body, slug, file: f };
+  }).filter(Boolean);
+}
+
+const companiesDir = join(dir, 'companies');
+let companies = readMdDir(companiesDir);
+
+// Legacy fallback: top-level *.md files = companies (company-research's format)
+if (companies.length === 0) {
+  companies = readMdDir(dir);
+}
+
+const peopleDir = join(dir, 'people');
+const people = readMdDir(peopleDir);
+
+if (companies.length === 0 && people.length === 0) {
+  console.error(`No .md files found in ${dir} (looked in companies/, people/, and top-level)`);
+  process.exit(1);
+}
+
+// Sort companies by ICP score descending
+companies.sort((a, b) => (parseInt(b.icp_fit_score) || 0) - (parseInt(a.icp_fit_score) || 0));
+
+// Deduplicate companies by normalized name
+const seen = new Map();
+for (const c of companies) {
+  const name = (c.company_name || '').toLowerCase().replace(/[,\s]+(inc|llc|ltd|corp|co)\.?$/i, '').trim();
+  if (!name) continue;
+  if (!seen.has(name)) seen.set(name, c);
+}
+const deduped = [...seen.values()];
+
+// Build company lookup: slug → company, name(lowered) → company
+const companyBySlug = new Map();
+const companyByName = new Map();
+for (const c of deduped) {
+  if (c.slug) companyBySlug.set(c.slug, c);
+  if (c.company_name) companyByName.set(c.company_name.toLowerCase().trim(), c);
+}
+
+function resolveCompany(person) {
+  if (person.company_slug && companyBySlug.has(person.company_slug)) return companyBySlug.get(person.company_slug);
+  if (person.company) {
+    const k = person.company.toLowerCase().trim();
+    if (companyByName.has(k)) return companyByName.get(k);
+    const slugGuess = slugify(person.company);
+    if (companyBySlug.has(slugGuess)) return companyBySlug.get(slugGuess);
+  }
+  return null;
+}
+
+// Augment each person with effective company + score for sorting
+for (const p of people) {
+  const comp = resolveCompany(p);
+  p._company = comp;
+  // Effective ICP: company score wins (per the plan), else person frontmatter, else -1 (last)
+  const cs = comp ? parseInt(comp.icp_fit_score) : NaN;
+  const ps = parseInt(p.icp_fit_score);
+  p._effectiveScore = !isNaN(cs) ? cs : (!isNaN(ps) ? ps : -1);
+}
+
+// Sort people by effective ICP descending; unscored last; stable on name
+people.sort((a, b) => {
+  if (b._effectiveScore !== a._effectiveScore) return b._effectiveScore - a._effectiveScore;
+  return (a.name || '').localeCompare(b.name || '');
+});
+
+// ----- Stats --------------------------------------------------------------
+
+const scores = deduped.map(c => parseInt(c.icp_fit_score) || 0);
+const high = scores.filter(s => s >= 8).length;
+const medium = scores.filter(s => s >= 5 && s < 8).length;
+const low = scores.filter(s => s < 5).length;
+const total = deduped.length;
+const highPct = total > 0 ? Math.round((high / total) * 100) : 0;
+const mediumPct = total > 0 ? Math.round((medium / total) * 100) : 0;
+const lowPct = total > 0 ? 100 - highPct - mediumPct : 0;
+
+const dirName = dir.split('/').filter(Boolean).pop() || 'event';
+const title = dirName.replace(/_/g, ' ').replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+
+// ----- Person card render --------------------------------------------------
+
+function buildResearchPrompt(person, company) {
+  const c = company || {};
+  const linkedin = (person.links && person.links.linkedin) || person.linkedin || '';
+  const userTail = userCompany ? ` Frame insights for ${userCompany}.` : '';
+  return `Use event-prospecting to deepen the brief on ${person.name} (${person.company || ''}, ${linkedin}). Source event: ${person.event_name || ''}. Existing notes: people/${person.slug}.md. Pull recent podcast appearances, GitHub activity, and any signals about ${c.icp_fit_reasoning || 'the company'}. Append findings to the same file.${userTail}`;
+}
+
+function renderPersonCard(person, company) {
+  const c = company || {};
+  const links = person.links || {};
+  const linkPills = ['linkedin', 'x', 'github', 'blog', 'podcast']
+    .filter(k => links[k])
+    .map(k => `<a class="link-pill link-${k}" href="${escapeHtml(links[k])}" target="_blank" rel="noopener">${k.toUpperCase()}</a>`)
+    .join(' ');
+
+  const score = c.icp_fit_score || person.icp_fit_score || '?';
+  const band = icpBand(score);
+  const dmOpener = person.dm_opener || '';
+  const research = buildResearchPrompt(person, c);
+
+  return `<div class="person-card" data-slug="${escapeHtml(person.slug)}" data-company="${escapeHtml((person.company || '').toLowerCase())}" data-role="${escapeHtml(roleBucket(person.title))}" data-icpband="${band}" data-icp-score="${escapeHtml(String(score))}">
+    <div class="card-header">
+      <h3>${escapeHtml(person.name || person.slug)}</h3>
+      <span class="icp-badge icp-${band}">ICP ${escapeHtml(String(score))}</span>
+    </div>
+    <div class="card-meta">${escapeHtml(person.title || '')}${person.title && person.company ? ' &middot; ' : ''}${escapeHtml(person.company || '')}</div>
+    ${linkPills ? `<div class="card-links">${linkPills}</div>` : ''}
+    <ul class="card-why">
+      <li><strong>Why the company:</strong> ${escapeHtml(c.icp_fit_reasoning || person.company_reason || '—')}</li>
+      <li><strong>Why the person:</strong> ${escapeHtml(person.role_reason || '—')}</li>
+      <li><strong>Hook:</strong> ${escapeHtml(person.hook || '—')}</li>
+    </ul>
+    <div class="card-actions">
+      <button class="btn-copy" data-clipboard="${escapeAttr(dmOpener)}">Copy DM opener</button>
+      <button class="btn-research" data-clipboard="${escapeAttr(research)}">Research deeper</button>
+    </div>
+  </div>`;
+}
+
+// ----- Shared CSS for the new event-prospecting UI -------------------------
+
+const eventCss = `
+  .nav-bar { display:flex; gap:0.5rem; margin-bottom:1.25rem; font-size:0.875rem; }
+  .nav-bar a { padding:0.4rem 0.85rem; border:1px solid var(--border); border-radius:4px; background:var(--card); color:var(--muted); font-weight:500; text-decoration:none; }
+  .nav-bar a.active { background:var(--brand); color:#fff; border-color:var(--brand); }
+  .filter-bar { display:flex; gap:0.75rem; flex-wrap:wrap; margin-bottom:1.25rem; align-items:center; }
+  .filter-group { display:flex; gap:0.4rem; flex-wrap:wrap; align-items:center; padding:0.4rem 0.6rem; background:var(--card); border:1px solid var(--border); border-radius:4px; }
+  .filter-group .label { font-size:0.7rem; color:var(--muted); text-transform:uppercase; letter-spacing:0.05em; font-weight:600; margin-right:0.25rem; }
+  .chip { display:inline-block; padding:0.2rem 0.6rem; border:1px solid var(--border); border-radius:999px; background:#fafafa; font-size:0.7rem; color:var(--muted); cursor:pointer; user-select:none; }
+  .chip.active { background:var(--brand); color:#fff; border-color:var(--brand); }
+  .chip:hover { border-color:var(--brand); }
+  .person-grid { display:grid; grid-template-columns:repeat(auto-fill, minmax(320px, 1fr)); gap:1rem; }
+  .person-card { background:var(--card); border:1px solid var(--border); border-radius:6px; padding:1rem 1.1rem; display:flex; flex-direction:column; gap:0.55rem; }
+  .person-card.hidden { display:none; }
+  .card-header { display:flex; justify-content:space-between; align-items:flex-start; gap:0.5rem; }
+  .card-header h3 { font-size:1rem; font-weight:600; color:var(--black); margin:0; }
+  .icp-badge { font-size:0.7rem; font-weight:700; padding:2px 8px; border-radius:3px; white-space:nowrap; }
+  .icp-badge.icp-high { background:rgba(144,201,77,0.14); color:#5a8a1a; }
+  .icp-badge.icp-mid { background:rgba(244,186,65,0.14); color:#9a7520; }
+  .icp-badge.icp-low { background:rgba(240,54,3,0.10); color:var(--low); }
+  .card-meta { font-size:0.8125rem; color:var(--muted); }
+  .card-links { display:flex; flex-wrap:wrap; gap:0.3rem; }
+  .link-pill { font-size:0.7rem; font-weight:600; padding:2px 8px; border-radius:3px; text-decoration:none; border:1px solid var(--border); color:var(--text); background:#fafafa; letter-spacing:0.04em; }
+  .link-pill:hover { background:var(--brand); color:#fff; border-color:var(--brand); }
+  .card-why { list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:0.3rem; font-size:0.8125rem; color:var(--text); }
+  .card-why li { line-height:1.45; }
+  .card-why strong { color:var(--black); font-weight:600; }
+  .card-actions { display:flex; gap:0.5rem; margin-top:auto; padding-top:0.5rem; }
+  .card-actions button { font:inherit; font-size:0.75rem; font-weight:600; padding:0.4rem 0.7rem; border-radius:4px; border:1px solid var(--border); background:var(--card); color:var(--text); cursor:pointer; }
+  .card-actions button:hover { background:var(--brand); color:#fff; border-color:var(--brand); }
+  .card-actions button.copied { background:var(--high); color:#fff; border-color:var(--high); }
+  details.attendees { margin-top:0.4rem; }
+  details.attendees summary { cursor:pointer; color:var(--brand); font-size:0.8125rem; font-weight:500; }
+  details.attendees ul { margin:0.4rem 0 0 1rem; padding:0; list-style:disc; }
+  details.attendees li { font-size:0.8125rem; color:var(--text); margin-bottom:0.2rem; }
+`;
+
+const clipboardScript = `
+<script>
+document.addEventListener('click', e => {
+  const btn = e.target.closest('button[data-clipboard]');
+  if (!btn) return;
+  const text = btn.getAttribute('data-clipboard') || '';
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(text).catch(() => {});
+  } else {
+    const ta = document.createElement('textarea');
+    ta.value = text;
+    document.body.appendChild(ta);
+    ta.select();
+    try { document.execCommand('copy'); } catch {}
+    ta.remove();
+  }
+  const orig = btn.textContent;
+  btn.classList.add('copied');
+  btn.textContent = 'Copied';
+  setTimeout(() => { btn.textContent = orig; btn.classList.remove('copied'); }, 1200);
+});
+
+// Filter chips (people.html)
+document.addEventListener('click', e => {
+  const chip = e.target.closest('.chip');
+  if (!chip) return;
+  const group = chip.closest('.filter-group');
+  if (!group) return;
+  group.querySelectorAll('.chip').forEach(c => c.classList.remove('active'));
+  chip.classList.add('active');
+  applyFilters();
+});
+
+function applyFilters() {
+  const grid = document.querySelector('.person-grid');
+  if (!grid) return;
+  const active = {};
+  document.querySelectorAll('.filter-group').forEach(g => {
+    const key = g.dataset.filter;
+    const chip = g.querySelector('.chip.active');
+    active[key] = chip ? chip.dataset.value : '';
+  });
+  grid.querySelectorAll('.person-card').forEach(card => {
+    let show = true;
+    for (const k in active) {
+      const v = active[k];
+      if (!v) continue;
+      if ((card.dataset[k] || '') !== v) { show = false; break; }
+    }
+    card.classList.toggle('hidden', !show);
+  });
+}
+</script>`;
+
+// ----- Person grid + filter chips -----------------------------------------
+
+function renderPeopleGrid(personList) {
+  if (personList.length === 0) {
+    return '<p style="color:var(--muted);">No people found.</p>';
+  }
+  return `<div class="person-grid">
+${personList.map(p => renderPersonCard(p, p._company)).join('\n')}
+</div>`;
+}
+
+// renderFilterBar is added in D3 — defined as a no-op here so D2 still compiles.
+function renderFilterBar(_personList) {
+  return '';
+}
+
+// ----- Companies table with attendees expandable ---------------------------
+
+function renderCompaniesTable() {
+  return deduped.map(c => {
+    const sc = scoreClass(c.icp_fit_score);
+    const hasDetail = c.body && c.body.length > 50;
+    const nameHtml = hasDetail
+      ? `<a href="companies/${c.slug}.html">${escapeHtml(c.company_name)}</a>`
+      : escapeHtml(c.company_name);
+    const websiteHtml = c.website
+      ? `<br><a href="${escapeHtml(c.website)}" target="_blank" style="font-size:0.75rem;color:var(--muted);">${escapeHtml(c.website.replace(/^https?:\/\/(www\.)?/, ''))}</a>`
+      : '';
+    return `      <tr>
+        <td><span class="score ${sc}">${escapeHtml(c.icp_fit_score || '—')}</span></td>
+        <td>${nameHtml}${websiteHtml}</td>
+        <td style="max-width:200px;">${escapeHtml(c.product_description || '')}</td>
+        <td>${escapeHtml(c.industry || '')}</td>
+        <td class="reasoning">${escapeHtml(c.icp_fit_reasoning || '')}</td>
+      </tr>`;
+  }).join('\n');
+}
+
+// ----- Compose final pages -------------------------------------------------
+
+const escapedTitle = escapeHtml(title);
+const metaLine = `${people.length} speakers &middot; ${deduped.length} companies &middot; ${new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}`;
+
+const navHtml = (active) => `<div class="nav-bar">
+  <a href="index.html" class="${active === 'index' ? 'active' : ''}">People</a>
+  <a href="people.html" class="${active === 'people' ? 'active' : ''}">People (filterable)</a>
+  <a href="companies.html" class="${active === 'companies' ? 'active' : ''}">Companies</a>
+</div>`;
+
+function injectCss(html) {
+  return html.replace('</style>', `${eventCss}\n</style>`);
+}
+
+function injectScript(html) {
+  return html.replace('</body>', `${clipboardScript}\n</body>`);
+}
+
+function renderShell(activeNav, contentHtml, pageTitle) {
+  let html = template
+    .replace(/\{\{TITLE\}\}/g, escapeHtml(pageTitle))
+    .replace(/\{\{COMPANY_NAME\}\}/g, escapedTitle)
+    .replace(/\{\{META\}\}/g, metaLine)
+    .replace(/\{\{TOTAL\}\}/g, String(total))
+    .replace(/\{\{HIGH_COUNT\}\}/g, String(high))
+    .replace(/\{\{MEDIUM_COUNT\}\}/g, String(medium))
+    .replace(/\{\{LOW_COUNT\}\}/g, String(low))
+    .replace(/\{\{HIGH_PCT\}\}/g, String(highPct))
+    .replace(/\{\{MEDIUM_PCT\}\}/g, String(mediumPct))
+    .replace(/\{\{LOW_PCT\}\}/g, String(lowPct))
+    .replace(/\{\{TABLE_ROWS\}\}/g, () => '');
+
+  // Replace the entire <table>...</table> block with our content
+  html = html.replace(/<table class="results-table">[\s\S]*?<\/table>/, `<div class="page-content">${navHtml(activeNav)}\n${contentHtml}</div>`);
+
+  html = injectCss(html);
+  html = injectScript(html);
+  return html;
+}
+
+const indexPersonGrid = renderPeopleGrid(people);
+const indexHtml = renderShell('index', indexPersonGrid, `Event Prospecting — ${title}`);
+writeFileSync(join(dir, 'index.html'), indexHtml);
+
+const peopleHtml = renderShell(
+  'people',
+  `${renderFilterBar(people)}\n${indexPersonGrid}`,
+  `People — ${title}`
+);
+writeFileSync(join(dir, 'people.html'), peopleHtml);
+
+const companiesContent = `<table class="results-table">
+    <thead>
+      <tr>
+        <th>Score</th>
+        <th>Company</th>
+        <th>Product</th>
+        <th>Industry</th>
+        <th>Fit Reasoning</th>
+      </tr>
+    </thead>
+    <tbody>
+${renderCompaniesTable()}
+    </tbody>
+  </table>`;
+const companiesHtml = renderShell('companies', companiesContent, `Companies — ${title}`);
+writeFileSync(join(dir, 'companies.html'), companiesHtml);
+
+// ----- Per-company detail pages -------------------------------------------
+
+try { mkdirSync(join(dir, 'companies'), { recursive: true }); } catch {}
+
+for (const c of deduped) {
+  if (!c.body || c.body.length < 50) continue;
+  const sc = scoreClass(c.icp_fit_score);
+  const bodyHtml = mdToHtml(c.body);
+
+  const companyHtml = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>${escapeHtml(c.company_name)} — Research</title>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  :root { --brand:#F03603; --high:#90C94D; --medium:#F4BA41; --low:#F03603; --black:#100D0D; --gray:#514F4F; --border:#edebeb; --bg:#F9F6F4; --card:#ffffff; --text:#100D0D; --muted:#514F4F; }
+  * { margin:0; padding:0; box-sizing:border-box; }
+  body { font-family:Inter,-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif; background:var(--bg); color:var(--text); line-height:1.6; font-size:16px; }
+  .container { max-width:800px; margin:0 auto; padding:2rem 1.5rem; }
+  a { color:var(--brand); text-decoration:none; }
+  a:hover { text-decoration:underline; }
+  .back { font-size:0.875rem; color:var(--muted); margin-bottom:1.5rem; display:inline-block; }
+  .back:hover { color:var(--brand); }
+  header { margin-bottom:2rem; }
+  header h1 { font-size:1.5rem; font-weight:600; margin-bottom:0.25rem; }
+  header .meta { color:var(--muted); font-size:0.875rem; }
+  .score-badge { display:inline-block; font-size:0.875rem; font-weight:700; padding:4px 14px; border-radius:4px; margin-right:0.75rem; }
+  .score-badge.high { background:rgba(144,201,77,0.12); color:#5a8a1a; border:1px solid rgba(144,201,77,0.3); }
+  .score-badge.medium { background:rgba(244,186,65,0.12); color:#9a7520; border:1px solid rgba(244,186,65,0.3); }
+  .score-badge.low { background:rgba(240,54,3,0.08); color:var(--low); border:1px solid rgba(240,54,3,0.2); }
+  .fields { background:var(--card); border:1px solid var(--border); border-radius:4px; padding:1.25rem; margin-bottom:2rem; display:grid; grid-template-columns:auto 1fr; gap:0.375rem 1rem; font-size:0.875rem; }
+  .fields dt { color:var(--muted); font-weight:500; }
+  .fields dd { color:var(--text); }
+  .research { background:var(--card); border:1px solid var(--border); border-radius:4px; padding:1.5rem; }
+  .research h2 { font-size:1.125rem; font-weight:600; margin:1.5rem 0 0.5rem 0; color:var(--black); }
+  .research h2:first-child { margin-top:0; }
+  .research p { margin-bottom:0.75rem; }
+  .research ul { margin:0.5rem 0 1rem 1.25rem; }
+  .research li { margin-bottom:0.375rem; font-size:0.875rem; }
+  .confidence { font-size:0.75rem; font-weight:600; padding:1px 6px; border-radius:2px; }
+  .confidence.high { background:rgba(144,201,77,0.12); color:#5a8a1a; }
+  .confidence.medium { background:rgba(244,186,65,0.12); color:#9a7520; }
+  .confidence.low { background:rgba(240,54,3,0.08); color:var(--low); }
+  footer { margin-top:3rem; padding-top:1.5rem; border-top:1px solid var(--border); text-align:center; font-size:0.75rem; color:var(--muted); }
+</style>
+</head>
+<body>
+<div class="container">
+  <a href="../index.html" class="back">&larr; Back to overview</a>
+  <header>
+    <h1>${escapeHtml(c.company_name)}</h1>
+    <div class="meta">
+      <span class="score-badge ${sc}">ICP Score: ${escapeHtml(c.icp_fit_score || '—')}</span>
+      ${c.website ? `<a href="${escapeHtml(c.website)}" target="_blank">${escapeHtml(c.website)}</a>` : ''}
+    </div>
+  </header>
+  <dl class="fields">
+    ${c.product_description ? `<dt>Product</dt><dd>${escapeHtml(c.product_description)}</dd>` : ''}
+    ${c.industry ? `<dt>Industry</dt><dd>${escapeHtml(c.industry)}</dd>` : ''}
+    ${c.target_audience ? `<dt>Target Audience</dt><dd>${escapeHtml(c.target_audience)}</dd>` : ''}
+    ${c.key_features ? `<dt>Key Features</dt><dd>${escapeHtml(c.key_features)}</dd>` : ''}
+    ${c.employee_estimate ? `<dt>Employees</dt><dd>${escapeHtml(c.employee_estimate)}</dd>` : ''}
+    ${c.funding_info ? `<dt>Funding</dt><dd>${escapeHtml(c.funding_info)}</dd>` : ''}
+    ${c.headquarters ? `<dt>HQ</dt><dd>${escapeHtml(c.headquarters)}</dd>` : ''}
+    ${c.icp_fit_reasoning ? `<dt>Fit Reasoning</dt><dd>${escapeHtml(c.icp_fit_reasoning)}</dd>` : ''}
+  </dl>
+  <div class="research">
+    ${bodyHtml}
+  </div>
+</div>
+<footer>Generated by <a href="https://github.com/anthropics/skills">event-prospecting</a> · Powered by <a href="https://browserbase.com">Browserbase</a></footer>
+</body>
+</html>`;
+
+  writeFileSync(join(dir, 'companies', `${c.slug}.html`), companyHtml);
+}
+
+// ----- CSV ----------------------------------------------------------------
+
+const priority = [
+  'company_name', 'website', 'product_description', 'icp_fit_score',
+  'icp_fit_reasoning', 'industry', 'target_audience', 'key_features',
+  'employee_estimate', 'funding_info', 'headquarters'
+];
+const scalarKeys = new Set();
+for (const row of deduped) {
+  for (const k of Object.keys(row)) {
+    if (k === 'body' || k === 'slug' || k === 'file') continue;
+    if (typeof row[k] === 'object' && row[k] !== null) continue;
+    scalarKeys.add(k);
+  }
+}
+const allCols = [...scalarKeys];
+const cols = [...priority.filter(c => allCols.includes(c)), ...allCols.filter(c => !priority.includes(c)).sort()];
+
+function csvEscape(v) {
+  if (v == null) return '';
+  const s = typeof v === 'object' ? JSON.stringify(v) : String(v);
+  if (s.includes(',') || s.includes('"') || s.includes('\n')) return '"' + s.replace(/"/g, '""') + '"';
+  return s;
+}
+
+const csvLines = [cols.join(',')];
+for (const row of deduped) {
+  csvLines.push(cols.map(c => csvEscape(row[c] || '')).join(','));
+}
+writeFileSync(join(dir, 'results.csv'), csvLines.join('\n') + '\n');
+
+// ----- Summary ------------------------------------------------------------
+
+console.error(JSON.stringify({
+  total_companies: deduped.length,
+  total_people: people.length,
+  high_fit: high,
+  medium_fit: medium,
+  low_fit: low,
+  files_generated: {
+    index: join(dir, 'index.html'),
+    people: join(dir, 'people.html'),
+    companies: join(dir, 'companies.html'),
+    company_pages: deduped.filter(c => c.body && c.body.length > 50).length,
+    csv: join(dir, 'results.csv')
+  }
+}, null, 2));
+
+console.log(join(dir, 'index.html'));
+
+if (shouldOpen) {
+  const { execSync } = await import('child_process');
+  try { execSync(`open "${join(dir, 'index.html')}"`); } catch {}
+}

--- a/skills/event-prospecting/scripts/compile_report.mjs
+++ b/skills/event-prospecting/scripts/compile_report.mjs
@@ -461,14 +461,53 @@ ${personList.map(p => renderPersonCard(p, p._company)).join('\n')}
 </div>`;
 }
 
-// renderFilterBar is added in D3 — defined as a no-op here so D2 still compiles.
-function renderFilterBar(_personList) {
-  return '';
+function uniqValues(list, fn) {
+  return [...new Set(list.map(fn).filter(Boolean))].sort();
+}
+
+// people.html filter chips: ICP band, role bucket, company.
+// Activating a chip applies a single-value filter against the matching
+// data-* attribute on each .person-card. Click handlers are in clipboardScript.
+function renderFilterBar(personList) {
+  const compNames = uniqValues(personList, p => p.company);
+  const roles = uniqValues(personList, p => roleBucket(p.title));
+  const bands = ['high', 'mid', 'low'];
+
+  const chip = (val, label) => `<span class="chip${val === '' ? ' active' : ''}" data-value="${escapeHtml(val)}">${escapeHtml(label)}</span>`;
+
+  const bandLabels = { high: 'High (8-10)', mid: 'Mid (6-7)', low: 'Low (1-5)' };
+
+  return `<div class="filter-bar">
+    <div class="filter-group" data-filter="icpband">
+      <span class="label">ICP</span>
+      ${chip('', 'All')}
+      ${bands.map(b => chip(b, bandLabels[b])).join(' ')}
+    </div>
+    <div class="filter-group" data-filter="role">
+      <span class="label">Role</span>
+      ${chip('', 'All')}
+      ${roles.map(r => chip(r, r)).join(' ')}
+    </div>
+    <div class="filter-group" data-filter="company">
+      <span class="label">Company</span>
+      ${chip('', 'All')}
+      ${compNames.map(c => chip(c.toLowerCase(), c)).join(' ')}
+    </div>
+  </div>`;
 }
 
 // ----- Companies table with attendees expandable ---------------------------
 
 function renderCompaniesTable() {
+  // Group people by company slug or name (lowered) so each row can show its attendees.
+  const byCompany = new Map();
+  for (const p of people) {
+    const key = p._company ? (p._company.slug || (p._company.company_name || '').toLowerCase()) : null;
+    if (!key) continue;
+    if (!byCompany.has(key)) byCompany.set(key, []);
+    byCompany.get(key).push(p);
+  }
+
   return deduped.map(c => {
     const sc = scoreClass(c.icp_fit_score);
     const hasDetail = c.body && c.body.length > 50;
@@ -478,9 +517,16 @@ function renderCompaniesTable() {
     const websiteHtml = c.website
       ? `<br><a href="${escapeHtml(c.website)}" target="_blank" style="font-size:0.75rem;color:var(--muted);">${escapeHtml(c.website.replace(/^https?:\/\/(www\.)?/, ''))}</a>`
       : '';
+    const key = c.slug || (c.company_name || '').toLowerCase();
+    const attendees = byCompany.get(key) || [];
+    const attendeeBlock = attendees.length ? `
+        <details class="attendees">
+          <summary>${attendees.length} attendee${attendees.length === 1 ? '' : 's'}</summary>
+          <ul>${attendees.map(a => `<li><strong>${escapeHtml(a.name || a.slug)}</strong>${a.title ? ' &mdash; ' + escapeHtml(a.title) : ''}${(a.links && a.links.linkedin) ? ` &middot; <a href="${escapeHtml(a.links.linkedin)}" target="_blank" rel="noopener">LinkedIn</a>` : ''}</li>`).join('')}</ul>
+        </details>` : '';
     return `      <tr>
         <td><span class="score ${sc}">${escapeHtml(c.icp_fit_score || '—')}</span></td>
-        <td>${nameHtml}${websiteHtml}</td>
+        <td>${nameHtml}${websiteHtml}${attendeeBlock}</td>
         <td style="max-width:200px;">${escapeHtml(c.product_description || '')}</td>
         <td>${escapeHtml(c.industry || '')}</td>
         <td class="reasoning">${escapeHtml(c.icp_fit_reasoning || '')}</td>

--- a/skills/event-prospecting/scripts/enrich_person.mjs
+++ b/skills/event-prospecting/scripts/enrich_person.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// enrich_person.mjs — given a person record, run a sequence of bb searches and
+// emit a structured enrichment record. Used by the per-person subagent.
+//
+// Usage: enrich_person.mjs --name "Greg Brockman" --company "OpenAI" --linkedin "https://..." --depth deep
+
+import { execFileSync } from 'child_process';
+
+function flag(name, def) {
+  const i = process.argv.indexOf(name);
+  return i !== -1 ? process.argv[i + 1] : def;
+}
+
+const name = flag('--name');
+const company = flag('--company', '');
+const linkedinIn = flag('--linkedin', '');
+const depth = flag('--depth', 'deep');
+
+if (!name) { console.error('--name required'); process.exit(1); }
+
+function bbSearch(query, n = 5) {
+  const out = execFileSync('bb', ['search', query, '--num-results', String(n)], {
+    encoding: 'utf-8', maxBuffer: 4 * 1024 * 1024, timeout: 20000,
+  });
+  return JSON.parse(out);
+}
+
+function harvestLinks(results) {
+  const links = { linkedin: linkedinIn || null, x: null, github: null, blog: null, podcast: null };
+  for (const r of results) {
+    const u = r.url || '';
+    if (!links.linkedin && /linkedin\.com\/in\//.test(u)) links.linkedin = u;
+    if (!links.x && /(x|twitter)\.com/.test(u)) links.x = u;
+    if (!links.github && /github\.com/.test(u)) links.github = u;
+    if (!links.podcast && /(spotify|podcast|simplecast|transistor)/.test(u)) links.podcast = u;
+    if (!links.blog && /(medium|substack|hashnode|dev\.to|\.blog)/.test(u)) links.blog = u;
+  }
+  return links;
+}
+
+const out = { name, company, linkedin: linkedinIn, hooks: [], links: {} };
+
+// Lane 1 — LinkedIn verify (always)
+const r1 = bbSearch(`${name} ${company} linkedin`);
+out.links = harvestLinks(r1.results || []);
+
+// Lane 2 — Recent activity (deep+)
+if (depth === 'deep' || depth === 'deeper') {
+  const r2 = bbSearch(`"${name}" podcast OR talk OR blog 2026`);
+  out.recentActivity = (r2.results || []).slice(0, 3).map(r => ({ title: r.title, url: r.url }));
+}
+
+// Lane 3 — GitHub + X (deeper)
+if (depth === 'deeper') {
+  const r3 = bbSearch(`"${name}" github`);
+  const r4 = bbSearch(`"${name}" site:x.com OR site:twitter.com`);
+  out.links = { ...out.links, ...harvestLinks([...(r3.results || []), ...(r4.results || [])]) };
+}
+
+console.log(JSON.stringify(out, null, 2));

--- a/skills/event-prospecting/scripts/extract_event.mjs
+++ b/skills/event-prospecting/scripts/extract_event.mjs
@@ -94,6 +94,35 @@ if (recon.strategy === 'next-data-eval') {
 // Add a slug
 people = people.map(p => ({ ...p, slug: slugify(p.name) }));
 
+// Filter event-host employees and obvious noise. The host org domain is derived
+// from the event URL — for stripesessions.com, that's stripe.
+const hostOrg = (() => {
+  try {
+    const h = new URL(recon.url).hostname.replace(/^www\./, '');
+    // 'stripesessions.com' → 'stripe' (drop the 'sessions' suffix or take the first chunk)
+    return h.split('.')[0].replace(/sessions?$/, '').replace(/conf$/, '');
+  } catch { return null; }
+})();
+
+const filterArgs = process.argv.slice(2);
+const userCompanyArg = (() => {
+  const i = filterArgs.indexOf('--user-company');
+  return i !== -1 ? filterArgs[i + 1] : null;
+})();
+
+const dropList = new Set([
+  hostOrg && hostOrg.toLowerCase(),
+  userCompanyArg && userCompanyArg.toLowerCase(),
+].filter(Boolean));
+
+const filtered = people.filter(p => {
+  if (!p.company) return true; // keep "unknown company" — synth assigns later
+  return !dropList.has(p.company.toLowerCase());
+});
+
+console.error(`Filtered ${people.length - filtered.length} host-org / user-company employees`);
+people = filtered;
+
 // Write people.jsonl
 const peopleFile = join(outDir, 'people.jsonl');
 writeFileSync(peopleFile, people.map(p => JSON.stringify(p)).join('\n') + '\n');

--- a/skills/event-prospecting/scripts/extract_event.mjs
+++ b/skills/event-prospecting/scripts/extract_event.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+// extract_event.mjs — read recon.json, dispatch to platform-specific extractor,
+// write people.jsonl (one speaker per line) and seed_companies.txt.
+//
+// Usage: node extract_event.mjs <output-dir>
+
+import { execFileSync } from 'child_process';
+import { readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+const outDir = process.argv[2];
+if (!outDir) { console.error('Usage: extract_event.mjs <output-dir>'); process.exit(1); }
+
+const recon = JSON.parse(readFileSync(join(outDir, 'recon.json'), 'utf-8'));
+
+function browse(...subargs) {
+  return execFileSync('browse', subargs, {
+    encoding: 'utf-8', maxBuffer: 16 * 1024 * 1024, timeout: 60000,
+  });
+}
+
+function slugify(s) {
+  return (s || '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+function extractFromNextData(paths) {
+  // Build a JS expression that walks __NEXT_DATA__ for each path and unions the arrays.
+  const js = `(() => {
+    const data = JSON.parse(document.getElementById('__NEXT_DATA__').textContent);
+    function get(obj, path) {
+      // path like '.props.pageProps.foo[0].bar' — naive parser, sufficient
+      const tokens = path.match(/\\.[a-zA-Z_$][\\w$]*|\\[\\d+\\]/g) || [];
+      let cur = obj;
+      for (const t of tokens) {
+        if (!cur) return null;
+        if (t.startsWith('.')) cur = cur[t.slice(1)];
+        else cur = cur[parseInt(t.slice(1, -1), 10)];
+      }
+      return cur;
+    }
+    const all = [];
+    ${JSON.stringify(paths)}.forEach(p => {
+      const arr = get(data, p);
+      if (Array.isArray(arr)) all.push(...arr);
+    });
+    return all.map(s => ({
+      name: s.name || s.fullName || null,
+      title: s.title || s.role || null,
+      company: s.companyName || s.company || s.org || null,
+      linkedin: s.linkedInProfile || s.linkedinUrl || s.linkedin || null,
+      bio: s.bio || s.description || null,
+    }));
+  })()`;
+  const res = JSON.parse(browse('goto', recon.url));
+  browse('wait', 'timeout', '2000');
+  const evalRes = JSON.parse(browse('eval', js));
+  return evalRes.result || [];
+}
+
+function extractFromMarkdown() {
+  browse('goto', recon.url);
+  browse('wait', 'timeout', '2500');
+  const md = JSON.parse(browse('get', 'markdown')).markdown || '';
+  // Naive: find blocks of "#### {Name}\n\n{Role}\n\n{Company}\n\n[LinkedIn]({url})"
+  // This is a fallback — coverage is best-effort.
+  const blocks = md.split(/\n#{2,4} /);
+  const out = [];
+  for (const b of blocks) {
+    const lines = b.split(/\n+/).map(l => l.trim()).filter(Boolean);
+    if (lines.length < 2) continue;
+    const name = lines[0];
+    if (!/^[A-Z]/.test(name)) continue;
+    const linkedinMatch = b.match(/linkedin\.com\/in\/([\w-]+)/i);
+    out.push({
+      name,
+      title: lines[1] || null,
+      company: lines[2] || null,
+      linkedin: linkedinMatch ? `https://www.linkedin.com/in/${linkedinMatch[1]}/` : null,
+    });
+  }
+  return out;
+}
+
+let people = [];
+if (recon.strategy === 'next-data-eval') {
+  people = extractFromNextData(recon.nextDataPaths || []);
+} else if (recon.strategy === 'markdown') {
+  people = extractFromMarkdown();
+} else {
+  console.error(`Strategy ${recon.strategy} not implemented in v0.1; falling back to markdown.`);
+  people = extractFromMarkdown();
+}
+
+// Add a slug
+people = people.map(p => ({ ...p, slug: slugify(p.name) }));
+
+// Write people.jsonl
+const peopleFile = join(outDir, 'people.jsonl');
+writeFileSync(peopleFile, people.map(p => JSON.stringify(p)).join('\n') + '\n');
+
+// Roll up to unique companies
+const companies = [...new Set(people.map(p => p.company).filter(Boolean))].sort();
+writeFileSync(join(outDir, 'seed_companies.txt'), companies.join('\n') + '\n');
+
+console.error(`Extracted ${people.length} people, ${companies.length} unique companies → ${outDir}`);
+console.log(JSON.stringify({ peopleCount: people.length, companyCount: companies.length, peopleFile }, null, 2));

--- a/skills/event-prospecting/scripts/extract_page.mjs
+++ b/skills/event-prospecting/scripts/extract_page.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+// Extract structured page content for company research.
+// Fetches via `bb fetch` (raw HTML to a temp file), pulls title + meta tags
+// + visible body text, and auto-falls back to `bb browse` when content is thin.
+//
+// Usage: node extract_page.mjs <url> [--max-chars N]
+// Output (stdout): structured block consumable by a research subagent.
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const THIN_CONTENT_THRESHOLD = 200; // body chars under this → JS-rendered, fall back
+
+function parseArgs(argv) {
+  const args = { url: null, maxChars: 3000 };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--max-chars") args.maxChars = parseInt(argv[++i], 10);
+    else if (!args.url) args.url = a;
+  }
+  if (!args.url) {
+    console.error("Usage: extract_page.mjs <url> [--max-chars N]");
+    process.exit(2);
+  }
+  return args;
+}
+
+function bbFetch(url, outFile) {
+  execFileSync("bb", ["fetch", "--allow-redirects", url, "--output", outFile], {
+    stdio: ["ignore", "ignore", "ignore"],
+  });
+}
+
+function bbBrowseMarkdown(url) {
+  try {
+    execFileSync("bb", ["browse", "--headless", "open", url], {
+      stdio: ["ignore", "ignore", "ignore"],
+      timeout: 90000,
+    });
+    const out = execFileSync("bb", ["browse", "--headless", "get", "markdown"], {
+      encoding: "utf8",
+      timeout: 90000,
+      maxBuffer: 50 * 1024 * 1024,
+    });
+    // bb browse prints banners (e.g. "Update available...") before the JSON blob.
+    // Find the first '{' and try to JSON.parse from there.
+    const start = out.indexOf("{");
+    if (start < 0) return "";
+    try {
+      const parsed = JSON.parse(out.slice(start));
+      if (parsed && typeof parsed.markdown === "string") return parsed.markdown;
+    } catch {
+      // Fallback: extract "markdown": "..." with a lenient regex that handles
+      // escaped quotes and newlines.
+      const m = out.slice(start).match(/"markdown"\s*:\s*"((?:\\.|[^"\\])*)"/s);
+      if (m) {
+        try { return JSON.parse(`"${m[1]}"`); } catch { return m[1]; }
+      }
+    }
+    return "";
+  } catch (err) {
+    return "";
+  }
+}
+
+function extractMeta(html, name, attr = "name") {
+  const re = new RegExp(
+    `<meta\\s+${attr}=["']${name}["']\\s+content=["']([^"']*)["']`,
+    "i"
+  );
+  const re2 = new RegExp(
+    `<meta\\s+content=["']([^"']*)["']\\s+${attr}=["']${name}["']`,
+    "i"
+  );
+  const m = html.match(re) || html.match(re2);
+  return m ? m[1].trim() : "";
+}
+
+function extractTitle(html) {
+  const m = html.match(/<title[^>]*>([^<]*)<\/title>/i);
+  return m ? m[1].trim() : "";
+}
+
+function extractVisibleText(html, maxChars) {
+  // Multi-line aware script/style removal.
+  let s = html
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, " ")
+    .replace(/<noscript\b[^>]*>[\s\S]*?<\/noscript>/gi, " ")
+    .replace(/<!--[\s\S]*?-->/g, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#[0-9]+;/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return s.slice(0, maxChars);
+}
+
+function extractHeadings(html, limit = 10) {
+  const re = /<h[1-3][^>]*>([\s\S]*?)<\/h[1-3]>/gi;
+  const out = [];
+  let m;
+  while ((m = re.exec(html)) && out.length < limit) {
+    const text = m[1].replace(/<[^>]+>/g, "").replace(/\s+/g, " ").trim();
+    if (text) out.push(text);
+  }
+  return out;
+}
+
+function main() {
+  const { url, maxChars } = parseArgs(process.argv.slice(2));
+  const dir = mkdtempSync(join(tmpdir(), "extract_page_"));
+  const htmlFile = join(dir, "page.html");
+
+  let html = "";
+  let fetchOk = false;
+  try {
+    bbFetch(url, htmlFile);
+    html = readFileSync(htmlFile, "utf8");
+    fetchOk = true;
+  } catch (err) {
+    console.error(`[extract_page] bb fetch failed: ${err.message}`);
+  }
+
+  const title = extractTitle(html);
+  const metaDesc = extractMeta(html, "description");
+  const ogTitle = extractMeta(html, "og:title", "property");
+  const ogDesc = extractMeta(html, "og:description", "property");
+  const headings = extractHeadings(html);
+  let body = extractVisibleText(html, maxChars);
+
+  // Thin content → JS-rendered SPA → fall back to bb browse.
+  let fallbackUsed = false;
+  if (body.length < THIN_CONTENT_THRESHOLD) {
+    const md = bbBrowseMarkdown(url);
+    if (md && md.length > body.length) {
+      body = md.replace(/\s+/g, " ").slice(0, maxChars);
+      fallbackUsed = true;
+    }
+  }
+
+  rmSync(dir, { recursive: true, force: true });
+
+  // Structured output for subagent to read.
+  const lines = [
+    `URL: ${url}`,
+    `FETCH_OK: ${fetchOk}`,
+    `FALLBACK_TO_BROWSE: ${fallbackUsed}`,
+    `TITLE: ${title}`,
+    `META_DESCRIPTION: ${metaDesc}`,
+    `OG_TITLE: ${ogTitle}`,
+    `OG_DESCRIPTION: ${ogDesc}`,
+    `HEADINGS: ${headings.join(" | ")}`,
+    `BODY_CHARS: ${body.length}`,
+    `BODY:`,
+    body,
+  ];
+  process.stdout.write(lines.join("\n") + "\n");
+}
+
+main();

--- a/skills/event-prospecting/scripts/list_urls.mjs
+++ b/skills/event-prospecting/scripts/list_urls.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+
+// Deduplicates discovery URLs from bb search JSON output files.
+// Usage: node list_urls.mjs /tmp [--prefix company]
+// Reads all {prefix}_discovery_batch_*.json files, deduplicates by domain,
+// outputs one URL per line to stdout, stats to stderr.
+
+import { readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+const args = process.argv.slice(2);
+
+if (args.includes('--help') || args.includes('-h') || args.length === 0) {
+  console.error(`Usage: node list_urls.mjs <directory> [--prefix <prefix>]
+
+Reads all <prefix>_discovery_batch_*.json files from <directory>,
+deduplicates URLs by domain, and outputs one URL per line to stdout.
+
+Options:
+  --prefix <prefix>  Batch file prefix (default: "company")
+  --help, -h         Show this help message
+
+Examples:
+  node list_urls.mjs /tmp
+  node list_urls.mjs /tmp --prefix company`);
+  process.exit(args.includes('--help') || args.includes('-h') ? 0 : 1);
+}
+
+const dir = args[0];
+const prefixIdx = args.indexOf('--prefix');
+const prefix = prefixIdx !== -1 && args[prefixIdx + 1] ? args[prefixIdx + 1] : 'company';
+
+const pattern = new RegExp(`^${prefix}_discovery_batch_.*\\.json$`);
+
+let files;
+try {
+  files = readdirSync(dir)
+    .filter(f => pattern.test(f))
+    .sort();
+} catch (err) {
+  console.error(`Error reading directory ${dir}: ${err.message}`);
+  process.exit(1);
+}
+
+if (files.length === 0) {
+  console.error(`No ${prefix}_discovery_batch_*.json files found in ${dir}`);
+  process.exit(1);
+}
+
+const seenDomains = new Set();
+const urls = [];
+let totalResults = 0;
+
+for (const file of files) {
+  try {
+    const data = JSON.parse(readFileSync(join(dir, file), 'utf-8'));
+    const results = Array.isArray(data) ? data : (data.results || []);
+    totalResults += results.length;
+
+    for (const result of results) {
+      const url = result.url;
+      if (!url) continue;
+
+      try {
+        const hostname = new URL(url).hostname.replace(/^www\./, '');
+        if (!seenDomains.has(hostname)) {
+          seenDomains.add(hostname);
+          urls.push(url);
+        }
+      } catch {
+        // Skip invalid URLs
+      }
+    }
+  } catch (err) {
+    console.error(`Warning: Failed to parse ${file}: ${err.message}`);
+  }
+}
+
+// Output deduplicated URLs to stdout
+for (const url of urls) {
+  console.log(url);
+}
+
+// Stats to stderr
+console.error(`\n${files.length} files, ${totalResults} total results, ${urls.length} unique domains`);

--- a/skills/event-prospecting/scripts/package.json
+++ b/skills/event-prospecting/scripts/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "event-prospecting-scripts",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true
+}

--- a/skills/event-prospecting/scripts/recon.mjs
+++ b/skills/event-prospecting/scripts/recon.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+// recon.mjs — probe an event URL, identify the platform, persist a recon.json
+// describing how to extract people. Output dir is the second arg or stdout.
+//
+// Usage: node recon.mjs <event-url> [output-dir]
+//
+// Detection priority:
+//   1. Next.js __NEXT_DATA__ (custom Next sites — Stripe Sessions class)
+//   2. Sessionize generator meta or sessionz.io script
+//   3. Lu.ma og:site_name
+//   4. Eventbrite og:site_name
+//   5. JSON-LD Event block
+//   6. Fall through to markdown-extraction strategy
+
+import { execFileSync } from 'child_process';
+import { writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+
+const args = process.argv.slice(2);
+if (args.length < 1 || args.includes('--help')) {
+  console.error(`Usage: node recon.mjs <event-url> [output-dir]`);
+  process.exit(1);
+}
+
+const url = args[0];
+const outDir = args[1];
+
+function browse(...subargs) {
+  return execFileSync('browse', subargs, {
+    encoding: 'utf-8', maxBuffer: 8 * 1024 * 1024, timeout: 60000,
+  });
+}
+
+function probe() {
+  // Navigate + settle
+  browse('goto', url);
+  browse('wait', 'timeout', '2500');
+  const titleRes = JSON.parse(browse('get', 'title'));
+  const title = titleRes.title || '';
+
+  // Probe in priority order via a single eval — cheaper than N calls.
+  const probeJs = `(() => {
+    const nd = document.getElementById('__NEXT_DATA__');
+    const meta = document.querySelector('meta[name="generator"]');
+    const og = document.querySelector('meta[property="og:site_name"]');
+    const jsonLd = [...document.querySelectorAll('script[type="application/ld+json"]')]
+      .map(s => { try { return JSON.parse(s.textContent); } catch { return null; }})
+      .filter(Boolean);
+    return {
+      hasNextData: !!nd,
+      nextDataLen: nd ? nd.textContent.length : 0,
+      generator: meta ? meta.content : null,
+      ogSite: og ? og.content : null,
+      jsonLdEvents: jsonLd.filter(j => j['@type'] === 'Event').length,
+      hostname: location.hostname
+    };
+  })()`;
+  const evalRes = JSON.parse(browse('eval', probeJs));
+  const r = evalRes.result || {};
+
+  // Decide platform
+  let platform = 'custom';
+  let strategy = 'markdown';
+  let nextDataPaths = null;
+
+  if (r.hasNextData) {
+    platform = 'next-data';
+    strategy = 'next-data-eval';
+    // Find arrays of speaker-like objects inside __NEXT_DATA__
+    const findJs = `(() => {
+      const data = JSON.parse(document.getElementById('__NEXT_DATA__').textContent);
+      const out = [];
+      function walk(o, path='') {
+        if (Array.isArray(o)) {
+          if (o.length > 3 && typeof o[0] === 'object' && o[0] !== null) {
+            const keys = Object.keys(o[0]);
+            const hasName = keys.some(k => /name/i.test(k));
+            const hasLinkedIn = JSON.stringify(o[0]).match(/linkedin/i);
+            if (hasName && hasLinkedIn) out.push({ path, len: o.length, keys: keys.slice(0,12) });
+          }
+          o.forEach((v,i) => walk(v, path+'['+i+']'));
+        } else if (o && typeof o === 'object') {
+          Object.keys(o).forEach(k => walk(o[k], path+'.'+k));
+        }
+      }
+      walk(data);
+      // Keep only top-level (non-nested) speaker arrays — drop talks[N].speakers
+      return out.filter(x => !/\\.talks\\[\\d+\\]\\.speakers/.test(x.path)).slice(0, 5);
+    })()`;
+    const findRes = JSON.parse(browse('eval', findJs));
+    nextDataPaths = (findRes.result || []).map(x => x.path);
+  } else if (r.generator && /sessionize/i.test(r.generator)) {
+    platform = 'sessionize';
+    strategy = 'sessionize-api';
+  } else if (r.hostname && /lu\.ma/.test(r.hostname)) {
+    platform = 'luma';
+    strategy = 'json-ld';
+  } else if (r.ogSite && /eventbrite/i.test(r.ogSite)) {
+    platform = 'eventbrite';
+    strategy = 'json-ld';
+  } else if (r.jsonLdEvents > 0) {
+    platform = 'json-ld';
+    strategy = 'json-ld';
+  }
+
+  return {
+    url,
+    title,
+    platform,
+    strategy,
+    nextDataPaths,
+    signals: r,
+    probedAt: new Date().toISOString(),
+  };
+}
+
+const result = probe();
+
+if (outDir) {
+  mkdirSync(outDir, { recursive: true });
+  const path = join(outDir, 'recon.json');
+  writeFileSync(path, JSON.stringify(result, null, 2));
+  console.error(`recon.json written → ${path}`);
+}
+console.log(JSON.stringify(result, null, 2));


### PR DESCRIPTION
# event-prospecting — design

**Status**: approved 2026-04-25
**Sibling skills**: company-research, cold-outbound, account-positioning, competitor-analysis, github-stargazers
**Path**: `/Users/jay/skills/skills/event-prospecting/`

## Purpose

Take a conference / event speakers URL, extract the people, filter their companies against the user's ICP, then deep-research only the people at ICP-fit companies. Output a person-first HTML report where each card answers "why should the AE talk to this person?" with all their public links and a one-click DM opener.

Architectural shape: a thin front-end (event recon + extract) and back-end (person enrichment + HTML) wrapped around the company-research backend. Most of the cost lives in company-research; this skill is glue + a different report.

## What problem this solves

GTM teams scrape conference speaker lists into spreadsheets manually or via Clay / Apify actors. The work that follows — figuring out *which* speakers actually matter for THIS sender, what the wedge is, and how to open the conversation — stays manual. This skill collapses that to one command per event.

Five gaps this targets (per find-skills research, 2026-04-25):
1. JS-rendered / Next.js speaker pages — most existing tools degrade
2. Sponsor → buying-committee mapping — tools dump company names but don't fan out
3. ICP scoring tied to *event context* (track / sponsor tier / talk topic) — generic ICP isn't enough
4. Multi-event recurrence — "this person spoke at 4 events I care about"
5. Open agent-native skill that chains scrape → enrich → score → CSV in one install

v0.1 hits #1, #3, #5. #2 and #4 are v0.2 candidates.

## Pipeline (10 steps)

| Step | What | Reuses |
|------|------|--------|
| 0 | Setup output dir `~/Desktop/{event_slug}_prospects_{YYYY-MM-DD-HHMM}/` | — |
| 1 | Load user profile from `profiles/{slug}.json`. Fail loudly if missing — point at company-research to build one. | company-research profile shape |
| 2 | **Recon** the event URL. Detect platform (Next.js `__NEXT_DATA__`, Sessionize public API, Lu.ma JSON-LD, Eventbrite JSON-LD, custom). Persist `recon.json`. | NEW |
| 3 | **Extract people** using platform-specific shortcut. For Next.js: 4 `browse` commands extract structured speaker JSON. Output `people.jsonl`. | NEW |
| 4 | Group by `.company` → unique seed company list (e.g. 240 people → 99 companies). | NEW (~5 LOC) |
| 5 | **ICP triage** — for each unique company, fetch homepage + score against user ICP (one tool call per company). | extract_page.mjs |
| 6 | **Filter** companies by `icp_fit_score >= --icp-threshold` (default 6). | NEW (~10 LOC) |
| 7 | **Deep research** the ICP-fit companies — full Plan→Research→Synthesize pattern, one subagent per company. Writes `companies/{slug}.md` with frontmatter scores. | company-research's `references/research-patterns.md` verbatim |
| 8 | **Enrich speakers** at ICP-fit companies only. Per person: LinkedIn snippet, recent activity (podcast / blog / talk / GitHub / X) for hook generation, harvest all public links. Writes `people/{slug}.md`. | NEW |
| 9 | Compile HTML report — person-first index, plus per-person + per-company drill-downs. Open in browser. Write `results.csv` for cold-outbound. | extends company-research's `compile_report.mjs` |

## Per-person card design

The primary deliverable. The index is a stack of these, ranked by ICP score.

```
┌────────────────────────────────────────────────┐
│  {Name}                              ICP {NN}  │
│  {Title} · {Company}                           │
│                                                │
│  🔗 {LinkedIn} {X} {GitHub} {Blog} {Podcast}   │  ← all public links found

---

## Phase E validation

Ran the full pipeline as a dry-run (recon → extract → manual ICP stubs → enrich → compile) against Stripe Sessions 2026 with the browserbase profile. Artifacts at `/tmp/sf_e2e_1777152213/`:
- `recon.json` → platform=next-data, 2 paths (correct)
- `people.jsonl` → 121 lines, `seed_companies.txt` → 98 (after host-org filter)
- `index.html` renders 3 person cards with correct ICP badges (high/high/mid)
- `people.html` and `companies.html` both written
- Copy DM opener + Research deeper buttons have populated `data-clipboard`

One bug found and fixed: Step 5's batch builder pulled `p.companyUrl`/`p.website` from `people.jsonl` but `extract_event.mjs` doesn't emit those fields. Replaced with a slugify-based homepage guess; the `Unknown — homepage content not accessible` fallback in `workflow.md` rule 3 absorbs misses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds two new Claude skills with multiple scripts, large prompt/workflow docs, and HTML templates; primary risk is operational (tool-call limits, brittle recon/extraction heuristics, and report generation) rather than changes to existing runtime code.
> 
> **Overview**
> Introduces a new `event-prospecting` skill that performs event URL recon, extracts speaker lists (Next.js `__NEXT_DATA__` plus markdown fallback), filters out host/user-company employees, and defines a subagent-driven pipeline for ICP triage, deep company research, and person enrichment that compiles into person-first HTML/CSV outputs.
> 
> Adds the supporting skill package structure (`SKILL.md`, profiles, fixtures, and reference docs for platform detection, research patterns, and workflow/tool-call caps) plus a reusable report template.
> 
> Separately adds a new `audit-agent-experience` skill (MIT licensed) with a full methodology/rubric, subagent brief + prompt variants, and an HTML report template for benchmarking onboarding/documentation DX via parallel agent runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a8ed253b29d1c5daf182507c251ff59cae01938. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->