### PR TITLE
fix(security): validate URL scheme before rendering href to block javascript: XSS

### DIFF
--- a/skills/company-research/scripts/compile_report.mjs
+++ b/skills/company-research/scripts/compile_report.mjs
@@ -97,7 +97,11 @@ function escapeHtml(str) {
 // field can't smuggle a `javascript:` payload into the rendered href.
 function safeUrl(u) {
   if (!u || typeof u !== 'string') return null;
-  const trimmed = u.trim();
+  // Strip C0 controls + DEL before any scheme check. The WHATWG URL parser
+  // removes these before parsing, so `java\tscript:` reaches the browser as
+  // `javascript:` and runs — but the scheme regex below wouldn't catch it
+  // because `[a-z0-9+.-]` rejects the tab and falls through to return trimmed.
+  const trimmed = u.trim().replace(/[\x00-\x1F\x7F]/g, '');
   if (/^(\/\/|https?:\/\/|mailto:)/i.test(trimmed)) return trimmed;
   if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return null;
   return trimmed;

--- a/skills/company-research/scripts/compile_report.mjs
+++ b/skills/company-research/scripts/compile_report.mjs
@@ -93,6 +93,16 @@ function escapeHtml(str) {
   return (str || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
+// Reject any URL whose scheme isn't http(s)/mailto so the company `website`
+// field can't smuggle a `javascript:` payload into the rendered href.
+function safeUrl(u) {
+  if (!u || typeof u !== 'string') return null;
+  const trimmed = u.trim();
+  if (/^(\/\/|https?:\/\/|mailto:)/i.test(trimmed)) return trimmed;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return null;
+  return trimmed;
+}
+
 function scoreClass(score) {
   const s = parseInt(score) || 0;
   if (s >= 8) return 'high';
@@ -205,8 +215,9 @@ const tableRows = deduped.map(c => {
   const nameHtml = hasDetail
     ? `<a href="companies/${c.slug}.html">${escapeHtml(c.company_name)}</a>`
     : escapeHtml(c.company_name);
-  const websiteHtml = c.website
-    ? `<br><a href="${escapeHtml(c.website)}" target="_blank" style="font-size:0.75rem;color:var(--muted);">${escapeHtml(c.website.replace(/^https?:\/\/(www\.)?/, ''))}</a>`
+  const safeWebsite = safeUrl(c.website);
+  const websiteHtml = safeWebsite
+    ? `<br><a href="${escapeHtml(safeWebsite)}" target="_blank" rel="noopener" style="font-size:0.75rem;color:var(--muted);">${escapeHtml(safeWebsite.replace(/^https?:\/\/(www\.)?/, ''))}</a>`
     : '';
   return `      <tr>
         <td><span class="score ${sc}">${escapeHtml(c.icp_fit_score || '—')}</span></td>
@@ -289,7 +300,7 @@ for (const c of deduped) {
     <h1>${escapeHtml(c.company_name)}</h1>
     <div class="meta">
       <span class="score-badge ${sc}">ICP Score: ${escapeHtml(c.icp_fit_score || '—')}</span>
-      ${c.website ? `<a href="${escapeHtml(c.website)}" target="_blank">${escapeHtml(c.website)}</a>` : ''}
+      ${(() => { const s = safeUrl(c.website); return s ? `<a href="${escapeHtml(s)}" target="_blank" rel="noopener">${escapeHtml(s)}</a>` : ''; })()}
     </div>
   </header>
   <dl class="fields">

--- a/skills/event-prospecting/scripts/compile_report.mjs
+++ b/skills/event-prospecting/scripts/compile_report.mjs
@@ -157,6 +157,17 @@ function escapeJsInAttr(str) {
   return escapeAttr(js);
 }
 
+// Reject any URL whose scheme isn't http(s)/mailto, so attacker-controlled
+// fields (LinkedIn, X, GitHub, blog, podcast, image, company website) can't
+// smuggle a `javascript:` payload into a rendered href.
+function safeUrl(u) {
+  if (!u || typeof u !== 'string') return null;
+  const trimmed = u.trim();
+  if (/^(\/\/|https?:\/\/|mailto:)/i.test(trimmed)) return trimmed;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return null;
+  return trimmed;
+}
+
 function scoreClass(score) {
   const s = parseInt(score) || 0;
   if (s >= 8) return 'high';
@@ -386,8 +397,9 @@ function renderPersonCard(person, company) {
     podcast: person.podcast || null,
   };
   const linkPills = ['linkedin', 'x', 'github', 'blog', 'podcast']
-    .filter(k => links[k])
-    .map(k => `<a class="link-pill link-${k}" href="${escapeHtml(links[k])}" target="_blank" rel="noopener">${k.toUpperCase()}</a>`)
+    .map(k => ({ k, safe: safeUrl(links[k]) }))
+    .filter(({ safe }) => safe)
+    .map(({ k, safe }) => `<a class="link-pill link-${k}" href="${escapeHtml(safe)}" target="_blank" rel="noopener">${k.toUpperCase()}</a>`)
     .join(' ');
 
   const score = c.icp_fit_score || person.icp_fit_score || '?';
@@ -396,8 +408,9 @@ function renderPersonCard(person, company) {
   const hook = person.hook || extractSection(person.body, 'Hook') || '—';
   const roleReason = person.role_reason || extractSection(person.body, 'Why the person') || '—';
   const dmOpener = person.dm_opener || extractSection(person.body, 'DM Opener') || '';
-  const photo = person.image
-    ? `<img class="photo" src="${escapeHtml(person.image)}" alt="${escapeHtml(person.name || '')}" loading="lazy" referrerpolicy="no-referrer" onerror="this.replaceWith(Object.assign(document.createElement('div'),{className:'photo photo-placeholder',textContent:'${escapeJsInAttr(initials(person.name))}'}))">`
+  const safeImage = safeUrl(person.image);
+  const photo = safeImage
+    ? `<img class="photo" src="${escapeHtml(safeImage)}" alt="${escapeHtml(person.name || '')}" loading="lazy" referrerpolicy="no-referrer" onerror="this.replaceWith(Object.assign(document.createElement('div'),{className:'photo photo-placeholder',textContent:'${escapeJsInAttr(initials(person.name))}'}))">`
     : `<div class="photo photo-placeholder">${escapeHtml(initials(person.name))}</div>`;
 
   return `<div class="person-card" data-slug="${escapeHtml(person.slug)}" data-company="${escapeHtml((person.company || '').toLowerCase())}" data-role="${escapeHtml(roleBucket(person.title))}" data-icpband="${band}" data-icp-score="${escapeHtml(String(score))}">
@@ -566,8 +579,9 @@ function renderGroupedByCompany(personList) {
     const nameHtml = hasDetail
       ? `<a href="companies/${escapeHtml(company.slug)}.html">${escapeHtml(company.company_name)}</a>`
       : escapeHtml(company.company_name);
-    const websiteHtml = company.website
-      ? ` &middot; <a href="${escapeHtml(company.website)}" target="_blank" rel="noopener">${escapeHtml(company.website.replace(/^https?:\/\/(www\.)?/, ''))}</a>`
+    const safeCompanyWebsite = safeUrl(company.website);
+    const websiteHtml = safeCompanyWebsite
+      ? ` &middot; <a href="${escapeHtml(safeCompanyWebsite)}" target="_blank" rel="noopener">${escapeHtml(safeCompanyWebsite.replace(/^https?:\/\/(www\.)?/, ''))}</a>`
       : '';
     const metaBits = [
       `${members.length} speaker${members.length === 1 ? '' : 's'}`,
@@ -656,15 +670,20 @@ function renderCompaniesTable() {
     const nameHtml = hasDetail
       ? `<a href="companies/${c.slug}.html">${escapeHtml(c.company_name)}</a>`
       : escapeHtml(c.company_name);
-    const websiteHtml = c.website
-      ? `<br><a href="${escapeHtml(c.website)}" target="_blank" style="font-size:0.75rem;color:var(--muted);">${escapeHtml(c.website.replace(/^https?:\/\/(www\.)?/, ''))}</a>`
+    const safeWebsite = safeUrl(c.website);
+    const websiteHtml = safeWebsite
+      ? `<br><a href="${escapeHtml(safeWebsite)}" target="_blank" rel="noopener" style="font-size:0.75rem;color:var(--muted);">${escapeHtml(safeWebsite.replace(/^https?:\/\/(www\.)?/, ''))}</a>`
       : '';
     const key = c.slug || (c.company_name || '').toLowerCase();
     const attendees = byCompany.get(key) || [];
     const attendeeBlock = attendees.length ? `
         <details class="attendees">
           <summary>${attendees.length} attendee${attendees.length === 1 ? '' : 's'}</summary>
-          <ul>${attendees.map(a => `<li><strong>${escapeHtml(a.name || a.slug)}</strong>${a.title ? ' &mdash; ' + escapeHtml(a.title) : ''}${(a.links && a.links.linkedin) ? ` &middot; <a href="${escapeHtml(a.links.linkedin)}" target="_blank" rel="noopener">LinkedIn</a>` : ''}</li>`).join('')}</ul>
+          <ul>${attendees.map(a => {
+            const safeLinkedin = safeUrl(a.links && a.links.linkedin);
+            const linkedinHtml = safeLinkedin ? ` &middot; <a href="${escapeHtml(safeLinkedin)}" target="_blank" rel="noopener">LinkedIn</a>` : '';
+            return `<li><strong>${escapeHtml(a.name || a.slug)}</strong>${a.title ? ' &mdash; ' + escapeHtml(a.title) : ''}${linkedinHtml}</li>`;
+          }).join('')}</ul>
         </details>` : '';
     return `      <tr>
         <td><span class="score ${sc}">${escapeHtml(c.icp_fit_score || '—')}</span></td>
@@ -802,7 +821,7 @@ for (const c of deduped) {
     <h1>${escapeHtml(c.company_name)}</h1>
     <div class="meta">
       <span class="score-badge ${sc}">ICP Score: ${escapeHtml(c.icp_fit_score || '—')}</span>
-      ${c.website ? `<a href="${escapeHtml(c.website)}" target="_blank">${escapeHtml(c.website)}</a>` : ''}
+      ${(() => { const s = safeUrl(c.website); return s ? `<a href="${escapeHtml(s)}" target="_blank" rel="noopener">${escapeHtml(s)}</a>` : ''; })()}
     </div>
   </header>
   <dl class="fields">

--- a/skills/event-prospecting/scripts/compile_report.mjs
+++ b/skills/event-prospecting/scripts/compile_report.mjs
@@ -162,7 +162,11 @@ function escapeJsInAttr(str) {
 // smuggle a `javascript:` payload into a rendered href.
 function safeUrl(u) {
   if (!u || typeof u !== 'string') return null;
-  const trimmed = u.trim();
+  // Strip C0 controls + DEL before any scheme check. The WHATWG URL parser
+  // removes these before parsing, so `java\tscript:` reaches the browser as
+  // `javascript:` and runs — but the scheme regex below wouldn't catch it
+  // because `[a-z0-9+.-]` rejects the tab and falls through to return trimmed.
+  const trimmed = u.trim().replace(/[\x00-\x1F\x7F]/g, '');
   if (/^(\/\/|https?:\/\/|mailto:)/i.test(trimmed)) return trimmed;
   if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return null;
   return trimmed;


### PR DESCRIPTION
## Summary

Both `compile_report.mjs` scripts (`event-prospecting` + `company-research`) render attacker-controlled URL fields — LinkedIn / X / GitHub / blog / podcast / image / company website — into `<a href="…">` via `escapeHtml` only. `escapeHtml` handles `&`, `<`, `>`, `"` but does **not** validate the URL scheme, so `javascript:fetch(…)` (and `data:`, `vbscript:`, etc.) survive unchanged and produce a clickable XSS link in the rendered report.

## Impact

If an investigator runs `event-prospecting` against an attacker-controlled conference page (the OSINT-style use case the skill is built for), the page can plant a malicious `linkedInProfile` / `website` / `image` field. The subagent stores the URL verbatim into `people/<slug>.md` frontmatter, `compile_report.mjs` renders it into an `<a href="javascript:…">` pill, and one click on the LINKEDIN pill of the attacker's own card runs JS in the report origin — exfiltrating the **full report DOM** (every speaker + every company researched in the run, not just the attacker's own data) to attacker.com via `fetch()`.

`file://` origin caps cookie scope, but outbound `fetch()` still works, and the report is the cross-target leak surface (everything researched in the run is one DOM tree).

## Location

7 sinks share the root cause:

- `skills/event-prospecting/scripts/compile_report.mjs:397` — link pills (`linkedin`/`x`/`github`/`blog`/`podcast`)
- `skills/event-prospecting/scripts/compile_report.mjs:411` — per-card `photo` `<img src>`
- `skills/event-prospecting/scripts/compile_report.mjs:582` — grouped-by-company website link
- `skills/event-prospecting/scripts/compile_report.mjs:673` — companies-table website cell
- `skills/event-prospecting/scripts/compile_report.mjs:680` — attendee LinkedIn cell
- `skills/event-prospecting/scripts/compile_report.mjs:824` — per-company detail page website
- `skills/company-research/scripts/compile_report.mjs:218` — companies-table website cell
- `skills/company-research/scripts/compile_report.mjs:303` — per-company detail page website

(Line numbers post-patch — the originals were a few lines lower in each block.)

## Fix

A small `safeUrl(u)` helper in each file. Allows `http://`, `https://`, `mailto:`, and protocol-relative `//`; rejects anything that parses as a URL with any other scheme by anchoring against `[a-z][a-z0-9+.-]*:`. Plain strings without a scheme pass through unchanged so relative paths still render. The helper is applied at every URL-bearing href / src sink before `escapeHtml`, and `target="_blank"` links pick up `rel="noopener"` consistently.

The `safeUrl` regex is intentionally allow-list-then-reject rather than a single regex — easier to extend (e.g. add `tel:` if needed) and the early-exit on plain strings keeps callers simple.

```js
function safeUrl(u) {
  if (!u || typeof u !== 'string') return null;
  const trimmed = u.trim();
  if (/^(\/\/|https?:\/\/|mailto:)/i.test(trimmed)) return trimmed;
  if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return null;
  return trimmed;
}
```

`+43 / -13` across the two files; no new dependencies, no behavior change for legitimate `http(s)` links.

## Detected by

Aeon — manual review of the report-template URL sinks. Severity: **medium** (CWE-79). Picked up that `escapeHtml` doesn't touch `:` so any `<scheme>:<payload>` ride-along survives the encode.

Scanners on this run: `semgrep=ok` (no findings on the patched files; the 3 `raw-html-format` warnings on lines 426/427/430 are false positives — the values are already `escapeHtml`-wrapped or `escapeAttr`-wrapped); `trufflehog=ok` (filesystem 246 chunks + git history 740 chunks, 0 verified secrets); `osv-scanner=ok` (35 transitive CVEs across `skills/safe-browser/templates/.../package-lock.json`, `skills/autobrowse/package-lock.json`, `skills/cookie-sync/package-lock.json` — out of scope for this PR; happy to file a separate dep-bump PR if useful).

## Verification

- `node --check skills/event-prospecting/scripts/compile_report.mjs` — clean.
- `node --check skills/company-research/scripts/compile_report.mjs` — clean.
- Spot-checked `safeUrl` against the obvious cases: `https://example.com` → passes through, `javascript:alert(1)` → null, `data:text/html,<script>` → null, `vbscript:msgbox(1)` → null, `//cdn.example.com/x.js` → passes through, `mailto:hi@example.com` → passes through, `relative/path.html` → passes through, `""` / `null` / `undefined` → null.
- No test suite present in the repo for the report-render path, so verification is static.

## Disclosure note

The repo doesn't have a `SECURITY.md` and PVR is off, so under our fix-PR-first policy a public fix PR is the right channel — diff is the disclosure but the fix lands at the same time. Happy to convert to a private advisory if maintainers prefer.

---

Filed by [Aeon](https://github.com/aaronjmars/aeon-aaron).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches HTML generation for multiple attacker-controlled link/image fields; low complexity but could inadvertently drop or alter legitimate non-http(s)/mailto URLs in generated reports.
> 
> **Overview**
> Adds a `safeUrl()` allowlist-based URL sanitizer to both `company-research` and `event-prospecting` report compilers, stripping control characters and rejecting non-`http(s)`/`mailto` schemes to prevent `javascript:`-style XSS in generated HTML.
> 
> Applies `safeUrl()` to all rendered `href`/`src` sinks (company websites, social link pills, attendee LinkedIn links, and person images) and consistently adds `rel="noopener"` on `target="_blank"` links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39ac3ed571a2bb8c4a85c71d186fd94b2a1ad688. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->