### PR TITLE
fix: path traversal via crafted filenames + command injection in --open

### DIFF
--- a/skills/company-research/scripts/compile_report.mjs
+++ b/skills/company-research/scripts/compile_report.mjs
@@ -169,7 +169,9 @@ for (const file of files) {
   const fields = parseFrontmatter(content);
   if (!fields) continue;
   const body = parseBody(content);
-  const slug = file.replace('.md', '');
+  // Sanitize slug to prevent path traversal via crafted filenames
+  // (e.g. "../../etc/evil.md" → "evilevil" without "../" components)
+  const slug = file.replace('.md', '').replace(/\.\./g, '').replace(/[\\/]/g, '');
   companies.push({ ...fields, body, slug, file });
 }
 
@@ -351,6 +353,6 @@ console.log(join(dir, 'index.html'));
 
 // Open in browser if requested
 if (shouldOpen) {
-  const { execSync } = await import('child_process');
-  try { execSync(`open "${join(dir, 'index.html')}"`); } catch {}
+  const { execFileSync } = await import('child_process');
+  try { execFileSync('open', [join(dir, 'index.html')]); } catch {}
 }

--- a/skills/event-prospecting/scripts/compile_report.mjs
+++ b/skills/event-prospecting/scripts/compile_report.mjs
@@ -273,7 +273,8 @@ function readMdDir(p) {
     const fields = parseFrontmatter(content);
     if (!fields) return null;
     const body = parseBody(content);
-    const slug = f.replace('.md', '');
+    // Sanitize slug to prevent path traversal via crafted filenames
+    const slug = f.replace('.md', '').replace(/\.\./g, '').replace(/[\\/]/g, '');
     return { ...fields, body, slug, file: f };
   }).filter(Boolean);
 }
@@ -907,6 +908,6 @@ console.error(JSON.stringify({
 console.log(join(dir, 'index.html'));
 
 if (shouldOpen) {
-  const { execSync } = await import('child_process');
-  try { execSync(`open "${join(dir, 'index.html')}"`); } catch {}
+  const { execFileSync } = await import('child_process');
+  try { execFileSync('open', [join(dir, 'index.html')]); } catch {}
 }


### PR DESCRIPTION
Two vulnerabilities in `company-research` and `event-prospecting` compile_report.mjs.

## 1. Path traversal via crafted .md filenames

The slug is derived directly from the markdown filename:

```js
const slug = file.replace('.md', '');
```

A crafted filename like `../../etc/evil.md` produces slug `../../etc/evil`. When passed to:

```js
writeFileSync(join(dir, 'companies', `${slug}.html`), companyHtml)
```

This resolves to a path outside the output directory (e.g. `/tmp/etc/evil.html`). The slug is also interpolated unsanitized into `<a href="companies/${c.slug}.html">`, allowing arbitrary href injection in the generated HTML.

**Fix:** Strip `..`, `/`, and `\` from the slug after the `.md` removal.

## 2. Command injection via `--open`

```js
execSync(`open "${join(dir, 'index.html')}"`)
```

The `dir` argument comes from `process.argv[2]`. If it contains `$(cmd)` or `` `cmd` ``, bash executes the command inside the double-quoted template literal.

**Fix:** Use `execFileSync('open', [path])` which passes arguments directly to the executable without shell interpolation — the same pattern used by `evaluate.mjs` for `browse` commands.

---

9 lines changed across 2 files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security-sensitive file-path and process-invocation code paths; while the changes are small, they affect how output filenames/links are generated and how the report is launched.
> 
> **Overview**
> Closes two injection vectors in the `compile_report.mjs` scripts for *company-research* and *event-prospecting*.
> 
> Company page `slug` values derived from `.md` filenames are now sanitized to strip `..` and path separators, preventing path traversal (and related link/attribute injection) when generating per-company HTML files.
> 
> The `--open` option now uses `execFileSync('open', [path])` instead of shelling out via `execSync`, avoiding shell interpolation/command injection via a crafted output directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d396a82bd91c64f7e2867ee99ee310c70feb5b7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->