### PR TITLE
docs(readme): add windows profile refresh command

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,17 @@ Install Chrome for your platform:
 ### Profile refresh
 
 To refresh cookies from your main Chrome profile:
+
+On macOS/Linux:
+
 ```bash
 rm -rf .chrome-profile
+```
+
+On Windows PowerShell:
+
+```powershell
+Remove-Item -LiteralPath .chrome-profile -Recurse -Force
 ```
 
 ## Resources


### PR DESCRIPTION
## Summary
- add an explicit macOS/Linux label for the existing `.chrome-profile` cleanup command
- add the Windows PowerShell equivalent for the same profile refresh step

## Why
The README already documents Windows installation, but the profile refresh section only showed a POSIX command. This makes that recovery step unclear for Windows users.

## Verification
- confirmed `.chrome-profile` is the repo's documented local profile directory
- verified the change is limited to `README.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds platform-specific cleanup commands; no runtime or behavioral impact.
> 
> **Overview**
> Clarifies the `Profile refresh` troubleshooting step by labeling the existing `.chrome-profile` removal command as *macOS/Linux* and adding the equivalent *Windows PowerShell* command to delete `.chrome-profile`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd0c2625f8725b3d2528be62d2d761cf50ba65b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->