### PR TITLE
docs: rename bb/browse-cli references to unified browse CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Browserbase Skills
 
-A set of skills for enabling **[Claude Code](https://docs.claude.com/en/docs/claude-code/overview)** to work with Browserbase through browser automation and the official `bb` CLI.
+A set of skills for enabling **[Claude Code](https://docs.claude.com/en/docs/claude-code/overview)** to work with Browserbase through browser automation and the official `browse` CLI.
 
 ## Skills
 
@@ -9,8 +9,8 @@ This plugin includes the following skills (see `skills/` for details):
 | Skill | Description |
 |-------|-------------|
 | [browser](skills/browser/SKILL.md) | Automate web browser interactions via CLI commands — supports remote Browserbase sessions with anti-bot stealth, CAPTCHA solving, and residential proxies |
-| [browserbase-cli](skills/browserbase-cli/SKILL.md) | Use the official `bb` CLI for Browserbase Functions and platform API workflows including sessions, projects, contexts, extensions, fetch, and dashboard |
-| [functions](skills/functions/SKILL.md) | Deploy serverless browser automation to Browserbase cloud using the `bb` CLI |
+| [browserbase-cli](skills/browserbase-cli/SKILL.md) | Use the official `browse` CLI for Browserbase Functions and platform API workflows including sessions, projects, contexts, extensions, fetch, and dashboard |
+| [functions](skills/functions/SKILL.md) | Deploy serverless browser automation to Browserbase cloud using the `browse` CLI |
 | [site-debugger](skills/site-debugger/SKILL.md) | Diagnose and fix failing browser automations — analyzes bot detection, selectors, timing, auth, and captchas, then generates a tested site playbook |
 | [browser-trace](skills/browser-trace/SKILL.md) | Capture a full DevTools-protocol trace (CDP firehose, screenshots, DOM dumps) alongside any browser automation, then bisect the stream into per-page searchable buckets |
 | [safe-browser](skills/safe-browser/SKILL.md) | Build local Claude Agent SDK browser agents whose only browser capability is a CDP-gated `safe_browser` tool with domain allowlist enforcement |
@@ -56,8 +56,8 @@ Once installed, you can ask Claude to browse or use the Browserbase CLI:
 - *"Go to Hacker News, get the top post comments, and summarize them "*
 - *"QA test http://localhost:3000 and fix any bugs you encounter"*
 - *"Order me a pizza, you're already signed in on Doordash"*
-- *"Use `bb` to list my Browserbase projects and show the output as JSON"*
-- *"Initialize a new Browserbase Function with `bb functions init` and explain the next commands"*
+- *"Use `browse` to list my Browserbase projects and show the output as JSON"*
+- *"Initialize a new Browserbase Function with `browse functions init` and explain the next commands"*
 - *"Use safe-browser to build a Hacker News scraper that only stays on the main site"*
 
 Claude will handle the rest.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Once installed, you can ask Claude to browse or use the Browserbase CLI:
 
 Claude will handle the rest.
 
-For local and localhost work, `browse env local` now starts a clean isolated browser by default. Use `browse env local --auto-connect` when the agent should reuse your existing local Chrome session, cookies, or login state.
+For local and localhost work, pass `--local` on the first browser command (for example, `browse open http://localhost:3000 --local`) to start a clean isolated browser. Use `--auto-connect` when the agent should reuse your existing local Chrome session, cookies, or login state.
 
 ## Troubleshooting
 

--- a/skills/autobrowse/README.md
+++ b/skills/autobrowse/README.md
@@ -12,7 +12,7 @@ The output is a `skill.md` — a site-specific playbook any agent can follow. On
 
 - Node.js 18+
 - [Claude Code](https://claude.ai/code)
-- `browse` CLI: `npm install -g @browserbasehq/browse-cli`
+- `browse` CLI: `npm install -g browse`
 - `ANTHROPIC_API_KEY` in your environment
 - For bot-protected sites: `BROWSERBASE_API_KEY` + `BROWSERBASE_PROJECT_ID`
 

--- a/skills/autobrowse/README.md
+++ b/skills/autobrowse/README.md
@@ -14,7 +14,7 @@ The output is a `skill.md` — a site-specific playbook any agent can follow. On
 - [Claude Code](https://claude.ai/code)
 - `browse` CLI: `npm install -g browse`
 - `ANTHROPIC_API_KEY` in your environment
-- For bot-protected sites: `BROWSERBASE_API_KEY` + `BROWSERBASE_PROJECT_ID`
+- For bot-protected sites: `BROWSERBASE_API_KEY`
 
 ## Setup
 

--- a/skills/autobrowse/REFERENCE.md
+++ b/skills/autobrowse/REFERENCE.md
@@ -19,7 +19,7 @@ node ${CLAUDE_SKILL_DIR}/scripts/evaluate.mjs --task <name> [options]
 |----------|----------|-------------|
 | `ANTHROPIC_API_KEY` | Yes | Claude API key |
 | `BROWSERBASE_API_KEY` | Remote only | Browserbase API key |
-| `BROWSERBASE_PROJECT_ID` | Remote only | Browserbase project ID |
+| `BROWSERBASE_PROJECT_ID` | No | Optional Browserbase project override |
 
 ## Trace artifacts
 

--- a/skills/autobrowse/SKILL.md
+++ b/skills/autobrowse/SKILL.md
@@ -175,9 +175,9 @@ description: <1-2 sentences describing what this skill does and when to use it. 
 ## Browse CLI Reference
 The inner agent uses the `browse` CLI. Key commands for this task:
 - `browse stop` — kill existing session (always run before switching to remote)
-- `browse env remote` — start a fresh Browserbase cloud session
-- `browse newpage <url>` — open URL in a new tab (required in remote mode — `browse open` fails with "no page available")
-- `browse open <url>` — navigate existing tab (local mode only)
+- `browse open <url> --remote` — start a fresh Browserbase cloud session and navigate
+- `browse open <url> --local` — start a clean local browser and navigate
+- `browse tab new <url>` — open URL in a new tab
 - `browse wait load` — wait for page to finish loading
 - `browse wait timeout <ms>` — wait a fixed amount of time for spinners or animations
 - `browse wait selector "<selector>"` — wait for an element to become visible

--- a/skills/autobrowse/references/example-skill.md
+++ b/skills/autobrowse/references/example-skill.md
@@ -130,7 +130,6 @@ Read the confirmation number from the snapshot and immediately output the final 
   "location_entered": "INTERSECTION OF 7TH ST & CHARLES J BRENHAM PL SAN FRANCISCO, CA 94102",
   "submission_method": "anonymous",
   "gotchas": [
-    "Use --session sf311 to avoid contaminated default Browserbase session",
     "Run browse stop before --remote when a daemon may already be active",
     "Location field is map-driven: type in ESRI search box, click autocomplete, Enter → wait 3000ms → Tab",
     "XPath Next buttons fail — always snapshot first and click by ref",

--- a/skills/autobrowse/references/example-skill.md
+++ b/skills/autobrowse/references/example-skill.md
@@ -59,7 +59,7 @@ browse open "https://sanfrancisco.form.us.empro.verintcloudservices.com/form/aut
 browse wait load
 ```
 
-`browse stop` before `browse open ... --remote` is mandatory. Skipping it can reuse a contaminated or ended prior session.
+If a daemon may already be active, run `browse stop` before opening remote; active local sessions do not switch to remote automatically.
 
 ### Page 1 — Disclaimer (turns 6–7)
 
@@ -131,7 +131,7 @@ Read the confirmation number from the snapshot and immediately output the final 
   "submission_method": "anonymous",
   "gotchas": [
     "Use --session sf311 to avoid contaminated default Browserbase session",
-    "browse stop + browse open --remote forces a fresh Browserbase session",
+    "Run browse stop before --remote when a daemon may already be active",
     "Location field is map-driven: type in ESRI search box, click autocomplete, Enter → wait 3000ms → Tab",
     "XPath Next buttons fail — always snapshot first and click by ref",
     "Page 3 description: use CSS selector #dform_widget_Request_description with fill",
@@ -143,7 +143,7 @@ Read the confirmation number from the snapshot and immediately output the final 
 
 ## Site-Specific Gotchas
 
-1. **Dead session on reconnect**: After a session ends, `browse stop` followed by `browse open <url> --remote` forces a fresh session.
+1. **Active daemon mode switch**: If a daemon may already be running in local or remote mode, run `browse stop` before `browse open <url> --remote`; active sessions do not switch modes automatically.
 
 3. **Location field is map-driven**: The Location textarea is populated by the ESRI geocoder. Workflow: type in the search box → wait 2000ms → snapshot → click autocomplete suggestion → press Enter → wait 3000ms → press Tab → Location field auto-populates.
 
@@ -183,7 +183,7 @@ To recover in future runs: follow the exact turn budget above with no deviations
   "location_entered": "INTERSECTION OF 7TH ST & CHARLES J BRENHAM PL SAN FRANCISCO, CA 94102",
   "submission_method": "anonymous",
   "gotchas": [
-    "browse stop + browse open --remote forces a fresh Browserbase session",
+    "Run browse stop before --remote when a daemon may already be active",
     "Location field is map-driven: type in ESRI search box, click autocomplete, Enter → wait 3000ms → Tab",
     "XPath Next buttons fail — always snapshot first and use ref ID",
     "Page 3 description: use CSS selector #dform_widget_Request_description with fill",

--- a/skills/autobrowse/references/example-skill.md
+++ b/skills/autobrowse/references/example-skill.md
@@ -29,9 +29,8 @@ tsx scripts/evaluate.ts --task sf-311-request --env remote
 
 ```bash
 browse stop
-browse env local
-browse env remote
-browse open <url>
+browse open <url> --local
+browse open <url> --remote
 browse wait load
 browse wait timeout <ms>
 browse snapshot
@@ -41,7 +40,7 @@ browse type <text>
 browse press Enter
 browse press Tab
 browse select "//select" <value>
-browse fill "#css-id" <text> --no-press-enter
+browse fill "#css-id" <text>
 ```
 
 Wait syntax:
@@ -56,13 +55,11 @@ Wait syntax:
 
 ```bash
 browse stop
-browse env local        # REQUIRED: forces new Browserbase session
-browse env remote       # restarted:true = clean session
-browse open "https://sanfrancisco.form.us.empro.verintcloudservices.com/form/auto/pw_street_sidewalkdefect?Issue=street_defect&Nature_of_request=pavement_defect"
+browse open "https://sanfrancisco.form.us.empro.verintcloudservices.com/form/auto/pw_street_sidewalkdefect?Issue=street_defect&Nature_of_request=pavement_defect" --remote
 browse wait load
 ```
 
-The `env local` + `env remote` sequence is mandatory. Skipping `env local` causes `env remote` to reconnect to a dead prior session, producing "No Page found" errors.
+`browse stop` before `browse open ... --remote` is mandatory. Skipping it can reuse a contaminated or ended prior session.
 
 ### Page 1 — Disclaimer (turns 6–7)
 
@@ -95,7 +92,7 @@ The Location textarea is map-driven — the ESRI geocoder populates it. Do not t
 
 ```bash
 browse select "//select" "Pothole or pavement defect"
-browse fill "#dform_widget_Request_description" "Large pothole approximately 12 inches wide near the crosswalk, causing hazard for cyclists" --no-press-enter
+browse fill "#dform_widget_Request_description" "Large pothole approximately 12 inches wide near the crosswalk, causing hazard for cyclists"
 browse click 0-970
 ```
 
@@ -134,10 +131,10 @@ Read the confirmation number from the snapshot and immediately output the final 
   "submission_method": "anonymous",
   "gotchas": [
     "Use --session sf311 to avoid contaminated default Browserbase session",
-    "env local + env remote forces a fresh Browserbase session",
+    "browse stop + browse open --remote forces a fresh Browserbase session",
     "Location field is map-driven: type in ESRI search box, click autocomplete, Enter → wait 3000ms → Tab",
     "XPath Next buttons fail — always snapshot first and click by ref",
-    "Page 3 description: use CSS selector #dform_widget_Request_description with fill --no-press-enter",
+    "Page 3 description: use CSS selector #dform_widget_Request_description with fill",
     "Page 3 Next ref 0-970 is stable — no snapshot needed"
   ],
   "error_reasoning": null
@@ -146,13 +143,13 @@ Read the confirmation number from the snapshot and immediately output the final 
 
 ## Site-Specific Gotchas
 
-1. **Dead session on reconnect**: After a session ends, `browse env remote` alone reconnects to the same dead Browserbase session (no pages). The `env local` → `env remote` sequence forces creating a fresh session.
+1. **Dead session on reconnect**: After a session ends, `browse stop` followed by `browse open <url> --remote` forces a fresh session.
 
 3. **Location field is map-driven**: The Location textarea is populated by the ESRI geocoder. Workflow: type in the search box → wait 2000ms → snapshot → click autocomplete suggestion → press Enter → wait 3000ms → press Tab → Location field auto-populates.
 
 4. **XPath Next button fails**: `//button[normalize-space(.)='Next']` XPath fails to advance pages on this Verint form. Always click Next by ref obtained from a snapshot.
 
-5. **Page 3 textarea by CSS ID**: The Request Description textarea has a stable `id="dform_widget_Request_description"`. Use `fill "#dform_widget_Request_description" <text> --no-press-enter`.
+5. **Page 3 textarea by CSS ID**: The Request Description textarea has a stable `id="dform_widget_Request_description"`. Use `fill "#dform_widget_Request_description" <text>`.
 
 6. **Page 3 Next ref is stable at 0-970**: No snapshot needed before clicking Next on Page 3.
 
@@ -186,10 +183,10 @@ To recover in future runs: follow the exact turn budget above with no deviations
   "location_entered": "INTERSECTION OF 7TH ST & CHARLES J BRENHAM PL SAN FRANCISCO, CA 94102",
   "submission_method": "anonymous",
   "gotchas": [
-    "env local + env remote forces a fresh Browserbase session",
+    "browse stop + browse open --remote forces a fresh Browserbase session",
     "Location field is map-driven: type in ESRI search box, click autocomplete, Enter → wait 3000ms → Tab",
     "XPath Next buttons fail — always snapshot first and use ref ID",
-    "Page 3 description: use CSS selector #dform_widget_Request_description with fill --no-press-enter",
+    "Page 3 description: use CSS selector #dform_widget_Request_description with fill",
     "Page 3 Next ref 0-970 is stable — no snapshot needed before clicking"
   ],
   "error_reasoning": null

--- a/skills/autobrowse/scripts/evaluate.mjs
+++ b/skills/autobrowse/scripts/evaluate.mjs
@@ -279,7 +279,7 @@ function buildSystemPrompt(strategy, traceDir, browseEnv) {
 browse stop
 browse open <url> --remote
 \`\`\`
-Always run \`browse stop\` first to kill any existing local session before opening the target with \`--remote\`.`
+Run \`browse stop\` first when a prior daemon may be active; active sessions do not switch between local and remote automatically.`
     : `Use **local mode** — runs on local Chrome:
 \`\`\`
 browse open <url> --local
@@ -338,7 +338,7 @@ ${envDesc}
 7. \`browse stop\` — clean up
 
 ## Critical Rules
-1. **Always start with \`browse stop\` then \`browse open <url> ${openFlag}\`**
+1. **Start clean when needed** — if a daemon may already be active, run \`browse stop\` before \`browse open <url> ${openFlag}\`
 2. **ALWAYS snapshot after every action** — refs like \`[0-5]\` invalidate when the DOM changes
 3. **Use fill, not type, for input fields** — fill clears existing text first
 4. **Use refs from the LATEST snapshot only** — old refs are stale

--- a/skills/autobrowse/scripts/evaluate.mjs
+++ b/skills/autobrowse/scripts/evaluate.mjs
@@ -35,19 +35,18 @@ const TOOLS = [
     description:
       "Execute a browse CLI command for browser automation.\n\n" +
       "Browse commands:\n" +
-      "  browse env local|remote    — Switch browser environment\n" +
-      "  browse open <url>          — Navigate to URL\n" +
+      "  browse open <url> --local|--remote — Navigate and choose browser mode\n" +
       "  browse snapshot            — Get accessibility tree; refs look like [0-5] (primary perception)\n" +
-      "  browse screenshot <path>   — Save screenshot to file\n" +
+      "  browse screenshot --path <path> — Save screenshot to file\n" +
       "  browse click <ref>         — Click element by [X-Y] ref from snapshot\n" +
       "  browse type <text>         — Type into focused element\n" +
       "  browse fill <sel> <value>  — Fill input (clears first — preferred over type)\n" +
       "  browse press <key>         — Keyboard: Enter, Tab, Escape, ArrowRight, ArrowLeft...\n" +
-      "  browse scroll <x> <y> <dx> <dy> — Scroll at coords (positive dy scrolls down)\n" +
+      "  browse mouse scroll <x> <y> <dx> <dy> — Scroll at coords (positive dy scrolls down)\n" +
       "  browse select <sel> <val>  — Select dropdown option\n" +
       "  browse wait load|selector|timeout — Wait for page load, a selector, or a timeout\n" +
       "  browse get url/title/text  — Get page info\n" +
-      "  browse drag <x1> <y1> <x2> <y2> — Drag (for sliders)\n" +
+      "  browse mouse drag <x1> <y1> <x2> <y2> — Drag (for sliders)\n" +
       "  browse back/reload/stop    — Navigation/session control\n\n" +
       "Critical: Always `browse snapshot` after every action — refs invalidate on DOM changes.",
     input_schema: {
@@ -273,16 +272,17 @@ function executeCommand(command) {
 }
 
 function buildSystemPrompt(strategy, traceDir, browseEnv) {
+  const openFlag = browseEnv === "remote" ? "--remote" : "--local";
   const envDesc = browseEnv === "remote"
     ? `Use **remote mode** (Browserbase) — anti-bot stealth, CAPTCHA solving, residential proxies:
 \`\`\`
 browse stop
-browse env remote
+browse open <url> --remote
 \`\`\`
-Always run \`browse stop\` first to kill any existing local session before switching to remote.`
+Always run \`browse stop\` first to kill any existing local session before opening the target with \`--remote\`.`
     : `Use **local mode** — runs on local Chrome:
 \`\`\`
-browse env local
+browse open <url> --local
 \`\`\``;
 
   return `You are a browser automation agent. You navigate websites using the browse CLI via the execute tool.
@@ -298,13 +298,13 @@ ${envDesc}
 ## Commands
 
 ### Navigation
-- \`browse open <url>\` — Go to URL
+- \`browse open <url> ${openFlag}\` — Go to URL
 - \`browse reload\` — Reload page
 - \`browse back\` / \`browse forward\` — History navigation
 
 ### Page State (prefer snapshot over screenshot)
 - \`browse snapshot\` — Get accessibility tree. Each element has a ref in \`[X-Y]\` format (e.g. \`[0-5]\`, \`[2-147]\`). This is your PRIMARY perception tool.
-- \`browse screenshot ${traceDir}/screenshots/step-NN.png\` — Save visual screenshot (for debugging only)
+- \`browse screenshot --path ${traceDir}/screenshots/step-NN.png\` — Save visual screenshot (for debugging only)
 - \`browse get url\` / \`browse get title\` — Page info
 - \`browse get text <selector>\` — Get text content ("body" for all)
 - \`browse get value <selector>\` — Get form field value
@@ -312,11 +312,12 @@ ${envDesc}
 ### Interaction
 - \`browse click [X-Y]\` — Click element by ref from the latest snapshot. Pass the ref EXACTLY as it appears in the tree, including brackets (e.g. \`browse click [2-147]\`).
 - \`browse type <text>\` — Type text into focused element
-- \`browse fill <selector> <value>\` — Fill input AND press Enter (clears existing text — PREFERRED over type)
+- \`browse fill <selector> <value>\` — Fill input without pressing Enter (clears existing text — PREFERRED over type)
+- \`browse fill <selector> <value> --press-enter\` — Fill input and press Enter
 - \`browse select <selector> <values...>\` — Select dropdown option(s)
 - \`browse press <key>\` — Press key: Enter, Tab, Escape, ArrowRight, ArrowLeft, ArrowUp, ArrowDown, Cmd+A
-- \`browse drag <fromX> <fromY> <toX> <toY>\` — Drag (useful for sliders)
-- \`browse scroll <x> <y> <deltaX> <deltaY>\` — Scroll at coords (positive dy scrolls down)
+- \`browse mouse drag <fromX> <fromY> <toX> <toY>\` — Drag (useful for sliders)
+- \`browse mouse scroll <x> <y> <deltaX> <deltaY>\` — Scroll at coords (positive dy scrolls down)
 - \`browse wait load\` — Wait for page to finish loading
 - \`browse wait timeout <ms>\` — Wait a fixed amount of time for spinners or animations
 - \`browse wait selector "<selector>"\` — Wait for an element to become visible (or use \`--state\`)
@@ -324,12 +325,12 @@ ${envDesc}
 ### Session
 - \`browse stop\` — Close browser
 - \`browse status\` — Check daemon status
-- \`browse pages\` — List open tabs
-- \`browse tab_switch <index>\` — Switch tabs
+- \`browse tab list\` — List open tabs
+- \`browse tab switch <index-or-target-id>\` — Switch tabs
 
 ## Workflow Pattern
-1. \`browse env ${browseEnv}\` — set browser environment
-2. \`browse open <url>\` — navigate to page
+1. \`browse stop\` — clean up any previous run
+2. \`browse open <url> ${openFlag}\` — navigate to page in ${browseEnv} mode
 3. \`browse snapshot\` — read accessibility tree; refs appear as \`[X-Y]\`
 4. \`browse click [X-Y]\` / \`browse fill <sel> <val>\` / \`browse press <key>\` — interact using refs
 5. \`browse snapshot\` — confirm action worked (refs invalidate after DOM changes!)
@@ -337,12 +338,12 @@ ${envDesc}
 7. \`browse stop\` — clean up
 
 ## Critical Rules
-1. **Always start with \`browse env ${browseEnv}\` then \`browse open <url>\`**
+1. **Always start with \`browse stop\` then \`browse open <url> ${openFlag}\`**
 2. **ALWAYS snapshot after every action** — refs like \`[0-5]\` invalidate when the DOM changes
 3. **Use fill, not type, for input fields** — fill clears existing text first
 4. **Use refs from the LATEST snapshot only** — old refs are stale
 5. **Never invent refs.** If you haven't seen \`[X-Y]\` in the snapshot output, it doesn't exist. Snapshot first, then click.
-6. **Save screenshots at key decision points** — \`browse screenshot ${traceDir}/screenshots/step-NN.png\`
+6. **Save screenshots at key decision points** — \`browse screenshot --path ${traceDir}/screenshots/step-NN.png\`
 7. **When an action fails**, run \`browse snapshot\` to see current state and try a different approach
 8. **When done, output your final answer as a JSON code block**
 

--- a/skills/autobrowse/scripts/evaluate.mjs
+++ b/skills/autobrowse/scripts/evaluate.mjs
@@ -86,7 +86,7 @@ Options:
 Environment variables:
   ANTHROPIC_API_KEY          Required — Claude API key
   BROWSERBASE_API_KEY        Required for --env remote
-  BROWSERBASE_PROJECT_ID     Required for --env remote
+  BROWSERBASE_PROJECT_ID     Optional Browserbase project override
 
 Output:
   traces/<task>/run-NNN/summary.md     Decision log and final output

--- a/skills/browser-to-api/SKILL.md
+++ b/skills/browser-to-api/SKILL.md
@@ -31,12 +31,11 @@ If the user wants to **capture** traffic, send them to `browser-trace` first.
 ### 1. Capture with `browser-trace` (and optionally bodies via `browse network on`)
 
 ```bash
-# Local example (see browser-trace SKILL.md for Browserbase variant)
-browse env local
-browse open about:blank
-TARGET="$(browse status --json | jq -r .wsUrl)"
+# Local example against an existing debuggable Chrome target
+TARGET=9222
 
 node ../browser-trace/scripts/start-capture.mjs "$TARGET" my-site
+browse open about:blank --cdp "$TARGET"
 browse network on                                    # capture request/response bodies
 browse open https://example.com
 # ...drive whatever flows you want covered...

--- a/skills/browser-trace/EXAMPLES.md
+++ b/skills/browser-trace/EXAMPLES.md
@@ -88,6 +88,8 @@ jq -c 'select(.params.response.status >= 400 and .params.response.status < 600)
 
 **User says**: "The page hangs after I click Continue. It just sits there."
 
+`--cdp` is the correct flag when driving a browser that was already opened with a CDP endpoint or debug port. Pass it on each `browse` command in this flow so every action targets the same captured browser instead of the default daemon session.
+
 ```bash
 node scripts/start-capture.mjs 9222 hang
 browse open https://example.com/checkout --cdp 9222

--- a/skills/browser-trace/EXAMPLES.md
+++ b/skills/browser-trace/EXAMPLES.md
@@ -18,6 +18,7 @@ node scripts/start-capture.mjs 9222 form-bug
 browse open https://example.com/signup --cdp 9222
 browse fill 'input[name=email]' 'user@example.com'
 browse fill 'input[name=password]' 'hunter2'
+browse snapshot
 browse click @0-7   # Submit button ref from `browse snapshot`
 
 node scripts/stop-capture.mjs form-bug

--- a/skills/browser-trace/EXAMPLES.md
+++ b/skills/browser-trace/EXAMPLES.md
@@ -132,14 +132,15 @@ SESSION=$(browse cloud sessions create --keep-alive --timeout 600)
 SID=$(echo "$SESSION" | jq -r .id)
 URL=$(echo "$SESSION" | jq -r .connectUrl)
 
-browse open https://app.example.com/dashboard --remote --session "$SID"
+BROWSE_NAME=prod-repro-browser
+browse open https://app.example.com/dashboard --cdp "$URL" --session "$BROWSE_NAME"
 node scripts/start-capture.mjs "$URL" prod-repro
 
 # Drive whatever flow is suspected. The daemon caches the remote target,
 # so subsequent commands only need --session to pick the right daemon.
-browse click @0-5 --session "$SID"
-browse type 'search query' --session "$SID"
-browse press Enter --session "$SID"
+browse click @0-5 --session "$BROWSE_NAME"
+browse type 'search query' --session "$BROWSE_NAME"
+browse press Enter --session "$BROWSE_NAME"
 sleep 5
 
 node scripts/stop-capture.mjs prod-repro

--- a/skills/browser-trace/EXAMPLES.md
+++ b/skills/browser-trace/EXAMPLES.md
@@ -88,12 +88,10 @@ jq -c 'select(.params.response.status >= 400 and .params.response.status < 600)
 
 **User says**: "The page hangs after I click Continue. It just sits there."
 
-`--cdp` is the correct flag when driving a browser that was already opened with a CDP endpoint or debug port. Pass it on each `browse` command in this flow so every action targets the same captured browser instead of the default daemon session.
-
 ```bash
 node scripts/start-capture.mjs 9222 hang
 browse open https://example.com/checkout --cdp 9222
-browse click @0-12 --cdp 9222   # Continue button
+browse click @0-12   # Continue button
 sleep 30             # let the hang play out
 node scripts/stop-capture.mjs hang
 node scripts/bisect-cdp.mjs hang

--- a/skills/browser-trace/EXAMPLES.md
+++ b/skills/browser-trace/EXAMPLES.md
@@ -15,11 +15,10 @@ The recipes below use raw `jq` on the bisected files so you can see exactly what
 node scripts/start-capture.mjs 9222 form-bug
 
 # Reproduce the bug.
-browse env local 9222
-browse open https://example.com/signup
-browse fill 'input[name=email]' 'user@example.com'
-browse fill 'input[name=password]' 'hunter2'
-browse click @0-7   # Submit button ref from `browse snapshot`
+browse open https://example.com/signup --cdp 9222
+browse fill 'input[name=email]' 'user@example.com' --cdp 9222
+browse fill 'input[name=password]' 'hunter2' --cdp 9222
+browse click @0-7 --cdp 9222   # Submit button ref from `browse snapshot --cdp 9222`
 
 node scripts/stop-capture.mjs form-bug
 node scripts/bisect-cdp.mjs form-bug
@@ -59,8 +58,7 @@ If the POST is missing entirely, the click handler is broken — open `dom/<late
 
 ```bash
 node scripts/start-capture.mjs 9222 audit
-browse env local 9222
-browse open https://your-site.example
+browse open https://your-site.example --cdp 9222
 # ...interact with the page...
 node scripts/stop-capture.mjs audit
 node scripts/bisect-cdp.mjs audit
@@ -92,9 +90,8 @@ jq -c 'select(.params.response.status >= 400 and .params.response.status < 600)
 
 ```bash
 node scripts/start-capture.mjs 9222 hang
-browse env local 9222
-browse open https://example.com/checkout
-browse click @0-12   # Continue button
+browse open https://example.com/checkout --cdp 9222
+browse click @0-12 --cdp 9222   # Continue button
 sleep 30             # let the hang play out
 node scripts/stop-capture.mjs hang
 node scripts/bisect-cdp.mjs hang
@@ -130,22 +127,22 @@ The pending-requests query is the smoking gun: if a fetch never finishes, the pa
 ```bash
 # Use Browserbase remote so the run uses the same Chromium build / stealth as prod.
 export BROWSERBASE_API_KEY=...
-SESSION=$(bb sessions create --keep-alive --timeout 600)
+SESSION=$(browse cloud sessions create --keep-alive --timeout 600)
 SID=$(echo "$SESSION" | jq -r .id)
 URL=$(echo "$SESSION" | jq -r .connectUrl)
 
-browse --connect "$SID" open https://app.example.com/dashboard
+browse open https://app.example.com/dashboard --remote --session "$SID"
 node scripts/start-capture.mjs "$URL" prod-repro
 
 # Drive whatever flow is suspected.
-browse --connect "$SID" click @0-5
-browse --connect "$SID" type 'search query'
-browse --connect "$SID" press Enter
+browse click @0-5 --remote --session "$SID"
+browse type 'search query' --remote --session "$SID"
+browse press Enter --remote --session "$SID"
 sleep 5
 
 node scripts/stop-capture.mjs prod-repro
 node scripts/bisect-cdp.mjs prod-repro
-bb sessions update "$SID" --status REQUEST_RELEASE
+browse cloud sessions update "$SID" --status REQUEST_RELEASE
 ```
 
 Queries:
@@ -181,7 +178,7 @@ The stack frame points at the prod JS file + line; the screenshot shows what the
 export BROWSERBASE_API_KEY=...
 
 # Find running sessions (no --status flag, so filter client-side).
-bb sessions list | jq -r '.[] | select(.status == "RUNNING") | "\(.id)\t\(.region)\t\(.startedAt)"'
+browse cloud sessions list | jq -r '.[] | select(.status == "RUNNING") | "\(.id)\t\(.region)\t\(.startedAt)"'
 
 # Attach the tracer to the session you care about.
 SID=<session-id-from-above>

--- a/skills/browser-trace/EXAMPLES.md
+++ b/skills/browser-trace/EXAMPLES.md
@@ -16,9 +16,9 @@ node scripts/start-capture.mjs 9222 form-bug
 
 # Reproduce the bug.
 browse open https://example.com/signup --cdp 9222
-browse fill 'input[name=email]' 'user@example.com' --cdp 9222
-browse fill 'input[name=password]' 'hunter2' --cdp 9222
-browse click @0-7 --cdp 9222   # Submit button ref from `browse snapshot --cdp 9222`
+browse fill 'input[name=email]' 'user@example.com'
+browse fill 'input[name=password]' 'hunter2'
+browse click @0-7   # Submit button ref from `browse snapshot`
 
 node scripts/stop-capture.mjs form-bug
 node scripts/bisect-cdp.mjs form-bug
@@ -134,10 +134,11 @@ URL=$(echo "$SESSION" | jq -r .connectUrl)
 browse open https://app.example.com/dashboard --remote --session "$SID"
 node scripts/start-capture.mjs "$URL" prod-repro
 
-# Drive whatever flow is suspected.
-browse click @0-5 --remote --session "$SID"
-browse type 'search query' --remote --session "$SID"
-browse press Enter --remote --session "$SID"
+# Drive whatever flow is suspected. The daemon caches the remote target,
+# so subsequent commands only need --session to pick the right daemon.
+browse click @0-5 --session "$SID"
+browse type 'search query' --session "$SID"
+browse press Enter --session "$SID"
 sleep 5
 
 node scripts/stop-capture.mjs prod-repro

--- a/skills/browser-trace/REFERENCE.md
+++ b/skills/browser-trace/REFERENCE.md
@@ -17,6 +17,8 @@ Technical reference for the capture pipeline, the bisect mapping, and the jq rec
 
 CDP allows multiple concurrent clients on the same target. The tracer enables only read-only domains and never sends action commands like `Input.dispatch*` or `Runtime.evaluate`, so it cannot perturb the run.
 
+Sampler commands pass `--cdp <target>` because they run from the trace helper process and need to attach to the traced target directly. Normal follow-up commands in a browse daemon session do not need to repeat `--cdp` after the first `browse open ... --cdp <target>`.
+
 ## Scripts
 
 All scripts read `O11Y_ROOT` (default `.o11y`) so runs land under `$O11Y_ROOT/<run-id>/`. They are Node ESM modules (`node` 18+) and depend only on `browse` plus the Node standard library — no `npm install` step. `jq` is referenced throughout the docs for ad-hoc querying but the scripts themselves don't need it.
@@ -324,7 +326,7 @@ The interval-second arg to `start-capture.mjs` controls only the sampler. The fi
 | `browse cdp exited immediately`                | unreachable target / completed Browserbase session             | verify port is listening (`curl http://localhost:9222/json/version`) or session is `RUNNING` (`browse cloud sessions get`) |
 | `error: unknown command 'cdp'`                 | older browse build lacks the command                          | `npm install -g browse@latest` (or the alpha tag if needed)   |
 | Browserbase session ends as soon as tracer connects | tracer was the only client; no automation attached          | create with `--keep-alive`, attach with `browse open --remote --session <id>` first   |
-| `index.jsonl` shows `"url": ""`                 | one-shot `browse get url --cdp <target>` failed (transient)   | benign; happens during navigation transitions                 |
+| `index.jsonl` shows `"url": ""`                 | sampler `browse get url` failed transiently                   | benign; happens during navigation transitions                 |
 | Screenshots empty / huge / inconsistent sizes  | viewport not set                                              | `browse viewport 1920 1080 --cdp <target>` once before capture |
 | `raw.ndjson` grows but bisect buckets empty    | wrong domains; e.g. you wanted DOM but didn't enable it       | `O11Y_DOMAINS="Network Console Runtime Log Page DOM" bash start-capture.mjs ...` |
 | Loop process leaks after crash                  | `stop-capture.mjs` not run                                     | `pkill -f snapshot-loop.mjs`; PID files in `<run-dir>` are stale  |

--- a/skills/browser-trace/REFERENCE.md
+++ b/skills/browser-trace/REFERENCE.md
@@ -71,9 +71,9 @@ Invoked by `start-capture.mjs`; not meant to be called directly. Loops at the co
 
 ### `bb-capture.mjs --new|<session-id> [run-id] [interval-sec]`
 
-Browserbase wrapper around `start-capture.mjs`. With `--new`, runs `bb sessions create --keep-alive` and starts the tracer. With an existing session id, fetches its `connectUrl` via `bb sessions get` and asserts the session is `RUNNING` before attaching.
+Browserbase wrapper around `start-capture.mjs`. With `--new`, runs `browse cloud sessions create --keep-alive` and starts the tracer. With an existing session id, fetches its `connectUrl` via `browse cloud sessions get` and asserts the session is `RUNNING` before attaching.
 
-Stamps the run's `manifest.json` with a `browserbase` object containing `session_id`, `project_id`, `region`, `started_at`, `expires_at`, `keep_alive`, and the `debugger_url` from `bb sessions debug`.
+Stamps the run's `manifest.json` with a `browserbase` object containing `session_id`, `project_id`, `region`, `started_at`, `expires_at`, `keep_alive`, and the `debugger_url` from `browse cloud sessions debug`.
 
 Reads `BROWSERBASE_API_KEY`. `BB_SESSION_TIMEOUT` (default `600`) controls the timeout passed to `--new` sessions.
 
@@ -81,11 +81,11 @@ Reads `BROWSERBASE_API_KEY`. `BB_SESSION_TIMEOUT` (default `600`) controls the t
 
 Pulls platform-side artifacts after the tracer has stopped:
 
-- **`browserbase/session.json`** — `bb sessions get` snapshot. Always written; contains the post-run `proxyBytes`, `status`, `endedAt`.
-- **`browserbase/logs.json`** — `bb sessions logs` output. Often `[]`. The CDP firehose is authoritative; this is a side channel for cases where Browserbase happened to record server-side log entries.
+- **`browserbase/session.json`** — `browse cloud sessions get` snapshot. Always written; contains the post-run `proxyBytes`, `status`, `endedAt`.
+- **`browserbase/logs.json`** — `browse cloud sessions logs` output. Often `[]`. The CDP firehose is authoritative; this is a side channel for cases where Browserbase happened to record server-side log entries.
 - **`browserbase/downloads.zip`** — only kept when there's real content (size > 22 bytes — an empty Browserbase downloads zip is exactly the EOCD record).
 
-`--release` calls `bb sessions update --status REQUEST_RELEASE` to end the session. Skip it when attaching to a session you don't own (e.g. one a production worker is using).
+`--release` calls `browse cloud sessions update --status REQUEST_RELEASE` to end the session. Skip it when attaching to a session you don't own (e.g. one a production worker is using).
 
 ## Bisect map
 
@@ -239,21 +239,21 @@ for m in .o11y/*/manifest.json; do
 done
 ```
 
-### When to use `bb sessions debug` vs the tracer
+### When to use `browse cloud sessions debug` vs the tracer
 
 They're complementary:
 
 - **tracer (this skill)** captures the firehose to disk — durable, searchable, scriptable. Use for postmortem and automated checks.
-- **`bb sessions debug` URL** is an interactive Chrome DevTools view served by Browserbase, scoped to one running session. Use when you want to *watch* a live run, single-step through requests, or inspect the live DOM by hand.
+- **`browse cloud sessions debug` URL** is an interactive Chrome DevTools view served by Browserbase, scoped to one running session. Use when you want to *watch* a live run, single-step through requests, or inspect the live DOM by hand.
 
 You can do both simultaneously: `bb-capture.mjs --new` prints the debugger URL when it starts, and stamps it in the manifest for later.
 
 ### Notes on Browserbase data sources
 
-- `bb sessions logs` is best-effort; in practice it's frequently empty even with `--log-session` on. Don't build queries on top of it; treat anything that lands there as a bonus.
-- `bb sessions recording` (rrweb session replay) is deprecated — neither helper fetches it. Use the screenshots + DOM dumps in `screenshots/` and `dom/`.
-- `bb sessions list` doesn't accept a `--status` filter; pipe through jq (`select(.status == "RUNNING")`).
-- The Browserbase proxy charges per byte. `bb sessions get` returns running `proxyBytes`; the tracer's network buckets give you per-host detail to attribute it.
+- `browse cloud sessions logs` is best-effort; in practice it's frequently empty even with `--log-session` on. Don't build queries on top of it; treat anything that lands there as a bonus.
+- `browse cloud sessions recording` (rrweb session replay) is deprecated — neither helper fetches it. Use the screenshots + DOM dumps in `screenshots/` and `dom/`.
+- `browse cloud sessions list` doesn't accept a `--status` filter; pipe through jq (`select(.status == "RUNNING")`).
+- The Browserbase proxy charges per byte. `browse cloud sessions get` returns running `proxyBytes`; the tracer's network buckets give you per-host detail to attribute it.
 
 ## Per-page drill-down
 
@@ -313,7 +313,7 @@ tail -f .o11y/<run-id>/cdp/raw.ndjson | jq -c '{m:.method, u:.params.request.url
 | ------------------ | -------------------------------------- | ------------------------------------------------------------ |
 | `O11Y_ROOT`        | `.o11y`                                | base directory under which `<run-id>/` is created             |
 | `O11Y_DOMAINS`     | `Network Console Runtime Log Page`     | space-separated CDP domains for the firehose                 |
-| `BROWSERBASE_API_KEY` | —                                   | required for `bb sessions create` / `bb sessions get`         |
+| `BROWSERBASE_API_KEY` | —                                   | required for `browse cloud sessions create` / `browse cloud sessions get`         |
 
 The interval-second arg to `start-capture.mjs` controls only the sampler. The firehose is always streamed in real time.
 
@@ -321,9 +321,9 @@ The interval-second arg to `start-capture.mjs` controls only the sampler. The fi
 
 | Symptom                                        | Likely cause                                                  | Fix                                                          |
 | ---------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------ |
-| `browse cdp exited immediately`                | unreachable target / completed Browserbase session             | verify port is listening (`curl http://localhost:9222/json/version`) or session is `RUNNING` (`bb sessions get`) |
-| `error: unknown command 'cdp'`                 | stable browse-cli (≤ 0.5.0) lacks the command                 | `npm install -g @browserbasehq/browse-cli@alpha`              |
-| Browserbase session ends as soon as tracer connects | tracer was the only client; no automation attached          | create with `--keep-alive`, attach `browse --connect` first   |
+| `browse cdp exited immediately`                | unreachable target / completed Browserbase session             | verify port is listening (`curl http://localhost:9222/json/version`) or session is `RUNNING` (`browse cloud sessions get`) |
+| `error: unknown command 'cdp'`                 | older browse build lacks the command                          | `npm install -g browse@latest` (or the alpha tag if needed)   |
+| Browserbase session ends as soon as tracer connects | tracer was the only client; no automation attached          | create with `--keep-alive`, attach with `browse open --remote --session <id>` first   |
 | `index.jsonl` shows `"url": ""`                 | one-shot `browse --ws ... get url` failed (transient)         | benign; happens during navigation transitions                 |
 | Screenshots empty / huge / inconsistent sizes  | viewport not set                                              | `browse --ws <target> viewport 1920 1080` once before capture |
 | `raw.ndjson` grows but bisect buckets empty    | wrong domains; e.g. you wanted DOM but didn't enable it       | `O11Y_DOMAINS="Network Console Runtime Log Page DOM" bash start-capture.mjs ...` |

--- a/skills/browser-trace/REFERENCE.md
+++ b/skills/browser-trace/REFERENCE.md
@@ -17,7 +17,7 @@ Technical reference for the capture pipeline, the bisect mapping, and the jq rec
 
 CDP allows multiple concurrent clients on the same target. The tracer enables only read-only domains and never sends action commands like `Input.dispatch*` or `Runtime.evaluate`, so it cannot perturb the run.
 
-Sampler commands pass `--cdp <target>` because they run from the trace helper process and need to attach to the traced target directly. Normal follow-up commands in a browse daemon session do not need to repeat `--cdp` after the first `browse open ... --cdp <target>`.
+Sampler commands pass `--cdp <target>` because they run from the trace helper process and need to attach to the traced target directly. Normal follow-up commands in a browse daemon session do not need to repeat `--cdp` after the first `browse open ... --cdp <target>`. If the default daemon may already be active in another mode, use a named `--session` for sampler or automation commands.
 
 ## Scripts
 
@@ -325,7 +325,7 @@ The interval-second arg to `start-capture.mjs` controls only the sampler. The fi
 | ---------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------ |
 | `browse cdp exited immediately`                | unreachable target / completed Browserbase session             | verify port is listening (`curl http://localhost:9222/json/version`) or session is `RUNNING` (`browse cloud sessions get`) |
 | `error: unknown command 'cdp'`                 | older browse build lacks the command                          | `npm install -g browse@latest` (or the alpha tag if needed)   |
-| Browserbase session ends as soon as tracer connects | tracer was the only client; no automation attached          | create with `--keep-alive`, attach with `browse open --remote --session <id>` first   |
+| Browserbase session ends as soon as tracer connects | tracer was the only client; no automation attached          | create with `--keep-alive`, attach automation with `browse open --cdp <connectUrl> --session <name>` first   |
 | `index.jsonl` shows `"url": ""`                 | sampler `browse get url` failed transiently                   | benign; happens during navigation transitions                 |
 | Screenshots empty / huge / inconsistent sizes  | viewport not set                                              | `browse viewport 1920 1080 --cdp <target>` once before capture |
 | `raw.ndjson` grows but bisect buckets empty    | wrong domains; e.g. you wanted DOM but didn't enable it       | `O11Y_DOMAINS="Network Console Runtime Log Page DOM" bash start-capture.mjs ...` |

--- a/skills/browser-trace/REFERENCE.md
+++ b/skills/browser-trace/REFERENCE.md
@@ -11,8 +11,8 @@ Technical reference for the capture pipeline, the bisect mapping, and the jq rec
         │                                    │
         ▼                                    ▼
     drives page                browse cdp <target>     (firehose → raw.ndjson)
-                               browse --ws <target> screenshot     (sampler → screenshots/)
-                               browse --ws <target> get html body  (sampler → dom/)
+                               browse screenshot --cdp <target> --path <file>  (sampler → screenshots/)
+                               browse get html body --cdp <target>             (sampler → dom/)
 ```
 
 CDP allows multiple concurrent clients on the same target. The tracer enables only read-only domains and never sends action commands like `Input.dispatch*` or `Runtime.evaluate`, so it cannot perturb the run.
@@ -251,7 +251,7 @@ You can do both simultaneously: `bb-capture.mjs --new` prints the debugger URL w
 ### Notes on Browserbase data sources
 
 - `browse cloud sessions logs` is best-effort; in practice it's frequently empty even with `--log-session` on. Don't build queries on top of it; treat anything that lands there as a bonus.
-- `browse cloud sessions recording` (rrweb session replay) is deprecated — neither helper fetches it. Use the screenshots + DOM dumps in `screenshots/` and `dom/`.
+- Session replay artifact fetching is deprecated — neither helper fetches it. Use the screenshots + DOM dumps in `screenshots/` and `dom/`.
 - `browse cloud sessions list` doesn't accept a `--status` filter; pipe through jq (`select(.status == "RUNNING")`).
 - The Browserbase proxy charges per byte. `browse cloud sessions get` returns running `proxyBytes`; the tracer's network buckets give you per-host detail to attribute it.
 
@@ -324,7 +324,7 @@ The interval-second arg to `start-capture.mjs` controls only the sampler. The fi
 | `browse cdp exited immediately`                | unreachable target / completed Browserbase session             | verify port is listening (`curl http://localhost:9222/json/version`) or session is `RUNNING` (`browse cloud sessions get`) |
 | `error: unknown command 'cdp'`                 | older browse build lacks the command                          | `npm install -g browse@latest` (or the alpha tag if needed)   |
 | Browserbase session ends as soon as tracer connects | tracer was the only client; no automation attached          | create with `--keep-alive`, attach with `browse open --remote --session <id>` first   |
-| `index.jsonl` shows `"url": ""`                 | one-shot `browse --ws ... get url` failed (transient)         | benign; happens during navigation transitions                 |
-| Screenshots empty / huge / inconsistent sizes  | viewport not set                                              | `browse --ws <target> viewport 1920 1080` once before capture |
+| `index.jsonl` shows `"url": ""`                 | one-shot `browse get url --cdp <target>` failed (transient)   | benign; happens during navigation transitions                 |
+| Screenshots empty / huge / inconsistent sizes  | viewport not set                                              | `browse viewport 1920 1080 --cdp <target>` once before capture |
 | `raw.ndjson` grows but bisect buckets empty    | wrong domains; e.g. you wanted DOM but didn't enable it       | `O11Y_DOMAINS="Network Console Runtime Log Page DOM" bash start-capture.mjs ...` |
 | Loop process leaks after crash                  | `stop-capture.mjs` not run                                     | `pkill -f snapshot-loop.mjs`; PID files in `<run-dir>` are stale  |

--- a/skills/browser-trace/SKILL.md
+++ b/skills/browser-trace/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: browser-trace
 description: Capture a full DevTools-protocol trace of any browser automation — CDP firehose, screenshots, and DOM dumps — then bisect the stream into per-page searchable buckets. Use when the user wants to debug a failed run, audit network/console/DOM activity, attach a trace to an in-progress session, or feed structured per-page summaries back into an agent loop so its next iteration learns from the last one.
-compatibility: "Requires Node 18+, the browse CLI (`npm install -g browse` — `browse cdp` is alpha-tagged), and optionally `jq` for ad-hoc querying of the bisected JSONL files. For remote Browserbase sessions, also requires `BROWSERBASE_API_KEY` (the same `browse` binary handles `browse cloud sessions ...` API calls). The skill scripts themselves use only the Node standard library — no `npm install` step."
+compatibility: "Requires Node 18+, the browse CLI (`npm install -g browse`) with `browse cdp`, and optionally `jq` for ad-hoc querying of the bisected JSONL files. For remote Browserbase sessions, also requires `BROWSERBASE_API_KEY`. The skill scripts themselves use only the Node standard library — no `npm install` step."
 license: MIT
 allowed-tools: Bash, Read, Grep
 ---
@@ -25,14 +25,14 @@ If the user just wants to **drive** the browser, use the `browser` skill instead
 
 ```bash
 node --version                                  # require Node 18+
-which browse || npm install -g browse              # provides both `browse` and `browse cloud ...` API commands
+which browse || npm install -g browse
 which jq     || true                                # optional — used only for ad-hoc querying
 ```
 
-Verify `browse cdp` exists (it ships in 0.5.0-alpha-a4ca430+):
+Verify `browse cdp` exists:
 
 ```bash
-browse --help | grep -q "^\s*cdp " || echo "browse cdp not in this version — install @alpha"
+browse --help | grep -q "^\s*cdp " || echo "browse cdp not available — update browse"
 ```
 
 ## How it works

--- a/skills/browser-trace/SKILL.md
+++ b/skills/browser-trace/SKILL.md
@@ -85,7 +85,7 @@ node scripts/bb-capture.mjs --new my-run
 # 2. Drive automation. bb-capture stamped the session id into the manifest.
 SID=$(jq -r .browserbase.session_id .o11y/my-run/manifest.json)
 browse open https://example.com --remote --session "$SID"
-browse open https://news.ycombinator.com --remote --session "$SID"
+browse open https://news.ycombinator.com --session "$SID"
 
 # 3. Stop the tracer, bisect, then pull platform artifacts and release.
 node scripts/stop-capture.mjs my-run

--- a/skills/browser-trace/SKILL.md
+++ b/skills/browser-trace/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: browser-trace
 description: Capture a full DevTools-protocol trace of any browser automation — CDP firehose, screenshots, and DOM dumps — then bisect the stream into per-page searchable buckets. Use when the user wants to debug a failed run, audit network/console/DOM activity, attach a trace to an in-progress session, or feed structured per-page summaries back into an agent loop so its next iteration learns from the last one.
-compatibility: "Requires Node 18+, the browse CLI (`npm install -g @browserbasehq/browse-cli@alpha` or 0.5.1+ once released — `browse cdp` is alpha-tagged), and optionally `jq` for ad-hoc querying of the bisected JSONL files. For remote Browserbase sessions, also requires the `bb` CLI (`npm install -g @browserbasehq/cli`) and `BROWSERBASE_API_KEY`. The skill scripts themselves use only the Node standard library — no `npm install` step."
+compatibility: "Requires Node 18+, the browse CLI (`npm install -g browse` — `browse cdp` is alpha-tagged), and optionally `jq` for ad-hoc querying of the bisected JSONL files. For remote Browserbase sessions, also requires `BROWSERBASE_API_KEY` (the same `browse` binary handles `browse cloud sessions ...` API calls). The skill scripts themselves use only the Node standard library — no `npm install` step."
 license: MIT
 allowed-tools: Bash, Read, Grep
 ---
@@ -10,7 +10,7 @@ allowed-tools: Bash, Read, Grep
 
 Attach a **second, read-only CDP client** to a browser session that is already being driven by your main automation. The trace records the full DevTools firehose to NDJSON, polls for screenshots and DOM dumps in parallel, and slices everything into a directory tree that bash tools can search.
 
-This skill does **not** drive pages — it only listens. Pair it with the `browser` skill, `bb`, Stagehand, Playwright, or anything else that speaks CDP.
+This skill does **not** drive pages — it only listens. Pair it with the `browser` skill, `browse`, Stagehand, Playwright, or anything else that speaks CDP.
 
 ## When to use
 
@@ -25,8 +25,7 @@ If the user just wants to **drive** the browser, use the `browser` skill instead
 
 ```bash
 node --version                                  # require Node 18+
-which browse || npm install -g @browserbasehq/browse-cli@alpha
-which bb     || npm install -g @browserbasehq/cli   # only needed for Browserbase remote
+which browse || npm install -g browse              # provides both `browse` and `browse cloud ...` API commands
 which jq     || true                                # optional — used only for ad-hoc querying
 ```
 
@@ -61,8 +60,7 @@ The tracer has three pieces:
 node scripts/start-capture.mjs 9222 my-run
 
 # 3. Run your main automation against port 9222.
-browse env local 9222
-browse open https://example.com
+browse open https://example.com --cdp 9222
 # ...whatever the run does...
 
 # 4. Stop and bisect.
@@ -86,8 +84,8 @@ node scripts/bb-capture.mjs --new my-run
 
 # 2. Drive automation. bb-capture stamped the session id into the manifest.
 SID=$(jq -r .browserbase.session_id .o11y/my-run/manifest.json)
-browse --connect "$SID" open https://example.com
-browse --connect "$SID" open https://news.ycombinator.com
+browse open https://example.com --remote --session "$SID"
+browse open https://news.ycombinator.com --remote --session "$SID"
 
 # 3. Stop the tracer, bisect, then pull platform artifacts and release.
 node scripts/stop-capture.mjs my-run
@@ -98,8 +96,8 @@ node scripts/bb-finalize.mjs my-run --release
 Attaching to a session that's *already running* (e.g. one your production worker created) — `bb-capture.mjs` accepts a session id instead of `--new`:
 
 ```bash
-# Pick a running session (filter client-side; bb sessions list has no --status flag)
-bb sessions list | jq -r '.[] | select(.status == "RUNNING") | .id'
+# Pick a running session (filter client-side; browse cloud sessions list has no --status flag)
+browse cloud sessions list | jq -r '.[] | select(.status == "RUNNING") | .id'
 
 node scripts/bb-capture.mjs <session-id> mid-flight-debug
 # ...tracer runs alongside the existing automation client; no disruption...
@@ -112,11 +110,11 @@ node scripts/bb-finalize.mjs mid-flight-debug   # without --release: leave the s
 
 `bb-capture.mjs` adds a `browserbase` block to `manifest.json` (session id, project, region, started_at, expires_at, debugger URL). `bb-finalize.mjs` writes:
 
-- `<run>/browserbase/session.json` — final `bb sessions get` snapshot (proxyBytes, status, ended_at, viewport, …)
-- `<run>/browserbase/logs.json` — `bb sessions logs` output. **Often empty.** The CDP firehose in `cdp/raw.ndjson` is the source of truth; this is a side channel.
+- `<run>/browserbase/session.json` — final `browse cloud sessions get` snapshot (proxyBytes, status, ended_at, viewport, …)
+- `<run>/browserbase/logs.json` — `browse cloud sessions logs` output. **Often empty.** The CDP firehose in `cdp/raw.ndjson` is the source of truth; this is a side channel.
 - `<run>/browserbase/downloads.zip` — files the session downloaded, if any (the script discards the empty 22-byte zip you get when there are none)
 
-`bb sessions recording` (rrweb session replay) is **deprecated** and isn't fetched. Use the screenshots + DOM dumps in `screenshots/` and `dom/` for visual ground truth.
+`browse cloud sessions recording` (rrweb session replay) is **deprecated** and isn't fetched. Use the screenshots + DOM dumps in `screenshots/` and `dom/` for visual ground truth.
 
 The live `debugger_url` in the manifest opens an interactive Chrome DevTools view served by Browserbase — handy for *watching* a long-running automation while the tracer captures the firehose to disk.
 
@@ -145,9 +143,9 @@ The live `debugger_url` in the manifest opens an interactive Chrome DevTools vie
   screenshots/<iso-ts>.png      one PNG per sample interval
   dom/<iso-ts>.html             one HTML dump per sample interval
   browserbase/                  added by bb-finalize.mjs (Browserbase runs only)
-    session.json                final `bb sessions get` snapshot (proxyBytes, status, ended_at, …)
-    logs.json                   `bb sessions logs` output (often [])
-    downloads.zip               `bb sessions downloads get` output (only if the session downloaded files)
+    session.json                final `browse cloud sessions get` snapshot (proxyBytes, status, ended_at, …)
+    logs.json                   `browse cloud sessions logs` output (often [])
+    downloads.zip               `browse cloud sessions downloads get` output (only if the session downloaded files)
 ```
 
 When a run was started via `bb-capture.mjs`, `manifest.json` also carries a top-level `browserbase` block: `session_id`, `project_id`, `region`, `started_at`, `expires_at`, `keep_alive`, `debugger_url`.
@@ -233,19 +231,19 @@ See **REFERENCE.md** for the full jq recipe library and a method-by-method bisec
 3. **Order matters for remote**: on Browserbase, attach the main automation client before (or together with) the tracer, and create the session with `--keep-alive`. Otherwise the session ends as soon as the tracer's WS closes.
 4. **Don't poll faster than ~1s**: each sample opens a one-shot CDP connection and screenshots Chrome. 2s is a good default.
 5. **Pick domains deliberately**: defaults (`Network Console Runtime Log Page`) cover most debugging. Add `DOM` for DOM-tree mutations (very noisy) via `O11Y_DOMAINS="$O11Y_DOMAINS DOM"`.
-6. **Use `--connect <session-id>` for the automation client on remote**, not a fresh `browse env remote` (which would create a new session each time).
+6. **Reuse one Browserbase session for the automation client on remote** by passing `--remote --session <session-id>`, not a fresh `browse open --remote` without `--session` (which would create a new session each time).
 7. **Always run `stop-capture.mjs`**, even after a crash, so background processes don't linger and the manifest gets `stopped_at`.
 8. **Bisect once per run**: `bisect-cdp.mjs` is idempotent — it overwrites the per-bucket files from `raw.ndjson` each time.
 
 ## Troubleshooting
 
-- **`browse cdp exited immediately`**: usually means the target is unreachable (wrong port) or the Browserbase session has already ended. For remote, verify with `bb sessions get <id>` — if `status` is `COMPLETED`, recreate with `--keep-alive` and attach automation first.
+- **`browse cdp exited immediately`**: usually means the target is unreachable (wrong port) or the Browserbase session has already ended. For remote, verify with `browse cloud sessions get <id>` — if `status` is `COMPLETED`, recreate with `--keep-alive` and attach automation first.
 - **Empty `raw.ndjson` even though processes are running**: confirm a CDP client is actually driving the page. The tracer only emits events that the browser generates, so an idle browser produces ~5 lines of attach/discover messages and nothing else.
 - **Screenshots all look identical**: check `index.jsonl` — if `url` doesn't change, the page hasn't navigated yet. The polling loop runs independently of the main automation's pace.
 - **Browserbase session ends mid-run**: it likely hit `--timeout`. Recreate with a higher timeout (`BB_SESSION_TIMEOUT=1800 node scripts/bb-capture.mjs --new ...`) or remove the timeout flag.
-- **`bb-capture.mjs <id>` says "not RUNNING"**: the session you tried to attach to ended. List candidates with `bb sessions list | jq '.[] | select(.status == "RUNNING")'` and try again.
-- **`browserbase/logs.json` is empty `[]`**: expected — `bb sessions logs` is sparse in practice. The CDP firehose in `cdp/raw.ndjson` is the source of truth.
-- **Where's the session recording (rrweb)?**: `bb sessions recording` is deprecated; this skill doesn't fetch it. Use the screenshot stream in `screenshots/` and DOM dumps in `dom/`.
+- **`bb-capture.mjs <id>` says "not RUNNING"**: the session you tried to attach to ended. List candidates with `browse cloud sessions list | jq '.[] | select(.status == "RUNNING")'` and try again.
+- **`browserbase/logs.json` is empty `[]`**: expected — `browse cloud sessions logs` is sparse in practice. The CDP firehose in `cdp/raw.ndjson` is the source of truth.
+- **Where's the session recording (rrweb)?**: `browse cloud sessions recording` is deprecated; this skill doesn't fetch it. Use the screenshot stream in `screenshots/` and DOM dumps in `dom/`.
 
 For full reference, see [REFERENCE.md](REFERENCE.md).
 For example debug runs, see [EXAMPLES.md](EXAMPLES.md).

--- a/skills/browser-trace/SKILL.md
+++ b/skills/browser-trace/SKILL.md
@@ -72,7 +72,7 @@ node scripts/bisect-cdp.mjs my-run
 
 Two helpers wrap the platform-side bookkeeping: `bb-capture.mjs` creates or attaches to a session and starts the tracer; `bb-finalize.mjs` pulls platform artifacts (final session metadata, server logs, downloads) into the run dir at the end.
 
-> Browserbase ends a session as soon as its last CDP client disconnects. **Always create with `--keep-alive` and attach an automation client before (or together with) the tracer.** `bb-capture.mjs --new` does this for you.
+> Browserbase ends a session as soon as its last CDP client disconnects. **Create with `--keep-alive`, then attach automation to the session's `connectUrl` before or together with the tracer.** `bb-capture.mjs --new` handles the keep-alive session and tracer setup; your automation still needs to attach.
 
 ```bash
 export BROWSERBASE_API_KEY=...
@@ -84,8 +84,10 @@ node scripts/bb-capture.mjs --new my-run
 
 # 2. Drive automation. bb-capture stamped the session id into the manifest.
 SID=$(jq -r .browserbase.session_id .o11y/my-run/manifest.json)
-browse open https://example.com --remote --session "$SID"
-browse open https://news.ycombinator.com --session "$SID"
+CONNECT_URL="$(browse cloud sessions get "$SID" | jq -r .connectUrl)"
+BROWSE_NAME=my-run-browser
+browse open https://example.com --cdp "$CONNECT_URL" --session "$BROWSE_NAME"
+browse open https://news.ycombinator.com --session "$BROWSE_NAME"
 
 # 3. Stop the tracer, bisect, then pull platform artifacts and release.
 node scripts/stop-capture.mjs my-run
@@ -231,7 +233,7 @@ See **REFERENCE.md** for the full jq recipe library and a method-by-method bisec
 3. **Order matters for remote**: on Browserbase, attach the main automation client before (or together with) the tracer, and create the session with `--keep-alive`. Otherwise the session ends as soon as the tracer's WS closes.
 4. **Don't poll faster than ~1s**: each sample runs browser CLI read commands and screenshots Chrome. 2s is a good default.
 5. **Pick domains deliberately**: defaults (`Network Console Runtime Log Page`) cover most debugging. Add `DOM` for DOM-tree mutations (very noisy) via `O11Y_DOMAINS="$O11Y_DOMAINS DOM"`.
-6. **Reuse one Browserbase session for the automation client on remote** by passing `--remote --session <session-id>`, not a fresh `browse open --remote` without `--session` (which would create a new session each time).
+6. **Reuse one Browserbase session for the automation client on remote** by attaching to that session's `connectUrl` with `browse open ... --cdp "$CONNECT_URL" --session <name>`. The `--session` flag names the local browse daemon; it is not a Browserbase session attach flag.
 7. **Always run `stop-capture.mjs`**, even after a crash, so background processes don't linger and the manifest gets `stopped_at`.
 8. **Bisect once per run**: `bisect-cdp.mjs` is idempotent — it overwrites the per-bucket files from `raw.ndjson` each time.
 

--- a/skills/browser-trace/SKILL.md
+++ b/skills/browser-trace/SKILL.md
@@ -42,7 +42,7 @@ Every Chrome DevTools target accepts **multiple concurrent CDP clients**. Your m
 The tracer has three pieces:
 
 1. **Firehose**: `browse cdp <target>` streams every CDP event as one JSON object per line to `cdp/raw.ndjson`.
-2. **Sampler**: a polling loop calls `browse screenshot --cdp <target> --path <file>` and `browse get html body --cdp <target>` on an interval (default 2s). The per-command `--cdp` flag is one-shot and bypasses the daemon, so it doesn't fight the main automation.
+2. **Sampler**: a polling loop calls `browse screenshot --cdp <target> --path <file>` and `browse get html body --cdp <target>` on an interval (default 2s). The helper passes `--cdp` when it samples so it can attach to the traced target from its own process; once a browse daemon session is attached to a CDP target, follow-up commands in that session do not need to repeat `--cdp`.
 3. **Bisector**: after the run, `bisect-cdp.mjs` walks `raw.ndjson` once, slices it into per-bucket JSONL files keyed by CDP method, and additionally bisects per page using top-level `Page.frameNavigated` events as boundaries.
 
 ## Quickstart
@@ -229,7 +229,7 @@ See **REFERENCE.md** for the full jq recipe library and a method-by-method bisec
 1. **Use `bb-capture.mjs` on Browserbase**: it enforces `--keep-alive`, fetches the connectUrl, captures the debugger URL, and stamps the manifest. Doing it manually invites mistakes.
 2. **Don't `--release` a session you don't own**: `bb-finalize.mjs --release` is for sessions *you* created with `--new`. When attaching to a production session via `bb-capture.mjs <session-id>`, run `bb-finalize.mjs` without `--release` so the original automation keeps running.
 3. **Order matters for remote**: on Browserbase, attach the main automation client before (or together with) the tracer, and create the session with `--keep-alive`. Otherwise the session ends as soon as the tracer's WS closes.
-4. **Don't poll faster than ~1s**: each sample opens a one-shot CDP connection and screenshots Chrome. 2s is a good default.
+4. **Don't poll faster than ~1s**: each sample runs browser CLI read commands and screenshots Chrome. 2s is a good default.
 5. **Pick domains deliberately**: defaults (`Network Console Runtime Log Page`) cover most debugging. Add `DOM` for DOM-tree mutations (very noisy) via `O11Y_DOMAINS="$O11Y_DOMAINS DOM"`.
 6. **Reuse one Browserbase session for the automation client on remote** by passing `--remote --session <session-id>`, not a fresh `browse open --remote` without `--session` (which would create a new session each time).
 7. **Always run `stop-capture.mjs`**, even after a crash, so background processes don't linger and the manifest gets `stopped_at`.

--- a/skills/browser-trace/SKILL.md
+++ b/skills/browser-trace/SKILL.md
@@ -42,7 +42,7 @@ Every Chrome DevTools target accepts **multiple concurrent CDP clients**. Your m
 The tracer has three pieces:
 
 1. **Firehose**: `browse cdp <target>` streams every CDP event as one JSON object per line to `cdp/raw.ndjson`.
-2. **Sampler**: a polling loop calls `browse --ws <target> screenshot` and `browse --ws <target> get html body` on an interval (default 2s). `--ws` is one-shot and bypasses the daemon, so it doesn't fight the main automation.
+2. **Sampler**: a polling loop calls `browse screenshot --cdp <target> --path <file>` and `browse get html body --cdp <target>` on an interval (default 2s). The per-command `--cdp` flag is one-shot and bypasses the daemon, so it doesn't fight the main automation.
 3. **Bisector**: after the run, `bisect-cdp.mjs` walks `raw.ndjson` once, slices it into per-bucket JSONL files keyed by CDP method, and additionally bisects per page using top-level `Page.frameNavigated` events as boundaries.
 
 ## Quickstart
@@ -114,7 +114,7 @@ node scripts/bb-finalize.mjs mid-flight-debug   # without --release: leave the s
 - `<run>/browserbase/logs.json` — `browse cloud sessions logs` output. **Often empty.** The CDP firehose in `cdp/raw.ndjson` is the source of truth; this is a side channel.
 - `<run>/browserbase/downloads.zip` — files the session downloaded, if any (the script discards the empty 22-byte zip you get when there are none)
 
-`browse cloud sessions recording` (rrweb session replay) is **deprecated** and isn't fetched. Use the screenshots + DOM dumps in `screenshots/` and `dom/` for visual ground truth.
+Session replay artifact fetching is **deprecated** and isn't fetched. Use the screenshots + DOM dumps in `screenshots/` and `dom/` for visual ground truth.
 
 The live `debugger_url` in the manifest opens an interactive Chrome DevTools view served by Browserbase — handy for *watching* a long-running automation while the tracer captures the firehose to disk.
 
@@ -243,7 +243,7 @@ See **REFERENCE.md** for the full jq recipe library and a method-by-method bisec
 - **Browserbase session ends mid-run**: it likely hit `--timeout`. Recreate with a higher timeout (`BB_SESSION_TIMEOUT=1800 node scripts/bb-capture.mjs --new ...`) or remove the timeout flag.
 - **`bb-capture.mjs <id>` says "not RUNNING"**: the session you tried to attach to ended. List candidates with `browse cloud sessions list | jq '.[] | select(.status == "RUNNING")'` and try again.
 - **`browserbase/logs.json` is empty `[]`**: expected — `browse cloud sessions logs` is sparse in practice. The CDP firehose in `cdp/raw.ndjson` is the source of truth.
-- **Where's the session recording (rrweb)?**: `browse cloud sessions recording` is deprecated; this skill doesn't fetch it. Use the screenshot stream in `screenshots/` and DOM dumps in `dom/`.
+- **Where's the session recording (rrweb)?**: session replay artifact fetching is deprecated; this skill doesn't fetch it. Use the screenshot stream in `screenshots/` and DOM dumps in `dom/`.
 
 For full reference, see [REFERENCE.md](REFERENCE.md).
 For example debug runs, see [EXAMPLES.md](EXAMPLES.md).

--- a/skills/browser-trace/scripts/bb-capture.mjs
+++ b/skills/browser-trace/scripts/bb-capture.mjs
@@ -32,13 +32,13 @@ if (!target) {
 let sessionJson;
 if (target === '--new') {
   const timeout = String(process.env.BB_SESSION_TIMEOUT || '600');
-  const r = runCmd('bb', ['sessions', 'create', '--keep-alive', '--timeout', timeout]);
-  if (!r.ok) { console.error(r.stderr || 'bb sessions create failed'); process.exit(1); }
+  const r = runCmd('browse', ['cloud', 'sessions', 'create', '--keep-alive', '--timeout', timeout]);
+  if (!r.ok) { console.error(r.stderr || 'browse cloud sessions create failed'); process.exit(1); }
   sessionJson = JSON.parse(r.stdout);
   console.log(`Created Browserbase session: ${sessionJson.id}`);
 } else {
-  const r = runCmd('bb', ['sessions', 'get', target]);
-  if (!r.ok) { console.error(r.stderr || 'bb sessions get failed'); process.exit(1); }
+  const r = runCmd('browse', ['cloud', 'sessions', 'get', target]);
+  if (!r.ok) { console.error(r.stderr || 'browse cloud sessions get failed'); process.exit(1); }
   sessionJson = JSON.parse(r.stdout);
   if (sessionJson.status !== 'RUNNING') {
     console.error(`Session ${target} is not RUNNING (status=${sessionJson.status}). Recreate with --keep-alive.`);
@@ -50,7 +50,7 @@ const sessionId = sessionJson.id;
 const connectUrl = sessionJson.connectUrl;
 
 let debugJson = null;
-const dbg = runCmd('bb', ['sessions', 'debug', sessionId]);
+const dbg = runCmd('browse', ['cloud', 'sessions', 'debug', sessionId]);
 if (dbg.ok) {
   try { debugJson = JSON.parse(dbg.stdout); } catch {}
 }

--- a/skills/browser-trace/scripts/bb-finalize.mjs
+++ b/skills/browser-trace/scripts/bb-finalize.mjs
@@ -6,7 +6,7 @@
 // Usage:
 //   node scripts/bb-finalize.mjs <run-id> [--release]
 //
-//   --release  send `bb sessions update --status REQUEST_RELEASE` after
+//   --release  send `browse cloud sessions update --status REQUEST_RELEASE` after
 //              finalizing (use only when this run owns the session).
 
 import fs from 'node:fs';
@@ -45,18 +45,18 @@ ensureDir(bbDir);
 
 // Final session metadata — proxyBytes, status, ended_at all settle here.
 {
-  const r = runCmd('bb', ['sessions', 'get', sessionId]);
+  const r = runCmd('browse', ['cloud', 'sessions', 'get', sessionId]);
   if (r.ok) {
     fs.writeFileSync(path.join(bbDir, 'session.json'), r.stdout);
     console.log('wrote session.json');
   } else {
-    console.error('warn: bb sessions get failed');
+    console.error('warn: browse cloud sessions get failed');
   }
 }
 
 // Server-side logs. Often empty — the firehose in cdp/raw.ndjson is the source of truth.
 {
-  const r = runCmd('bb', ['sessions', 'logs', sessionId]);
+  const r = runCmd('browse', ['cloud', 'sessions', 'logs', sessionId]);
   if (r.ok) {
     fs.writeFileSync(path.join(bbDir, 'logs.json'), r.stdout);
     let n = '?';
@@ -69,7 +69,7 @@ ensureDir(bbDir);
 // content is always larger.
 {
   const out = path.join(bbDir, 'downloads.zip');
-  const r = runCmd('bb', ['sessions', 'downloads', 'get', sessionId, '--output', out]);
+  const r = runCmd('browse', ['cloud', 'sessions', 'downloads', 'get', sessionId, '--output', out]);
   if (r.ok && fs.existsSync(out)) {
     const size = fs.statSync(out).size;
     if (size <= 22) {
@@ -84,12 +84,12 @@ ensureDir(bbDir);
 }
 
 if (release) {
-  const r = runCmd('bb', ['sessions', 'update', sessionId, '--status', 'REQUEST_RELEASE']);
+  const r = runCmd('browse', ['cloud', 'sessions', 'update', sessionId, '--status', 'REQUEST_RELEASE']);
   if (r.ok) console.log(`released session ${sessionId}`);
 
   // Re-snapshot session.json so it reflects the final COMPLETED state with
   // settled proxyBytes and endedAt instead of the pre-release values.
-  const r2 = runCmd('bb', ['sessions', 'get', sessionId]);
+  const r2 = runCmd('browse', ['cloud', 'sessions', 'get', sessionId]);
   if (r2.ok) {
     fs.writeFileSync(path.join(bbDir, 'session.json'), r2.stdout);
     console.log('refreshed session.json (post-release)');

--- a/skills/browser-trace/scripts/snapshot-loop.mjs
+++ b/skills/browser-trace/scripts/snapshot-loop.mjs
@@ -2,8 +2,9 @@
 // Periodic screenshot + DOM HTML + URL sampler. Invoked by start-capture.mjs;
 // not meant to be run directly.
 //
-// Each tick opens a one-shot CDP connection via `browse ... --cdp <target>`
-// (bypasses the `browse` daemon so it doesn't fight the main automation).
+// Each tick samples the traced CDP target through browse. Passing --cdp here
+// ensures this helper attaches to the traced target even when it runs outside
+// the user's main automation flow.
 
 import fs from 'node:fs';
 import path from 'node:path';
@@ -60,7 +61,7 @@ while (!stopping) {
     try { fs.unlinkSync(tmp); } catch {}
   }
 
-  // URL via the daemon-bypassing one-shot. Returns {"url": "..."}.
+  // URL from the traced target. Returns {"url": "..."}.
   let urlValue = '';
   const u = spawnSync('browse', ['get', 'url', '--cdp', target], { encoding: 'utf8' });
   urlValue = getJsonField(u.stdout, 'url');

--- a/skills/browser-trace/scripts/snapshot-loop.mjs
+++ b/skills/browser-trace/scripts/snapshot-loop.mjs
@@ -2,7 +2,7 @@
 // Periodic screenshot + DOM HTML + URL sampler. Invoked by start-capture.mjs;
 // not meant to be run directly.
 //
-// Each tick opens a one-shot CDP connection via `browse --ws <target> ...`
+// Each tick opens a one-shot CDP connection via `browse ... --cdp <target>`
 // (bypasses the `browse` daemon so it doesn't fight the main automation).
 
 import fs from 'node:fs';
@@ -24,6 +24,16 @@ let stopping = false;
 process.on('SIGTERM', () => { stopping = true; });
 process.on('SIGINT',  () => { stopping = true; });
 
+function getJsonField(stdout, field) {
+  if (!stdout) return '';
+  try {
+    const parsed = JSON.parse(stdout);
+    return typeof parsed?.[field] === 'string' ? parsed[field] : '';
+  } catch {
+    return '';
+  }
+}
+
 while (!stopping) {
   const ts   = isoStampForFilename();
   const png  = path.join(RD, 'screenshots', `${ts}.png`);
@@ -31,16 +41,17 @@ while (!stopping) {
   const tmp  = `${html}.partial`;
 
   // Best-effort screenshot. If browse fails we just don't get one this tick.
-  spawnSync('browse', ['--ws', target, 'screenshot', png], { stdio: 'ignore' });
+  spawnSync('browse', ['screenshot', '--cdp', target, '--path', png], { stdio: 'ignore' });
   if (fs.existsSync(png) && fs.statSync(png).size === 0) {
     fs.unlinkSync(png);
   }
 
   // DOM dump via temp file → rename, so we never leave a 0-byte HTML behind.
   try {
-    const r = spawnSync('browse', ['--ws', target, 'get', 'html', 'body'], { encoding: 'utf8' });
-    if (r.stdout && r.stdout.length) {
-      fs.writeFileSync(tmp, r.stdout);
+    const r = spawnSync('browse', ['get', 'html', 'body', '--cdp', target], { encoding: 'utf8' });
+    const htmlBody = getJsonField(r.stdout, 'html');
+    if (htmlBody) {
+      fs.writeFileSync(tmp, htmlBody);
       fs.renameSync(tmp, html);
     }
   } catch { /* best-effort */ }
@@ -51,10 +62,8 @@ while (!stopping) {
 
   // URL via the daemon-bypassing one-shot. Returns {"url": "..."}.
   let urlValue = '';
-  const u = spawnSync('browse', ['--ws', target, '--json', 'get', 'url'], { encoding: 'utf8' });
-  if (u.stdout) {
-    try { urlValue = JSON.parse(u.stdout).url || ''; } catch {}
-  }
+  const u = spawnSync('browse', ['get', 'url', '--cdp', target], { encoding: 'utf8' });
+  urlValue = getJsonField(u.stdout, 'url');
 
   const screenshotRel = fs.existsSync(png)  ? `screenshots/${ts}.png` : '';
   const domRel        = fs.existsSync(html) ? `dom/${ts}.html`        : '';

--- a/skills/browser/EXAMPLES.md
+++ b/skills/browser/EXAMPLES.md
@@ -2,7 +2,7 @@
 
 Common browser automation workflows using the `browse` CLI. Each example demonstrates a distinct pattern using real commands.
 
-For localhost and other local dev flows, start with `browse open <url> --local` for a clean isolated browser. Use `browse open <url> --auto-connect` only when the agent should reuse your existing local Chrome session, cookies, or login state.
+For localhost and other local dev flows, start with `browse open <url> --local` for a clean isolated browser. Use `browse open <url> --auto-connect` only when the agent should attach to an existing debuggable Chrome session for cookies or login state.
 
 ## Example 1: Extract Data from a Page
 

--- a/skills/browser/EXAMPLES.md
+++ b/skills/browser/EXAMPLES.md
@@ -2,7 +2,7 @@
 
 Common browser automation workflows using the `browse` CLI. Each example demonstrates a distinct pattern using real commands.
 
-For localhost and other local dev flows, start with `browse env local` for a clean isolated browser. Use `browse env local --auto-connect` only when the agent should reuse your existing local Chrome session, cookies, or login state.
+For localhost and other local dev flows, start with `browse open <url> --local` for a clean isolated browser. Use `browse open <url> --auto-connect` only when the agent should reuse your existing local Chrome session, cookies, or login state.
 
 ## Example 1: Extract Data from a Page
 
@@ -75,8 +75,7 @@ browse stop
 
 ```bash
 # Attempt 1: local mode
-browse env local
-browse open https://competitor.com/pricing
+browse open https://competitor.com/pricing --local
 browse snapshot
 # Output shows: "Checking your browser..." (Cloudflare interstitial)
 # or: page content is empty / access denied
@@ -94,8 +93,7 @@ If the user agrees:
 export BROWSERBASE_API_KEY="bb_live_..."
 
 # Retry in remote mode
-browse env remote
-browse open https://competitor.com/pricing
+browse open https://competitor.com/pricing --remote
 browse snapshot                          # full page content now accessible
 browse get text ".pricing-table"
 browse stop
@@ -109,8 +107,11 @@ This uses Browserbase contexts to persist cookies and storage across sessions. R
 
 ```bash
 # Session 1: Log in and persist state
-browse env remote
-browse open https://app.example.com/login --context-id ctx_abc123 --persist
+SESSION_JSON="$(browse cloud sessions create --context-id ctx_abc123 --persist --keep-alive)"
+SESSION_ID="$(echo "$SESSION_JSON" | jq -r .id)"
+CONNECT_URL="$(echo "$SESSION_JSON" | jq -r .connectUrl)"
+
+browse open https://app.example.com/login --cdp "$CONNECT_URL"
 browse snapshot                          # find login form fields
 browse click @0-3                        # click email input
 browse type "user@example.com"
@@ -119,21 +120,26 @@ browse type "my-password"
 browse click @0-7                        # click Sign In button
 browse wait load
 browse snapshot                          # confirm logged-in dashboard
-browse stop                              # state is saved back to ctx_abc123
+browse stop
+browse cloud sessions update "$SESSION_ID" --status REQUEST_RELEASE  # state is saved back to ctx_abc123
 ```
 
 In a later session, reuse the same context — already authenticated:
 
 ```bash
 # Session 2: Resume with saved state (already logged in)
-browse env remote
-browse open https://app.example.com/dashboard --context-id ctx_abc123
+SESSION_JSON="$(browse cloud sessions create --context-id ctx_abc123 --keep-alive)"
+SESSION_ID="$(echo "$SESSION_JSON" | jq -r .id)"
+CONNECT_URL="$(echo "$SESSION_JSON" | jq -r .connectUrl)"
+
+browse open https://app.example.com/dashboard --cdp "$CONNECT_URL"
 browse snapshot                          # dashboard loads — no login needed
 browse get text ".welcome-message"
 browse stop
+browse cloud sessions update "$SESSION_ID" --status REQUEST_RELEASE
 ```
 
-**Key pattern**: Use `--context-id <id> --persist` on the first session to save auth state. On subsequent sessions, use `--context-id <id>` (with or without `--persist`) to resume where you left off. Omit `--persist` if you don't want changes from that session saved back.
+**Key pattern**: Use `browse cloud sessions create --context-id <id> --persist` for the first Browserbase session to save auth state, then attach with `browse open ... --cdp "$CONNECT_URL"`. On subsequent sessions, create with the same `--context-id` and omit `--persist` if you don't want changes saved back.
 
 ## Tips
 

--- a/skills/browser/REFERENCE.md
+++ b/skills/browser/REFERENCE.md
@@ -23,7 +23,7 @@ Technical reference for the `browse` CLI tool.
 The browse CLI is a **daemon-based** command-line tool:
 
 - **Daemon process**: A background process manages the browser instance. Auto-starts on the first command (e.g., `browse open`), persists across commands, and stops with `browse stop`.
-- **Local mode** (default): `browse open <url> --local` launches a clean isolated local browser. Use `browse open <url> --auto-connect` to reuse an existing debuggable Chrome, or `browse open <url> --cdp <port|url>` to attach to a specific CDP target.
+- **Local mode**: `browse open <url> --local` launches a clean isolated local browser. It is the default when `BROWSERBASE_API_KEY` is unset. Use `browse open <url> --auto-connect` to attach to an existing debuggable Chrome, or `browse open <url> --cdp <port|url>` to attach to a specific CDP target.
 - **Remote mode** (Browserbase): Connects to a Browserbase cloud browser session when `BROWSERBASE_API_KEY` is set.
 - **Accessibility-first**: Use `browse snapshot` to get the page's accessibility tree with element refs, then interact using those refs.
 
@@ -100,7 +100,7 @@ Returns a text representation of the page with refs like `@0-5` that can be pass
 Take a visual screenshot. Slower than snapshot and uses vision tokens.
 
 ```bash
-browse screenshot                        # auto-generated path
+browse screenshot                        # print base64 JSON
 browse screenshot --path ./capture.png   # custom path
 browse screenshot --full-page            # capture entire scrollable page
 ```
@@ -200,25 +200,25 @@ browse press Cmd+A                       # select all (Mac)
 browse press Ctrl+C                      # copy (Linux/Windows)
 ```
 
-#### `scroll <x> <y> <deltaX> <deltaY>`
+#### `mouse scroll <x> <y> <deltaX> <deltaY>`
 
 Scroll at a given position by a given amount.
 
 ```bash
-browse scroll 500 300 0 -300             # scroll up at (500, 300)
-browse scroll 500 300 0 500              # scroll down
+browse mouse scroll 500 300 0 -300       # scroll up at (500, 300)
+browse mouse scroll 500 300 0 500        # scroll down
 ```
 
-#### `drag <fromX> <fromY> <toX> <toY>`
+#### `mouse drag <fromX> <fromY> <toX> <toY>`
 
 Drag from one viewport coordinate to another.
 
 ```bash
-browse drag 80 80 310 100                # drag with default 10 steps
-browse drag 80 80 310 100 --steps 20     # more intermediate steps
-browse drag 80 80 310 100 --delay 50     # 50ms between steps
-browse drag 80 80 310 100 --button right # use right mouse button
-browse drag 80 80 310 100 --xpath        # return source/target XPaths
+browse mouse drag 80 80 310 100                # drag with default 10 steps
+browse mouse drag 80 80 310 100 --steps 20     # more intermediate steps
+browse mouse drag 80 80 310 100 --delay 50     # 50ms between steps
+browse mouse drag 80 80 310 100 --button right # use right mouse button
+browse mouse drag 80 80 310 100 --return-xpath # return source/target XPaths
 ```
 
 #### `highlight <selector>`
@@ -321,7 +321,7 @@ browse tab switch 1
 
 #### `tab close [index-or-target-id]`
 
-Close a tab. Closes current tab if no index given.
+Close a tab. Closes current tab if no index given. The CLI refuses to close the last remaining tab.
 
 ```bash
 browse tab close          # close current tab

--- a/skills/browser/REFERENCE.md
+++ b/skills/browser/REFERENCE.md
@@ -23,7 +23,7 @@ Technical reference for the `browse` CLI tool.
 The browse CLI is a **daemon-based** command-line tool:
 
 - **Daemon process**: A background process manages the browser instance. Auto-starts on the first command (e.g., `browse open`), persists across commands, and stops with `browse stop`.
-- **Local mode** (default): `browse env local` launches a clean isolated local browser. Use `browse env local --auto-connect` or `browse env local <port|url>` to attach to an existing browser via CDP.
+- **Local mode** (default): `browse open <url> --local` launches a clean isolated local browser. Use `browse open <url> --auto-connect` to reuse an existing debuggable Chrome, or `browse open <url> --cdp <port|url>` to attach to a specific CDP target.
 - **Remote mode** (Browserbase): Connects to a Browserbase cloud browser session when `BROWSERBASE_API_KEY` is set.
 - **Accessibility-first**: Use `browse snapshot` to get the page's accessibility tree with element refs, then interact using those refs.
 
@@ -33,7 +33,7 @@ The browse CLI is a **daemon-based** command-line tool:
 
 #### `open <url>`
 
-Navigate to a URL. Alias: `goto`. Auto-starts the daemon if not running.
+Navigate to a URL. Auto-starts the daemon if not running.
 
 ```bash
 browse open https://example.com
@@ -45,17 +45,23 @@ The `--wait` flag controls when navigation is considered complete. Values: `load
 
 ##### Context persistence (remote mode only)
 
-Use `--context-id` to load a Browserbase context, which carries browser state (cookies, localStorage, sessionStorage) across sessions. Add `--persist` to save any state changes back to the context when the session ends.
+Create a Browserbase session with `browse cloud sessions create --context-id <id>`, then attach to its CDP endpoint with `browse open <url> --cdp <connectUrl>`. Add `--persist` to the cloud session if state changes should save back to the context.
 
 ```bash
-browse open https://example.com --context-id ctx_abc123              # load context (read-only)
-browse open https://example.com --context-id ctx_abc123 --persist    # load + save changes back
+SESSION_JSON="$(browse cloud sessions create --context-id ctx_abc123 --persist --keep-alive)"
+SESSION_ID="$(echo "$SESSION_JSON" | jq -r .id)"
+CONNECT_URL="$(echo "$SESSION_JSON" | jq -r .connectUrl)"
+
+browse open https://example.com --cdp "$CONNECT_URL"
+# ...interact with the page...
+browse stop
+browse cloud sessions update "$SESSION_ID" --status REQUEST_RELEASE
 ```
 
-- `--context-id <id>` — Browserbase context ID to load. **Remote mode only** — the CLI will error if used in local mode.
-- `--persist` — Save cookies/storage changes back to the context on `browse stop`. Requires `--context-id`.
-- If the daemon is already running with a different context, it automatically restarts with the new one.
-- Calling `browse open` without `--context-id` clears any previously loaded context.
+- `--context-id <id>` — Browserbase context ID to load when creating the cloud session.
+- `--persist` — Save cookies/storage changes back to the context when the Browserbase session is released. Requires `--context-id`.
+- `--keep-alive` — Keep the Browserbase session alive while the local browse daemon attaches and detaches.
+- After `browse open ... --cdp "$CONNECT_URL"`, follow-up commands in that session do not repeat `--cdp`; the daemon remembers the attached target.
 
 #### `reload`
 
@@ -95,7 +101,7 @@ Take a visual screenshot. Slower than snapshot and uses vision tokens.
 
 ```bash
 browse screenshot                        # auto-generated path
-browse screenshot ./capture.png          # custom path
+browse screenshot --path ./capture.png   # custom path
 browse screenshot --full-page            # capture entire scrollable page
 ```
 
@@ -272,54 +278,54 @@ Check whether the daemon is running, its connection details, and current environ
 browse status
 ```
 
-#### `env [local|remote] [port|url]`
+#### Starting sessions with a mode flag
 
-Show or switch the browser environment. Without arguments, prints the current environment. With an argument, stores a per-session override, restarts the daemon if needed, and keeps using that mode until you switch again or run `browse stop`.
+Choose the browser target on the command that starts the session:
 
 ```bash
-browse env                               # print current environment
-browse env local                         # use clean isolated local browser
-browse env local --auto-connect          # auto-discover existing Chrome, fallback to isolated
-browse env local 9222                    # attach to a specific CDP target
-browse env local ws://localhost:9222/devtools/browser/...   # attach to explicit browser WebSocket
-browse env remote                        # switch to Browserbase (requires API keys)
+browse open https://example.com --local
+browse open https://example.com --local --headed
+browse open https://example.com --auto-connect
+browse open https://example.com --cdp 9222
+browse open https://example.com --cdp ws://localhost:9222/devtools/browser/...
+browse open https://example.com --remote
 ```
 
-- `browse status` shows the resolved local strategy when the daemon is running (`localStrategy`, `localSource`, `resolvedCdpUrl`)
-- `browse stop` clears the override so the next start falls back to env-var-based auto detection
+- `browse status` shows the resolved mode and active target once the daemon is running.
+- `browse stop` closes the current daemon session; the next `browse open` chooses mode from its flags or environment.
 
-#### `newpage [url]`
+#### `tab new [url]`
 
 Create a new tab, optionally navigating to a URL.
 
 ```bash
-browse newpage                           # open blank tab
-browse newpage https://example.com       # open tab with URL
+browse tab new                           # open blank tab
+browse tab new https://example.com       # open tab with URL
 ```
 
-#### `pages`
+#### `tab list`
 
 List all open tabs.
 
 ```bash
-browse pages
+browse tab list
 ```
 
-#### `tab_switch <index>`
+#### `tab switch <index-or-target-id>`
 
-Switch to a tab by its index (from `browse pages`).
+Switch to a tab by its index or target ID (from `browse tab list`).
 
 ```bash
-browse tab_switch 1
+browse tab switch 1
 ```
 
-#### `tab_close [index]`
+#### `tab close [index-or-target-id]`
 
 Close a tab. Closes current tab if no index given.
 
 ```bash
-browse tab_close          # close current tab
-browse tab_close 2        # close tab at index 2
+browse tab close          # close current tab
+browse tab close 2        # close tab at index 2
 ```
 
 ---
@@ -389,33 +395,18 @@ browse network clear
 
 ## Configuration
 
-### Global Flags
-
-#### `--json`
-
-Output as JSON for all commands. Useful for structured, parseable output.
-
-```bash
-browse --json get url                    # returns {"url": "https://..."}
-browse --json snapshot                   # returns JSON accessibility tree
-```
+### Common Flags
 
 #### `--session <name>`
 
 Run commands against a named session, enabling multiple concurrent browsers.
 
 ```bash
-browse --session work open https://a.com
-browse --session personal open https://b.com
+browse open https://a.com --session work
+browse open https://b.com --session personal
 ```
 
-#### `--context-id <id>`
-
-Load a Browserbase context to persist browser state (cookies, localStorage, sessionStorage) across sessions. Remote mode only. See [`open`](#open-url) for details.
-
-#### `--persist`
-
-Save browser state changes back to the Browserbase context when the session ends. Must be used with `--context-id`.
+Context flags such as `--context-id` and `--persist` live on `browse cloud sessions create`; attach to the resulting `connectUrl` with `browse open ... --cdp <connectUrl>`.
 
 ### Environment Variables
 
@@ -425,7 +416,7 @@ Save browser state changes back to the Browserbase context when the session ends
 | `BROWSERBASE_API_KEY` | For remote mode | API key from https://browserbase.com/settings; makes Browserbase the default desired mode when no override is set |
 | `BROWSERBASE_PROJECT_ID` | No | Passed through to Browserbase when set |
 
-Without an override, setting `BROWSERBASE_API_KEY` makes Browserbase the default desired mode. Otherwise the default desired mode is local. `browse env local`, `browse env local --auto-connect`, and `browse env remote` override that per session until `browse stop`.
+Without an override, setting `BROWSERBASE_API_KEY` makes Browserbase the default desired mode. Otherwise the default desired mode is local. Use `--local`, `--remote`, `--auto-connect`, or `--cdp <port|url>` on `browse open` when you need an explicit target.
 
 ### Setting credentials
 
@@ -445,7 +436,7 @@ Get these values from https://browserbase.com/settings.
 
 **"Chrome not found"** / **"Could not find local Chrome installation"**
 - Chrome/Chromium is not installed or not in a standard location.
-- Fix: Install Chrome, use `browse env local --auto-connect` if you already have a debuggable Chrome running, or switch to remote with `browse env remote` (no local browser needed).
+- Fix: Install Chrome, use `browse open <url> --auto-connect` if you already have a debuggable Chrome running, or switch to remote with `browse open <url> --remote` (no local browser needed).
 
 **"Daemon not running"**
 - No daemon process is active. Most commands auto-start the daemon, but `snapshot`, `click`, etc. require an active session.

--- a/skills/browser/REFERENCE.md
+++ b/skills/browser/REFERENCE.md
@@ -171,12 +171,12 @@ browse type "human-like" --mistakes      # simulate human typing with typos
 
 #### `fill <selector> <value>`
 
-Fill an input element matching a CSS selector and press Enter.
+Fill an input element matching a CSS selector. Add `--press-enter` when Enter is needed.
 
 ```bash
 browse fill "#search" "browser automation"
 browse fill "input[name=email]" "user@example.com"
-browse fill "#search" "query" --no-press-enter   # fill without pressing Enter
+browse fill "#search" "query" --press-enter   # fill and press Enter
 ```
 
 #### `select <selector> <values...>`

--- a/skills/browser/SKILL.md
+++ b/skills/browser/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: browser
 description: Automate web browser interactions using natural language via CLI commands. Use when the user asks to browse websites, navigate web pages, extract data from websites, take screenshots, fill forms, click buttons, or interact with web applications. Supports remote Browserbase sessions with automatic CAPTCHA solving, anti-bot stealth mode, and residential proxies — ideal for scraping protected websites, bypassing bot detection, and interacting with JavaScript-heavy pages.
-compatibility: "Requires the browse CLI (`npm install -g @browserbasehq/browse-cli`). Remote Browserbase sessions need `BROWSERBASE_API_KEY`. Local mode uses Chrome/Chromium on your machine."
+compatibility: "Requires the browse CLI (`npm install -g browse`). Remote Browserbase sessions need `BROWSERBASE_API_KEY`. Local mode uses Chrome/Chromium on your machine."
 license: MIT
 allowed-tools: Bash
 metadata:
@@ -11,7 +11,7 @@ metadata:
         - browse
     install:
       - kind: node
-        package: "@browserbasehq/browse-cli"
+        package: "browse"
         bins: [browse]
     homepage: https://github.com/browserbase/skills
 ---
@@ -25,7 +25,7 @@ Automate browser interactions using the browse CLI with Claude.
 Before running any browser commands, verify the CLI is available:
 
 ```bash
-which browse || npm install -g @browserbasehq/browse-cli
+which browse || npm install -g browse
 ```
 
 ## Environment Selection (Local vs Remote)

--- a/skills/browser/SKILL.md
+++ b/skills/browser/SKILL.md
@@ -34,7 +34,7 @@ The CLI supports explicit per-command environment flags. If you do nothing, the 
 
 ### Local mode
 - `browse open <url> --local` starts a clean isolated local browser
-- `browse open <url> --auto-connect` reuses an already-running debuggable Chrome and falls back to isolated if nothing is available
+- `browse open <url> --auto-connect` attaches to an already-running debuggable Chrome; use `--local` when no debuggable Chrome is available
 - `browse open <url> --cdp <port|url>` attaches to a specific CDP target
 - Best for: development, localhost, trusted sites, and reproducible runs
 
@@ -54,11 +54,11 @@ The CLI supports explicit per-command environment flags. If you do nothing, the 
 
 ## Commands
 
-All commands work identically in both modes. The daemon auto-starts on first command.
+Most driver commands work across local, remote, and CDP sessions after the daemon starts.
 
 ### Navigation
 ```bash
-browse open <url>                        # Go to URL (aliases: goto)
+browse open <url>                        # Go to URL
 browse open <url> --local                # Go to URL in a clean local browser
 browse open <url> --remote               # Go to URL in a Browserbase session
 browse reload                            # Reload current page
@@ -160,11 +160,11 @@ Don't switch for simple sites (docs, wikis, public APIs, localhost).
 
 ```bash
 browse open <url> --local          # clean isolated local browser
-browse open <url> --auto-connect   # reuse existing Chrome state
+browse open <url> --auto-connect   # attach to existing debuggable Chrome
 browse open <url> --remote         # Browserbase session
 ```
 
-Mode flags are applied when a session starts. After `browse stop`, the next start falls back to env-var-based auto detection. Use `browse status` to inspect the resolved local strategy while the daemon is running.
+Mode flags are applied when a session starts. After `browse stop`, the next start falls back to env-var-based auto detection. Use `browse status` to inspect the resolved mode and target while the daemon is running.
 
 For detailed examples, see [EXAMPLES.md](EXAMPLES.md).
 For API reference, see [REFERENCE.md](REFERENCE.md).

--- a/skills/browser/SKILL.md
+++ b/skills/browser/SKILL.md
@@ -30,24 +30,24 @@ which browse || npm install -g browse
 
 ## Environment Selection (Local vs Remote)
 
-The CLI supports explicit per-session environment overrides. If you do nothing, the next session defaults to Browserbase when `BROWSERBASE_API_KEY` is set and to local otherwise.
+The CLI supports explicit per-command environment flags. If you do nothing, the next session defaults to Browserbase when `BROWSERBASE_API_KEY` is set and to local otherwise.
 
 ### Local mode
-- `browse env local` starts a clean isolated local browser
-- `browse env local --auto-connect` reuses an already-running debuggable Chrome and falls back to isolated if nothing is available
-- `browse env local <port|url>` attaches to a specific CDP target
+- `browse open <url> --local` starts a clean isolated local browser
+- `browse open <url> --auto-connect` reuses an already-running debuggable Chrome and falls back to isolated if nothing is available
+- `browse open <url> --cdp <port|url>` attaches to a specific CDP target
 - Best for: development, localhost, trusted sites, and reproducible runs
 
 ### Remote mode (Browserbase)
-- `browse env remote` switches the current session to Browserbase
-- Without a local override, Browserbase is also the default when `BROWSERBASE_API_KEY` is set
+- `browse open <url> --remote` starts a Browserbase session
+- Without a local flag, Browserbase is also the default when `BROWSERBASE_API_KEY` is set
 - Provides: anti-bot stealth, automatic CAPTCHA solving, residential proxies, session persistence
 - **Use remote mode when:** the target site has bot detection, CAPTCHAs, IP rate limiting, Cloudflare protection, or requires geo-specific access
 - Get credentials at https://browserbase.com/settings
 
 ### When to choose which
-- **Repeatable local testing / clean state**: `browse env local`
-- **Reuse your local login/cookies**: `browse env local --auto-connect`
+- **Repeatable local testing / clean state**: `browse open <url> --local`
+- **Reuse your local login/cookies**: `browse open <url> --auto-connect`
 - **Simple browsing** (docs, wikis, public APIs): local mode is fine
 - **Protected sites** (login walls, CAPTCHAs, anti-scraping): use remote mode
 - **If local mode fails** with bot detection or access denied: switch to remote mode
@@ -59,8 +59,8 @@ All commands work identically in both modes. The daemon auto-starts on first com
 ### Navigation
 ```bash
 browse open <url>                        # Go to URL (aliases: goto)
-browse open <url> --context-id <id>      # Load Browserbase context (remote only)
-browse open <url> --context-id <id> --persist  # Load context + save changes back
+browse open <url> --local                # Go to URL in a clean local browser
+browse open <url> --remote               # Go to URL in a Browserbase session
 browse reload                            # Reload current page
 browse back                              # Go back in history
 browse forward                           # Go forward in history
@@ -69,7 +69,7 @@ browse forward                           # Go forward in history
 ### Page state (prefer snapshot over screenshot)
 ```bash
 browse snapshot                          # Get accessibility tree with element refs (fast, structured)
-browse screenshot [path]                 # Take visual screenshot (slow, uses vision tokens)
+browse screenshot --path <path>          # Take visual screenshot (slow, uses vision tokens)
 browse get url                           # Get current URL
 browse get title                         # Get page title
 browse get text <selector>               # Get text content (use "body" for all text)
@@ -83,11 +83,11 @@ Use `browse snapshot` as your default for understanding page state — it return
 ```bash
 browse click <ref>                       # Click element by ref from snapshot (e.g., @0-5)
 browse type <text>                       # Type text into focused element
-browse fill <selector> <value>           # Fill input and press Enter
+browse fill <selector> <value>           # Fill input; add --press-enter if Enter is needed
 browse select <selector> <values...>     # Select dropdown option(s)
 browse press <key>                       # Press key (Enter, Tab, Escape, Cmd+A, etc.)
-browse drag <fromX> <fromY> <toX> <toY>  # Drag from one point to another
-browse scroll <x> <y> <deltaX> <deltaY> # Scroll at coordinates
+browse mouse drag <fromX> <fromY> <toX> <toY>  # Drag from one point to another
+browse mouse scroll <x> <y> <deltaX> <deltaY>  # Scroll at coordinates
 browse highlight <selector>              # Highlight element on page
 browse is visible <selector>             # Check if element is visible
 browse is checked <selector>             # Check if element is checked
@@ -96,22 +96,17 @@ browse wait <type> [arg]                 # Wait for: load, selector, timeout
 
 ### Session management
 ```bash
-browse stop                              # Stop the browser daemon (also clears env override)
-browse status                            # Check daemon status (includes env)
-browse env                               # Show current environment (local or remote)
-browse env local                         # Use clean isolated local browser
-browse env local --auto-connect          # Reuse existing Chrome, fallback to isolated
-browse env local <port|url>              # Attach to a specific CDP target
-browse env remote                        # Switch to Browserbase (requires API keys)
-browse pages                             # List all open tabs
-browse tab_switch <index>                # Switch to tab by index
-browse tab_close [index]                 # Close tab
+browse stop                              # Stop the browser daemon
+browse status                            # Check daemon status and resolved mode
+browse tab list                          # List all open tabs
+browse tab switch <index-or-target-id>   # Switch to tab by index or target ID
+browse tab close [index-or-target-id]    # Close tab
 ```
 
 ### Typical workflow
-If the environment matters, set it first with `browse env local`, `browse env local --auto-connect`, or `browse env remote`.
+If the environment matters, put `--local`, `--remote`, `--auto-connect`, or `--cdp <port|url>` on the first browser command.
 
-1. `browse open <url>` — navigate to the page
+1. `browse open <url> --local` or `browse open <url> --remote` — navigate to the page
 2. `browse snapshot` — read the accessibility tree to understand page structure and get element refs
 3. `browse click <ref>` / `browse type <text>` / `browse fill <selector> <value>` — interact using refs from snapshot
 4. `browse snapshot` — confirm the action worked
@@ -134,7 +129,7 @@ browse stop
 |---------|-------|-------------|
 | Speed | Faster | Slightly slower |
 | Setup | Chrome required | API key required |
-| Reuse existing local cookies | With `browse env local --auto-connect` | N/A |
+| Reuse existing local cookies | With `browse open <url> --auto-connect` | N/A |
 | Stealth mode | No | Yes (custom Chromium, anti-bot fingerprinting) |
 | CAPTCHA solving | No | Yes (automatic reCAPTCHA/hCaptcha) |
 | Residential proxies | No | Yes (201 countries, geo-targeting) |
@@ -143,7 +138,7 @@ browse stop
 
 ## Best Practices
 
-1. **Choose the local strategy deliberately**: use `browse env local` for clean state, `browse env local --auto-connect` for existing local credentials, and `browse env remote` for protected sites
+1. **Choose the local strategy deliberately**: use `browse open <url> --local` for clean state, `browse open <url> --auto-connect` for existing local credentials, and `browse open <url> --remote` for protected sites
 2. **Always `browse open` first** before interacting
 3. **Use `browse snapshot`** to check page state — it's fast and gives you element refs
 4. **Only screenshot when visual context is needed** (layout checks, images, debugging)
@@ -153,7 +148,7 @@ browse stop
 ## Troubleshooting
 
 - **"No active page"**: Run `browse stop`, then check `browse status`. If it still says running, kill the zombie daemon with `pkill -f "browse.*daemon"`, then retry `browse open`
-- **Chrome not found**: Install Chrome, use `browse env local --auto-connect` if you already have a debuggable Chrome running, or switch to `browse env remote`
+- **Chrome not found**: Install Chrome, use `browse open <url> --auto-connect` if you already have a debuggable Chrome running, or switch to `browse open <url> --remote`
 - **Action fails**: Run `browse snapshot` to see available elements and their refs
 - **Browserbase fails**: Verify API key is set
 
@@ -164,12 +159,12 @@ Switch to remote when you detect: CAPTCHAs (reCAPTCHA, hCaptcha, Turnstile), bot
 Don't switch for simple sites (docs, wikis, public APIs, localhost).
 
 ```bash
-browse env local             # clean isolated local browser
-browse env local --auto-connect  # reuse existing Chrome state
-browse env remote            # switch to Browserbase
+browse open <url> --local          # clean isolated local browser
+browse open <url> --auto-connect   # reuse existing Chrome state
+browse open <url> --remote         # Browserbase session
 ```
 
-Overrides are scoped per session and stay in effect until you switch again or run `browse stop`. After `browse stop`, the next start falls back to env-var-based auto detection. Use `browse status` to inspect the resolved local strategy while the daemon is running.
+Mode flags are applied when a session starts. After `browse stop`, the next start falls back to env-var-based auto detection. Use `browse status` to inspect the resolved local strategy while the daemon is running.
 
 For detailed examples, see [EXAMPLES.md](EXAMPLES.md).
 For API reference, see [REFERENCE.md](REFERENCE.md).

--- a/skills/browserbase-cli/REFERENCE.md
+++ b/skills/browserbase-cli/REFERENCE.md
@@ -156,9 +156,10 @@ When both `--status` and `--body` are present on `browse cloud sessions update`,
 ```bash
 browse cloud contexts create --body '{"region":"us-west-2"}'
 browse cloud contexts get <context_id>
-browse cloud contexts update <context_id>
 browse cloud contexts delete <context_id>
 ```
+
+`browse cloud contexts update <context_id>` refreshes context upload URLs, but context uploads through this API are deprecated and may return a deprecation error. Avoid it unless Browserbase support has asked you to use that path.
 
 ### Extensions
 

--- a/skills/browserbase-cli/REFERENCE.md
+++ b/skills/browserbase-cli/REFERENCE.md
@@ -9,7 +9,7 @@
 - [Fetch API](#fetch-api)
 - [Search API](#search-api)
 - [Templates](#templates)
-- [Browse passthrough](#browse-passthrough)
+- [Local & remote browser driving](#local--remote-browser-driving)
 - [Skills](#skills)
 - [Troubleshooting](#troubleshooting)
 
@@ -18,15 +18,15 @@
 Install the CLI if needed:
 
 ```bash
-npm install -g @browserbasehq/cli
+npm install -g browse
 ```
 
 Check the available surface with:
 
 ```bash
-bb --help
-bb functions --help
-bb sessions --help
+browse --help
+browse functions --help
+browse cloud sessions --help
 ```
 
 ## Authentication and flags
@@ -37,7 +37,7 @@ All authenticated commands require an API key:
 export BROWSERBASE_API_KEY="your_api_key"
 ```
 
-Only `bb functions dev` and `bb functions publish` require a project ID:
+Only `browse functions dev` and `browse functions publish` require a project ID:
 
 ```bash
 export BROWSERBASE_PROJECT_ID="your_project_id"
@@ -47,12 +47,12 @@ export BROWSERBASE_PROJECT_ID="your_project_id"
 
 These command groups share a common flag shape:
 
-- `bb projects`
-- `bb sessions`
-- `bb contexts`
-- `bb extensions`
-- `bb fetch`
-- `bb search`
+- `browse cloud projects`
+- `browse cloud sessions`
+- `browse cloud contexts`
+- `browse cloud extensions`
+- `browse cloud fetch`
+- `browse cloud search`
 
 Common flags:
 
@@ -61,33 +61,33 @@ Common flags:
 
 ### Functions commands
 
-`bb functions ...` is slightly different:
+`browse functions ...` is slightly different:
 
 - uses `--api-url <apiUrl>`, not `--base-url`
-- `bb functions dev` and `bb functions publish` also support `--project-id`
-- `bb functions invoke` does not expose `--project-id`
+- `browse functions dev` and `browse functions publish` also support `--project-id`
+- `browse functions invoke` does not expose `--project-id`
 
 ## Functions
 
 ### Initialize a project
 
 ```bash
-bb functions init my-function
-bb functions init my-function --package-manager npm
+browse functions init my-function
+browse functions init my-function --package-manager npm
 ```
 
 ### Run local development
 
 ```bash
-bb functions dev index.ts
-bb functions dev index.ts --port 14113 --host 127.0.0.1 --verbose
+browse functions dev index.ts
+browse functions dev index.ts --port 14113 --host 127.0.0.1 --verbose
 ```
 
 ### Publish
 
 ```bash
-bb functions publish index.ts
-bb functions publish index.ts --dry-run
+browse functions publish index.ts
+browse functions publish index.ts --dry-run
 ```
 
 Use `--dry-run` when you want to inspect what would be packaged without uploading.
@@ -95,9 +95,9 @@ Use `--dry-run` when you want to inspect what would be packaged without uploadin
 ### Invoke
 
 ```bash
-bb functions invoke <function_id> --params '{"url":"https://example.com"}'
-bb functions invoke <function_id> --no-wait
-bb functions invoke --check-status <invocation_id>
+browse functions invoke <function_id> --params '{"url":"https://example.com"}'
+browse functions invoke <function_id> --no-wait
+browse functions invoke --check-status <invocation_id>
 ```
 
 ## Platform APIs
@@ -105,28 +105,28 @@ bb functions invoke --check-status <invocation_id>
 ### Projects
 
 ```bash
-bb projects list
-bb projects get <project_id>
-bb projects usage <project_id>
+browse cloud projects list
+browse cloud projects get <project_id>
+browse cloud projects usage <project_id>
 ```
 
 ### Sessions
 
 ```bash
-bb sessions list
-bb sessions list --q "user_metadata['userId']:'123'"
-bb sessions get <session_id>
-bb sessions create --proxies --advanced-stealth
-bb sessions create --region us-east-1 --timeout 300
-bb sessions create --solve-captchas --context-id ctx_abc --persist
-bb sessions create --body '{"proxies":[{"type":"browserbase","geolocation":{"country":"US"}}]}'
-echo '{"proxies":true}' | bb sessions create --stdin
-bb sessions update <session_id> --status REQUEST_RELEASE
-bb sessions debug <session_id>
-bb sessions logs <session_id>
-bb sessions recording <session_id>
-bb sessions downloads get <session_id> --output session-artifacts.zip
-bb sessions uploads create <session_id> ./file.txt
+browse cloud sessions list
+browse cloud sessions list --q "user_metadata['userId']:'123'"
+browse cloud sessions get <session_id>
+browse cloud sessions create --proxies --advanced-stealth
+browse cloud sessions create --region us-east-1 --timeout 300
+browse cloud sessions create --solve-captchas --context-id ctx_abc --persist
+browse cloud sessions create --body '{"proxies":[{"type":"browserbase","geolocation":{"country":"US"}}]}'
+echo '{"proxies":true}' | browse cloud sessions create --stdin
+browse cloud sessions update <session_id> --status REQUEST_RELEASE
+browse cloud sessions debug <session_id>
+browse cloud sessions logs <session_id>
+browse cloud sessions recording <session_id>
+browse cloud sessions downloads get <session_id> --output session-artifacts.zip
+browse cloud sessions uploads create <session_id> ./file.txt
 ```
 
 #### `sessions create` flags
@@ -151,46 +151,46 @@ Use flags for common options instead of building `--body` JSON manually:
 | `--body <body>` | Full JSON request body (merged with flags) |
 | `--stdin` | Read JSON request body from stdin |
 
-When both `--status` and `--body` are present on `bb sessions update`, the CLI merges them.
+When both `--status` and `--body` are present on `browse cloud sessions update`, the CLI merges them.
 
 ### Contexts
 
 ```bash
-bb contexts create --body '{"region":"us-west-2"}'
-bb contexts get <context_id>
-bb contexts update <context_id>
-bb contexts delete <context_id>
+browse cloud contexts create --body '{"region":"us-west-2"}'
+browse cloud contexts get <context_id>
+browse cloud contexts update <context_id>
+browse cloud contexts delete <context_id>
 ```
 
 ### Extensions
 
 ```bash
-bb extensions upload ./my-extension.zip
-bb extensions get <extension_id>
-bb extensions delete <extension_id>
+browse cloud extensions upload ./my-extension.zip
+browse cloud extensions get <extension_id>
+browse cloud extensions delete <extension_id>
 ```
 
 ## Fetch API
 
-Use `bb fetch` when the user wants Browserbase Fetch specifically or wants the request to stay inside the CLI workflow.
+Use `browse cloud fetch` when the user wants Browserbase Fetch specifically or wants the request to stay inside the CLI workflow.
 
 ```bash
-bb fetch https://example.com
-bb fetch https://example.com --allow-redirects
-bb fetch https://self-signed.example.com --allow-insecure-ssl
-bb fetch https://example.com --proxies --output page.html
+browse cloud fetch https://example.com
+browse cloud fetch https://example.com --allow-redirects
+browse cloud fetch https://self-signed.example.com --allow-insecure-ssl
+browse cloud fetch https://example.com --proxies --output page.html
 ```
 
 Prefer the `browser` skill when the target page requires JavaScript execution or page interaction.
 
 ## Search API
 
-Use `bb search` to find web pages by query without opening a browser session.
+Use `browse cloud search` to find web pages by query without opening a browser session.
 
 ```bash
-bb search "browser automation"
-bb search "web scraping best practices" --num-results 5
-bb search "AI agents" --output results.json
+browse cloud search "browser automation"
+browse cloud search "web scraping best practices" --num-results 5
+browse cloud search "AI agents" --output results.json
 ```
 
 Returns structured results with titles, URLs, and optional metadata (author, published date). Use `--num-results` to control how many results are returned (1-25, default 10).
@@ -204,54 +204,47 @@ Browse and scaffold starter templates from the Browserbase templates repository.
 ### List templates
 
 ```bash
-bb templates list
-bb templates list --language python
-bb templates list --language typescript
+browse templates list
+browse templates list --language python
+browse templates list --language typescript
 ```
 
 ### Clone a template
 
 ```bash
-bb templates clone form-filling --language typescript
-bb templates clone amazon-product-scraping --language python ./my-scraper
+browse templates clone form-filling --language typescript
+browse templates clone amazon-product-scraping --language python ./my-scraper
 ```
 
 Arguments:
-- `<slug>` (required) — template name from `bb templates list`
+- `<slug>` (required) — template name from `browse templates list`
 - `[path]` (optional) — destination directory, defaults to the template slug
 
 Options:
 - `--language <language>` — `python` or `typescript`
 
-## Browse passthrough
+## Local & remote browser driving
 
-`bb browse ...` forwards arguments to the standalone `browse` binary (`@browserbasehq/browse-cli`). The examples below are `browse-cli` subcommands — they are not native `bb` commands:
-
-```bash
-bb browse env
-bb browse env local
-bb browse env local --auto-connect
-bb browse env remote
-bb browse status
-bb browse open https://example.com
-```
-
-`bb browse` mirrors the standalone `browse` binary exactly. For local work, `bb browse env local` starts a clean isolated browser by default. Use `bb browse env local --auto-connect` only when you need the agent to reuse an existing local Chrome session, cookies, or login state.
-
-If `browse` is not installed, the CLI will prompt you to install it:
+The same `browse` binary drives local and remote browsers directly. There is no separate package — top-level commands like `browse open`, `browse get`, `browse click`, `browse fill`, `browse press`, `browse screenshot`, `browse cdp` all live here.
 
 ```bash
-npm install -g @browserbasehq/browse-cli
+browse open https://example.com                            # default mode (clean local browser)
+browse open https://example.com --local --headless         # explicit local + headless
+browse open https://example.com --auto-connect             # reuse existing local Chrome session
+browse open https://example.com --remote                   # create a new Browserbase remote session
+browse open https://example.com --remote --session <id>    # attach to an existing remote session
+browse get markdown body                                   # extract the current page as markdown
+browse status                                              # show the active session
 ```
 
-For most interactive browsing tasks, prefer the dedicated `browser` skill instead of routing through `bb browse`.
+For most interactive browsing tasks, prefer the dedicated `browser` skill instead of routing through the CLI directly.
 
 ## Skills
 
 Install Browserbase agent skills for Claude Code directly from the CLI:
 
 ```bash
-bb skills install
+browse skills install
 ```
 
 This runs the skill installer non-interactively via npx.
@@ -259,7 +252,7 @@ This runs the skill installer non-interactively via npx.
 ## Troubleshooting
 
 - Missing API key: set `BROWSERBASE_API_KEY` or pass `--api-key`
-- Missing project ID on `bb functions dev` or `bb functions publish`: set `BROWSERBASE_PROJECT_ID` or pass `--project-id`
-- Wrong base URL flag: use `--api-url` for `bb functions ...`, `--base-url` for the other API commands
+- Missing project ID on `browse functions dev` or `browse functions publish`: set `BROWSERBASE_PROJECT_ID` or pass `--project-id`
+- Wrong base URL flag: use `--api-url` for `browse functions ...`, `--base-url` for the other API commands
 - Invalid JSON input: wrap `--body` and `--params` payloads in single quotes so the shell preserves the JSON string
-- Browse passthrough missing: install `@browserbasehq/browse-cli` or use the `browser` skill directly
+- Command not found: re-run `npm install -g browse` and verify with `which browse`

--- a/skills/browserbase-cli/REFERENCE.md
+++ b/skills/browserbase-cli/REFERENCE.md
@@ -63,9 +63,8 @@ Common flags:
 
 `browse functions ...` is slightly different:
 
-- uses `--api-url <apiUrl>`, not `--base-url`
-- `browse functions dev` and `browse functions publish` also support `--project-id`
-- `browse functions invoke` does not expose `--project-id`
+- uses `--base-url <baseUrl>` for API base URL overrides
+- reads the API key and project from environment variables by default
 
 ## Functions
 
@@ -116,7 +115,7 @@ browse cloud projects usage <project_id>
 browse cloud sessions list
 browse cloud sessions list --q "user_metadata['userId']:'123'"
 browse cloud sessions get <session_id>
-browse cloud sessions create --proxies --advanced-stealth
+browse cloud sessions create --proxies --verified
 browse cloud sessions create --region us-east-1 --timeout 300
 browse cloud sessions create --solve-captchas --context-id ctx_abc --persist
 browse cloud sessions create --body '{"proxies":[{"type":"browserbase","geolocation":{"country":"US"}}]}'
@@ -124,7 +123,6 @@ echo '{"proxies":true}' | browse cloud sessions create --stdin
 browse cloud sessions update <session_id> --status REQUEST_RELEASE
 browse cloud sessions debug <session_id>
 browse cloud sessions logs <session_id>
-browse cloud sessions recording <session_id>
 browse cloud sessions downloads get <session_id> --output session-artifacts.zip
 browse cloud sessions uploads create <session_id> ./file.txt
 ```
@@ -136,7 +134,7 @@ Use flags for common options instead of building `--body` JSON manually:
 | Flag | Description |
 |------|-------------|
 | `--proxies` | Enable Browserbase proxy |
-| `--advanced-stealth` | Enable advanced stealth mode |
+| `--verified` | Enable Browserbase Verified browser mode |
 | `--solve-captchas` / `--no-solve-captchas` | Toggle automatic CAPTCHA solving |
 | `--block-ads` | Enable ad blocking |
 | `--region <region>` | Session region (`us-west-2`, `us-east-1`, `eu-central-1`, `ap-southeast-1`) |
@@ -205,8 +203,8 @@ Browse and scaffold starter templates from the Browserbase templates repository.
 
 ```bash
 browse templates list
-browse templates list --language python
-browse templates list --language typescript
+browse templates list --tag Python --source Browserbase
+browse templates list --tag TypeScript --source Browserbase
 ```
 
 ### Clone a template
@@ -252,7 +250,7 @@ This runs the skill installer non-interactively via npx.
 ## Troubleshooting
 
 - Missing API key: set `BROWSERBASE_API_KEY` or pass `--api-key`
-- Missing project ID on `browse functions dev` or `browse functions publish`: set `BROWSERBASE_PROJECT_ID` or pass `--project-id`
-- Wrong base URL flag: use `--api-url` for `browse functions ...`, `--base-url` for the other API commands
+- Missing project ID on `browse functions dev` or `browse functions publish`: set `BROWSERBASE_PROJECT_ID`
+- Wrong base URL flag: use `--base-url` for both `browse functions ...` and `browse cloud ...`
 - Invalid JSON input: wrap `--body` and `--params` payloads in single quotes so the shell preserves the JSON string
 - Command not found: re-run `npm install -g browse` and verify with `which browse`

--- a/skills/browserbase-cli/REFERENCE.md
+++ b/skills/browserbase-cli/REFERENCE.md
@@ -37,12 +37,6 @@ All authenticated commands require an API key:
 export BROWSERBASE_API_KEY="your_api_key"
 ```
 
-Only `browse functions dev` and `browse functions publish` require a project ID:
-
-```bash
-export BROWSERBASE_PROJECT_ID="your_project_id"
-```
-
 ### Platform API commands
 
 These command groups share a common flag shape:
@@ -227,11 +221,12 @@ Options:
 Top-level `browse` commands drive local and remote browsers directly: `browse open`, `browse get`, `browse click`, `browse fill`, `browse press`, `browse screenshot`, and `browse cdp`.
 
 ```bash
-browse open https://example.com                            # default mode (clean local browser)
+browse open https://example.com                            # default mode from env
 browse open https://example.com --local --headless         # explicit local + headless
-browse open https://example.com --auto-connect             # reuse existing local Chrome session
+browse open https://example.com --auto-connect             # attach to existing debuggable Chrome
 browse open https://example.com --remote                   # create a new Browserbase remote session
-browse open https://example.com --remote --session <id>    # attach to an existing remote session
+browse open https://example.com --remote --session research # use a named browse daemon session
+browse open https://example.com --cdp "$CONNECT_URL"       # attach to a pre-created CDP endpoint
 browse get markdown body                                   # extract the current page as markdown
 browse status                                              # show the active session
 ```
@@ -251,7 +246,6 @@ This runs the skill installer non-interactively via npx.
 ## Troubleshooting
 
 - Missing API key: set `BROWSERBASE_API_KEY` or pass `--api-key`
-- Missing project ID on `browse functions dev` or `browse functions publish`: set `BROWSERBASE_PROJECT_ID`
 - Wrong base URL flag: use `--base-url` for both `browse functions ...` and `browse cloud ...`
 - Invalid JSON input: wrap `--body` and `--params` payloads in single quotes so the shell preserves the JSON string
 - Command not found: re-run `npm install -g browse` and verify with `which browse`

--- a/skills/browserbase-cli/REFERENCE.md
+++ b/skills/browserbase-cli/REFERENCE.md
@@ -224,7 +224,7 @@ Options:
 
 ## Local & remote browser driving
 
-The same `browse` binary drives local and remote browsers directly. There is no separate package — top-level commands like `browse open`, `browse get`, `browse click`, `browse fill`, `browse press`, `browse screenshot`, `browse cdp` all live here.
+Top-level `browse` commands drive local and remote browsers directly: `browse open`, `browse get`, `browse click`, `browse fill`, `browse press`, `browse screenshot`, and `browse cdp`.
 
 ```bash
 browse open https://example.com                            # default mode (clean local browser)

--- a/skills/browserbase-cli/SKILL.md
+++ b/skills/browserbase-cli/SKILL.md
@@ -55,7 +55,7 @@ Use this skill when the user wants to:
 - `browse cloud fetch <url>` for Fetch API requests
 - `browse cloud search "<query>"` for Search API requests
 - `browse templates` to browse and scaffold starter templates
-- `browse open`, `browse get`, `browse click`, etc. for direct local/remote browser driving (no separate package required — same binary)
+- `browse open`, `browse get`, `browse click`, etc. for direct local/remote browser driving
 - `browse skills install` to install Browserbase agent skills for Claude Code
 
 For local browser work, `browse open <url> --local` starts a clean isolated browser by default. Use `browse open <url> --auto-connect` only when you need to reuse an existing local Chrome session, cookies, or login state.
@@ -118,7 +118,6 @@ browse templates clone amazon-product-scraping --language python ./my-scraper
 4. Use environment variables for auth unless the user explicitly wants one-off overrides.
 5. Pass structured request bodies with JSON strings in `--body` or `--params`.
 6. Remember that both `browse functions ...` and `browse cloud ...` use `--base-url` for API base URL overrides.
-7. The driver and cloud commands ship in the same `browse` binary — no separate install required.
 
 ## Troubleshooting
 

--- a/skills/browserbase-cli/SKILL.md
+++ b/skills/browserbase-cli/SKILL.md
@@ -1,22 +1,22 @@
 ---
 name: browserbase-cli
-description: Use the Browserbase CLI (`bb`) for Browserbase Functions and platform API workflows. Use when the user asks to run `bb`, deploy or invoke functions, manage sessions, projects, contexts, or extensions, fetch a page through the Browserbase Fetch API, search the web through the Browserbase Search API, or scaffold starter templates. Prefer the Browser skill for interactive browsing; use `bb browse` only when the user explicitly wants the Browserbase CLI path.
-compatibility: "Requires the Browserbase CLI (`npm install -g @browserbasehq/cli`). API commands require `BROWSERBASE_API_KEY`. `BROWSERBASE_PROJECT_ID` is only needed for `bb functions dev` and `bb functions publish`. `bb browse` additionally requires `npm install -g @browserbasehq/browse-cli`."
+description: Use the Browserbase CLI (`browse`) for Browserbase Functions and platform API workflows. Use when the user asks to run `browse`, deploy or invoke functions, manage sessions, projects, contexts, or extensions, fetch a page through the Browserbase Fetch API, search the web through the Browserbase Search API, or scaffold starter templates. Prefer the Browser skill for interactive browsing; use the top-level `browse` driver commands (`browse open`, `browse get`, etc.) only when the user explicitly wants the CLI path.
+compatibility: "Requires the Browserbase CLI (`npm install -g browse`). API commands require `BROWSERBASE_API_KEY`. `BROWSERBASE_PROJECT_ID` is only needed for `browse functions dev` and `browse functions publish`."
 license: MIT
 allowed-tools: Bash
 ---
 
 # Browserbase CLI
 
-Use the official `bb` CLI for Browserbase platform operations, Functions workflows, and Fetch API calls.
+Use the official `browse` CLI for Browserbase platform operations, Functions workflows, and Fetch API calls.
 
 ## Setup check
 
 Before using the CLI, verify it is installed:
 
 ```bash
-which bb || npm install -g @browserbasehq/cli
-bb --help
+which browse || npm install -g browse
+browse --help
 ```
 
 For authenticated commands, set the API key:
@@ -25,7 +25,7 @@ For authenticated commands, set the API key:
 export BROWSERBASE_API_KEY="your_api_key"
 ```
 
-If using `bb functions dev` or `bb functions publish`, also set:
+If using `browse functions dev` or `browse functions publish`, also set:
 
 ```bash
 export BROWSERBASE_PROJECT_ID="your_project_id"
@@ -35,96 +35,96 @@ export BROWSERBASE_PROJECT_ID="your_project_id"
 
 Use this skill when the user wants to:
 
-- run Browserbase commands through `bb`
+- run Browserbase commands through `browse`
 - scaffold, develop, publish, or invoke Browserbase Functions
 - inspect or manage Browserbase sessions, projects, contexts, or extensions
 - fetch a page through Browserbase without opening a browser session
 - search the web through Browserbase without opening a browser session
-- browse or scaffold starter templates with `bb templates`
+- browse or scaffold starter templates with `browse templates`
 
 ## When not to use this skill
 
 - For interactive browsing, page inspection, screenshots, clicking, typing, or login flows, prefer the `browser` skill.
 - For simple HTTP content retrieval where the user does not care about using the CLI specifically, the dedicated `fetch` skill is often a better fit.
-- Use `bb browse ...` only when the user explicitly wants the CLI wrapper or is already working in a `bb`-centric workflow.
+- Use the top-level driver commands (`browse open`, `browse get`, `browse click`, …) only when the user explicitly wants the CLI path or is already working in a `browse`-centric workflow.
 
 ## Command selection
 
-- `bb functions` for local dev, packaging, publishing, and invocation
-- `bb sessions`, `bb projects`, `bb contexts`, `bb extensions` for Browserbase platform resources
-- `bb fetch <url>` for Fetch API requests
-- `bb search "<query>"` for Search API requests
-- `bb templates` to browse and scaffold starter templates
-- `bb browse ...` to forward to the standalone `browse` binary (requires `@browserbasehq/browse-cli`)
-- `bb skills install` to install Browserbase agent skills for Claude Code
+- `browse functions` for local dev, packaging, publishing, and invocation
+- `browse cloud sessions`, `browse cloud projects`, `browse cloud contexts`, `browse cloud extensions` for Browserbase platform resources
+- `browse cloud fetch <url>` for Fetch API requests
+- `browse cloud search "<query>"` for Search API requests
+- `browse templates` to browse and scaffold starter templates
+- `browse open`, `browse get`, `browse click`, etc. for direct local/remote browser driving (no separate package required — same binary)
+- `browse skills install` to install Browserbase agent skills for Claude Code
 
-For `bb browse`, the standalone `browse` CLI behavior is the source of truth: `bb browse env local` uses a clean isolated local browser by default, and `bb browse env local --auto-connect` opts into reusing an existing local Chrome session.
+For local browser work, `browse open <url> --local` starts a clean isolated browser by default. Use `browse open <url> --auto-connect` only when you need to reuse an existing local Chrome session, cookies, or login state.
 
 ## Common workflows
 
 ### Functions
 
 ```bash
-bb functions init my-function
+browse functions init my-function
 cd my-function
-bb functions dev index.ts
-bb functions publish index.ts
-bb functions invoke <function_id> --params '{"url":"https://example.com"}'
+browse functions dev index.ts
+browse functions publish index.ts
+browse functions invoke <function_id> --params '{"url":"https://example.com"}'
 ```
 
-Use `bb functions invoke --check-status <invocation_id>` to poll an existing invocation instead of creating a new one.
+Use `browse functions invoke --check-status <invocation_id>` to poll an existing invocation instead of creating a new one.
 
 ### Platform APIs
 
 ```bash
-bb projects list
-bb sessions create --proxies --advanced-stealth --region us-east-1
-bb sessions create --solve-captchas --context-id ctx_abc --persist
-bb sessions get <session_id>
-bb sessions downloads get <session_id> --output session-artifacts.zip
-bb contexts create --body '{"region":"us-west-2"}'
-bb extensions upload ./my-extension.zip
+browse cloud projects list
+browse cloud sessions create --proxies --advanced-stealth --region us-east-1
+browse cloud sessions create --solve-captchas --context-id ctx_abc --persist
+browse cloud sessions get <session_id>
+browse cloud sessions downloads get <session_id> --output session-artifacts.zip
+browse cloud contexts create --body '{"region":"us-west-2"}'
+browse cloud extensions upload ./my-extension.zip
 ```
 
 ### Fetch API
 
 ```bash
-bb fetch https://example.com
-bb fetch https://example.com --allow-redirects --output page.html
+browse cloud fetch https://example.com
+browse cloud fetch https://example.com --allow-redirects --output page.html
 ```
 
 ### Search API
 
 ```bash
-bb search "browser automation"
-bb search "web scraping" --num-results 5
-bb search "AI agents" --output results.json
+browse cloud search "browser automation"
+browse cloud search "web scraping" --num-results 5
+browse cloud search "AI agents" --output results.json
 ```
 
 ### Templates
 
 ```bash
-bb templates list
-bb templates list --language python
-bb templates clone form-filling --language typescript
-bb templates clone amazon-product-scraping --language python ./my-scraper
+browse templates list
+browse templates list --language python
+browse templates clone form-filling --language typescript
+browse templates clone amazon-product-scraping --language python ./my-scraper
 ```
 
 ## Best practices
 
-1. Prefer `bb --help` and subgroup `--help` before guessing flags.
+1. Prefer `browse --help` and subgroup `--help` before guessing flags.
 2. Use dash-case flags exactly as shown in CLI help.
-3. Use `--output <file>` on `bb fetch` and `bb search` to save results to a file.
+3. Use `--output <file>` on `browse cloud fetch` and `browse cloud search` to save results to a file.
 4. Use environment variables for auth unless the user explicitly wants one-off overrides.
 5. Pass structured request bodies with JSON strings in `--body` or `--params`.
-6. Remember that `bb functions ...` uses `--api-url`, while platform API commands use `--base-url`.
-7. If `bb browse` fails because `browse` is missing, either install `@browserbasehq/browse-cli` or switch to the `browser` skill.
+6. Remember that `browse functions ...` uses `--api-url`, while `browse cloud ...` commands use `--base-url`.
+7. The driver and cloud commands ship in the same `browse` binary — no separate install required.
 
 ## Troubleshooting
 
 - Missing API key: set `BROWSERBASE_API_KEY` or pass `--api-key`
-- Missing project ID on `bb functions dev` or `bb functions publish`: set `BROWSERBASE_PROJECT_ID` or pass `--project-id`
+- Missing project ID on `browse functions dev` or `browse functions publish`: set `BROWSERBASE_PROJECT_ID` or pass `--project-id`
 - Unknown flag: rerun the relevant command with `--help` and use the exact dash-case form
-- `bb browse` install error: run `npm install -g @browserbasehq/browse-cli`
+- Command not found: re-run `npm install -g browse` and verify with `which browse`
 
 For command-by-command reference and more examples, see [REFERENCE.md](REFERENCE.md).

--- a/skills/browserbase-cli/SKILL.md
+++ b/skills/browserbase-cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: browserbase-cli
 description: Use the Browserbase CLI (`browse`) for Browserbase Functions and platform API workflows. Use when the user asks to run `browse`, deploy or invoke functions, manage sessions, projects, contexts, or extensions, fetch a page through the Browserbase Fetch API, search the web through the Browserbase Search API, or scaffold starter templates. Prefer the Browser skill for interactive browsing; use the top-level `browse` driver commands (`browse open`, `browse get`, etc.) only when the user explicitly wants the CLI path.
-compatibility: "Requires the Browserbase CLI (`npm install -g browse`). API commands require `BROWSERBASE_API_KEY`. `BROWSERBASE_PROJECT_ID` is only needed for `browse functions dev` and `browse functions publish`."
+compatibility: "Requires the Browserbase CLI (`npm install -g browse`). API commands require `BROWSERBASE_API_KEY`."
 license: MIT
 allowed-tools: Bash
 ---
@@ -23,12 +23,6 @@ For authenticated commands, set the API key:
 
 ```bash
 export BROWSERBASE_API_KEY="your_api_key"
-```
-
-If using `browse functions dev` or `browse functions publish`, also set:
-
-```bash
-export BROWSERBASE_PROJECT_ID="your_project_id"
 ```
 
 ## When to use this skill
@@ -58,7 +52,7 @@ Use this skill when the user wants to:
 - `browse open`, `browse get`, `browse click`, etc. for direct local/remote browser driving
 - `browse skills install` to install Browserbase agent skills for Claude Code
 
-For local browser work, `browse open <url> --local` starts a clean isolated browser by default. Use `browse open <url> --auto-connect` only when you need to reuse an existing local Chrome session, cookies, or login state.
+For local browser work, `browse open <url> --local` starts a clean isolated browser. Use `browse open <url> --auto-connect` only when you need to attach to an existing debuggable Chrome session.
 
 ## Common workflows
 
@@ -122,7 +116,6 @@ browse templates clone amazon-product-scraping --language python ./my-scraper
 ## Troubleshooting
 
 - Missing API key: set `BROWSERBASE_API_KEY` or pass `--api-key`
-- Missing project ID on `browse functions dev` or `browse functions publish`: set `BROWSERBASE_PROJECT_ID`
 - Unknown flag: rerun the relevant command with `--help` and use the exact dash-case form
 - Command not found: re-run `npm install -g browse` and verify with `which browse`
 

--- a/skills/browserbase-cli/SKILL.md
+++ b/skills/browserbase-cli/SKILL.md
@@ -78,7 +78,7 @@ Use `browse functions invoke --check-status <invocation_id>` to poll an existing
 
 ```bash
 browse cloud projects list
-browse cloud sessions create --proxies --advanced-stealth --region us-east-1
+browse cloud sessions create --proxies --verified --region us-east-1
 browse cloud sessions create --solve-captchas --context-id ctx_abc --persist
 browse cloud sessions get <session_id>
 browse cloud sessions downloads get <session_id> --output session-artifacts.zip
@@ -105,7 +105,7 @@ browse cloud search "AI agents" --output results.json
 
 ```bash
 browse templates list
-browse templates list --language python
+browse templates list --tag Python --source Browserbase
 browse templates clone form-filling --language typescript
 browse templates clone amazon-product-scraping --language python ./my-scraper
 ```
@@ -117,13 +117,13 @@ browse templates clone amazon-product-scraping --language python ./my-scraper
 3. Use `--output <file>` on `browse cloud fetch` and `browse cloud search` to save results to a file.
 4. Use environment variables for auth unless the user explicitly wants one-off overrides.
 5. Pass structured request bodies with JSON strings in `--body` or `--params`.
-6. Remember that `browse functions ...` uses `--api-url`, while `browse cloud ...` commands use `--base-url`.
+6. Remember that both `browse functions ...` and `browse cloud ...` use `--base-url` for API base URL overrides.
 7. The driver and cloud commands ship in the same `browse` binary — no separate install required.
 
 ## Troubleshooting
 
 - Missing API key: set `BROWSERBASE_API_KEY` or pass `--api-key`
-- Missing project ID on `browse functions dev` or `browse functions publish`: set `BROWSERBASE_PROJECT_ID` or pass `--project-id`
+- Missing project ID on `browse functions dev` or `browse functions publish`: set `BROWSERBASE_PROJECT_ID`
 - Unknown flag: rerun the relevant command with `--help` and use the exact dash-case form
 - Command not found: re-run `npm install -g browse` and verify with `which browse`
 

--- a/skills/company-research/SKILL.md
+++ b/skills/company-research/SKILL.md
@@ -37,7 +37,7 @@ Discover and deeply research companies to sell to. Uses Browserbase Search API f
 
 **CRITICAL — Tool restrictions (applies to main agent AND all subagents)**:
 - All web searches: use `browse cloud search`. NEVER use WebSearch.
-- All page content extraction: use `node {SKILL_DIR}/scripts/extract_page.mjs "<url>"`. This script fetches via `browse cloud fetch`, parses title + meta tags + visible body text, and automatically falls back to `browse get markdown` when the page is JS-rendered or over 1MB. NEVER hand-roll a `browse cloud fetch | sed` pipeline — it silently strips meta tags and doesn't handle the JSON envelope. NEVER use WebFetch.
+- All page content extraction: use `node {SKILL_DIR}/scripts/extract_page.mjs "<url>"`. This script fetches via `browse cloud fetch --output`, parses title + meta tags + visible body text, and automatically falls back to `browse get markdown` when fetch fails or returns thin JS-rendered content. NEVER hand-roll a `browse cloud fetch | sed` pipeline — it strips meta tags and doesn't parse the stdout JSON envelope. NEVER use WebFetch.
 - All research output: subagents write **one markdown file per company** to `{OUTPUT_DIR}/{company-slug}.md` using bash heredoc. NEVER use the Write tool or `python3 -c`. See `references/example-research.md` for the file format.
 - Report + CSV compilation: use `node {SKILL_DIR}/scripts/compile_report.mjs {OUTPUT_DIR} --open` — generates HTML report and CSV in one step, opens overview in browser.
 - URL deduplication: use `node {SKILL_DIR}/scripts/list_urls.mjs /tmp` after discovery.

--- a/skills/company-research/SKILL.md
+++ b/skills/company-research/SKILL.md
@@ -12,7 +12,7 @@ description: |
   "company research", "find prospects", "ICP research", "target companies",
   "who should we sell to", "market research", "lead research", "prospect list".
 license: MIT
-compatibility: Requires bb CLI (@browserbasehq/cli) and BROWSERBASE_API_KEY env var
+compatibility: Requires browse CLI (`npm install -g browse`) and BROWSERBASE_API_KEY env var
 allowed-tools: Bash Agent
 metadata:
   author: browserbase
@@ -23,11 +23,11 @@ metadata:
 
 Discover and deeply research companies to sell to. Uses Browserbase Search API for discovery and a Plan→Research→Synthesize pattern for deep enrichment — outputting a scored research report and CSV.
 
-**Required**: `BROWSERBASE_API_KEY` env var and `bb` CLI installed.
+**Required**: `BROWSERBASE_API_KEY` env var and `browse` CLI installed.
 
-**First-run setup**: On the first run you'll be prompted to approve `bb fetch`, `bb search`, `cat`, `mkdir`, `sed`, etc. Select **"Yes, and don't ask again for: bb fetch:\*"** (or equivalent) for each to auto-approve for the session. To permanently approve, add these to your `~/.claude/settings.json` under `permissions.allow`:
+**First-run setup**: On the first run you'll be prompted to approve `browse cloud fetch`, `browse cloud search`, `cat`, `mkdir`, `sed`, etc. Select **"Yes, and don't ask again for: browse cloud fetch:\*"** (or equivalent) for each to auto-approve for the session. To permanently approve, add these to your `~/.claude/settings.json` under `permissions.allow`:
 ```json
-"Bash(bb:*)", "Bash(bunx:*)", "Bash(bun:*)", "Bash(node:*)",
+"Bash(browse:*)", "Bash(bunx:*)", "Bash(bun:*)", "Bash(node:*)",
 "Bash(cat:*)", "Bash(mkdir:*)", "Bash(sed:*)", "Bash(head:*)", "Bash(tr:*)", "Bash(rm:*)"
 ```
 
@@ -36,8 +36,8 @@ Discover and deeply research companies to sell to. Uses Browserbase Search API f
 **Output directory**: All research output goes to `~/Desktop/{company_slug}_research_{YYYY-MM-DD}/`. This directory contains one `.md` file per researched company plus a final `.csv`. The user gets both the scored spreadsheet and the full research files on their Desktop.
 
 **CRITICAL — Tool restrictions (applies to main agent AND all subagents)**:
-- All web searches: use `bb search`. NEVER use WebSearch.
-- All page content extraction: use `node {SKILL_DIR}/scripts/extract_page.mjs "<url>"`. This script fetches via `bb fetch`, parses title + meta tags + visible body text, and automatically falls back to `bb browse` when the page is JS-rendered or over 1MB. NEVER hand-roll a `bb fetch | sed` pipeline — it silently strips meta tags and doesn't handle the JSON envelope. NEVER use WebFetch.
+- All web searches: use `browse cloud search`. NEVER use WebSearch.
+- All page content extraction: use `node {SKILL_DIR}/scripts/extract_page.mjs "<url>"`. This script fetches via `browse cloud fetch`, parses title + meta tags + visible body text, and automatically falls back to `browse get markdown` when the page is JS-rendered or over 1MB. NEVER hand-roll a `browse cloud fetch | sed` pipeline — it silently strips meta tags and doesn't handle the JSON envelope. NEVER use WebFetch.
 - All research output: subagents write **one markdown file per company** to `{OUTPUT_DIR}/{company-slug}.md` using bash heredoc. NEVER use the Write tool or `python3 -c`. See `references/example-research.md` for the file format.
 - Report + CSV compilation: use `node {SKILL_DIR}/scripts/compile_report.mjs {OUTPUT_DIR} --open` — generates HTML report and CSV in one step, opens overview in browser.
 - URL deduplication: use `node {SKILL_DIR}/scripts/list_urls.mjs /tmp` after discovery.
@@ -97,13 +97,13 @@ This is the most important step. The quality of everything downstream depends on
    See `references/research-patterns.md` for sub-question templates and research methodology.
 
    **Key research steps:**
-   - Search: `bb search "{company name}" --num-results 10`
+   - Search: `browse cloud search "{company name}" --num-results 10`
    - Fetch homepage: `node {SKILL_DIR}/scripts/extract_page.mjs "{company website}"`
    - **Discover site pages via sitemap** (do NOT hardcode paths like `/about` or `/customers`):
-     1. `bb fetch --allow-redirects "{company website}/sitemap.xml"` — sitemap is small, raw `bb fetch` is fine
+     1. `browse cloud fetch --allow-redirects "{company website}/sitemap.xml"` — sitemap is small, raw `browse cloud fetch` is fine
      2. Scan for URLs with keywords: `customer`, `case-stud`, `pricing`, `about`, `use-case`, `industry`, `solution`
      3. Optionally also fetch `/llms.txt` for page descriptions
-     4. Pick 3-5 most relevant URLs and extract with `extract_page.mjs` (NOT raw `bb fetch`)
+     4. Pick 3-5 most relevant URLs and extract with `extract_page.mjs` (NOT raw `browse cloud fetch`)
    - Search for external context and competitors
    - Accumulate findings with confidence levels
 
@@ -142,7 +142,7 @@ Generate search queries with these patterns:
 **Process**:
 1. Launch ALL discovery subagents at once (up to ~6 per message). Each runs its queries in a SINGLE Bash call:
    ```bash
-   bb search "{query}" --num-results 25 --output /tmp/company_discovery_batch_{N}.json
+   browse cloud search "{query}" --num-results 25 --output /tmp/company_discovery_batch_{N}.json
    ```
 2. After all waves complete, deduplicate: `node {SKILL_DIR}/scripts/list_urls.mjs /tmp`
 3. **Filter the URL list** — remove:

--- a/skills/company-research/references/research-patterns.md
+++ b/skills/company-research/references/research-patterns.md
@@ -21,9 +21,9 @@ This is the most important research in the pipeline. Every downstream decision d
 
 ### Page Discovery
 Discover site pages dynamically — do NOT hardcode paths like `/about` or `/customers`:
-1. Fetch `bb fetch --allow-redirects "{company website}/sitemap.xml"` — primary source, has ALL pages
+1. Fetch `browse cloud fetch --allow-redirects "{company website}/sitemap.xml"` — primary source, has ALL pages
 2. Scan sitemap URLs for keywords: `customer`, `case-stud`, `pricing`, `about`, `use-case`, `blog`, `docs`, `industry`, `solution`
-3. Optionally fetch `bb fetch --allow-redirects "{company website}/llms.txt"` for page descriptions
+3. Optionally fetch `browse cloud fetch --allow-redirects "{company website}/llms.txt"` for page descriptions
 4. Pick the 3-5 most relevant URLs from the sitemap and fetch those
 5. Sitemap is the source of truth. llms.txt is bonus context but often incomplete.
 

--- a/skills/company-research/references/workflow.md
+++ b/skills/company-research/references/workflow.md
@@ -4,7 +4,7 @@
 
 File: `/tmp/company_discovery_batch_{N}.json`
 
-`bb search --output` writes a JSON object (NOT a flat array):
+`browse cloud search --output` writes a JSON object (NOT a flat array):
 
 ```json
 {
@@ -48,7 +48,7 @@ Each research subagent writes one markdown file per company. See `references/exa
 
 ## Extracting Page Content
 
-Use `extract_page.mjs` for all homepage/product-page content extraction. It fetches via `bb fetch`, parses title + meta + visible body text, and falls back to `bb browse` automatically when the page is JS-rendered or too large for fetch:
+Use `extract_page.mjs` for all homepage/product-page content extraction. It fetches via `browse cloud fetch`, parses title + meta + visible body text, and falls back to `browse get markdown` automatically when the page is JS-rendered or too large for fetch:
 
 ```bash
 node {SKILL_DIR}/scripts/extract_page.mjs "https://example.com" --max-chars 3000
@@ -69,9 +69,9 @@ BODY:
 <cleaned visible text, max N chars>
 ```
 
-**Why not a raw `bb fetch | sed` pipeline?** `bb fetch` returns a JSON envelope with the HTML embedded as an escaped string — a naive sed pipeline strips `<>` from the JSON wrapper too and destroys the content. It also strips `<meta>` tags, which on Framer/Next.js SPAs are often the only readable content. `extract_page.mjs` handles both correctly.
+**Why not a raw `browse cloud fetch | sed` pipeline?** `browse cloud fetch` returns a JSON envelope with the HTML embedded as an escaped string — a naive sed pipeline strips `<>` from the JSON wrapper too and destroys the content. It also strips `<meta>` tags, which on Framer/Next.js SPAs are often the only readable content. `extract_page.mjs` handles both correctly.
 
-**When to use raw `bb fetch`**: Only for small structured files where you want the JSON envelope intact — e.g. `sitemap.xml`, `robots.txt`, `llms.txt`. For any HTML page you'd feed to a model, use `extract_page.mjs`.
+**When to use raw `browse cloud fetch`**: Only for small structured files where you want the JSON envelope intact — e.g. `sitemap.xml`, `robots.txt`, `llms.txt`. For any HTML page you'd feed to a model, use `extract_page.mjs`.
 
 ## Verifying content is real (not hallucinated)
 
@@ -99,9 +99,9 @@ TOOL RULES — CRITICAL, FOLLOW EXACTLY:
 TASK:
 Run ALL of the following searches in ONE Bash command:
 
-bb search "{query1}" --num-results 25 --output /tmp/company_discovery_batch_{N1}.json && \
-bb search "{query2}" --num-results 25 --output /tmp/company_discovery_batch_{N2}.json && \
-bb search "{query3}" --num-results 25 --output /tmp/company_discovery_batch_{N3}.json && \
+browse cloud search "{query1}" --num-results 25 --output /tmp/company_discovery_batch_{N1}.json && \
+browse cloud search "{query2}" --num-results 25 --output /tmp/company_discovery_batch_{N2}.json && \
+browse cloud search "{query3}" --num-results 25 --output /tmp/company_discovery_batch_{N3}.json && \
 echo "Discovery complete"
 
 After the command completes, report back ONLY the count of results found per batch.
@@ -125,11 +125,11 @@ URLS TO PROCESS:
 
 TOOL RULES — CRITICAL, FOLLOW EXACTLY:
 1. You may ONLY use the Bash tool. No exceptions.
-2. All searches: Bash → bb search "..." --num-results 10
+2. All searches: Bash → browse cloud search "..." --num-results 10
 3. All homepage/product-page content extraction:
    Bash → node {SKILL_DIR}/scripts/extract_page.mjs "URL" --max-chars 3000
-   This returns structured TITLE / META_DESCRIPTION / OG_DESCRIPTION / HEADINGS / BODY and auto-falls back to bb browse for JS-rendered or >1MB pages.
-   DO NOT hand-roll a `bb fetch | sed` pipeline — it silently strips meta tags and doesn't parse the JSON envelope. Use `bb fetch` raw only for sitemap.xml, robots.txt, llms.txt.
+   This returns structured TITLE / META_DESCRIPTION / OG_DESCRIPTION / HEADINGS / BODY and auto-falls back to browse get markdown for JS-rendered or >1MB pages.
+   DO NOT hand-roll a `browse cloud fetch | sed` pipeline — it silently strips meta tags and doesn't parse the JSON envelope. Use `browse cloud fetch` raw only for sitemap.xml, robots.txt, llms.txt.
 4. BATCH all file writes: Write ALL markdown files in a SINGLE Bash call using chained heredocs (one permission prompt, not one per file).
 5. BANNED TOOLS: WebFetch, WebSearch, Write, Read, Glob, Grep — ALL BANNED.
    If you use ANY banned tool, the entire run fails. Use ONLY Bash.
@@ -147,11 +147,11 @@ Decompose what you need to know into sub-questions based on ICP and enrichment f
 
 Phase B — Research Loop:
 For each sub-question (or just the homepage in quick mode):
-1. Run bb search with relevant query
+1. Run browse cloud search with relevant query
 2. Pick 1-2 most relevant URLs from results
 3. Extract page content: node {SKILL_DIR}/scripts/extract_page.mjs "URL" --max-chars 3000
-   (auto-handles the JSON envelope, meta tags, and the bb browse fallback)
-4. Smart page discovery: use `bb fetch --allow-redirects` on /sitemap.xml or /llms.txt to find relevant URLs — these are small XML/text files where the raw JSON envelope is fine. For the actual HTML pages you discover, use extract_page.mjs.
+   (auto-handles the JSON envelope, meta tags, and the browse get markdown fallback)
+4. Smart page discovery: use `browse cloud fetch --allow-redirects` on /sitemap.xml or /llms.txt to find relevant URLs — these are small XML/text files where the raw JSON envelope is fine. For the actual HTML pages you discover, use extract_page.mjs.
 5. Extract findings: factual statements with source, confidence level
 6. Accumulate findings, move to next sub-question
 7. Respect step budget: quick=2-3 calls, deep=5-8, deeper=10-15
@@ -235,7 +235,7 @@ deeper: research_subagents = ceil(expected_urls / 3)
 ### Error Handling
 - If a subagent fails, log the error and continue with remaining batches
 - If >50% of subagents fail in a wave, pause and inform the user
-- `extract_page.mjs` already handles the bb fetch → bb browse fallback internally. If it still returns FETCH_OK: false with empty BODY, skip the company and mark product_description as Unknown (do not guess).
+- `extract_page.mjs` already handles the browse cloud fetch → browse get markdown fallback internally. If it still returns FETCH_OK: false with empty BODY, skip the company and mark product_description as Unknown (do not guess).
 
 ## Report + CSV Compilation
 

--- a/skills/company-research/references/workflow.md
+++ b/skills/company-research/references/workflow.md
@@ -48,7 +48,7 @@ Each research subagent writes one markdown file per company. See `references/exa
 
 ## Extracting Page Content
 
-Use `extract_page.mjs` for all homepage/product-page content extraction. It fetches via `browse cloud fetch`, parses title + meta + visible body text, and falls back to `browse get markdown` automatically when the page is JS-rendered or too large for fetch:
+Use `extract_page.mjs` for all homepage/product-page content extraction. It fetches via `browse cloud fetch --output`, parses title + meta + visible body text, and falls back to `browse get markdown` automatically when fetch fails or returns thin JS-rendered content:
 
 ```bash
 node {SKILL_DIR}/scripts/extract_page.mjs "https://example.com" --max-chars 3000
@@ -69,7 +69,7 @@ BODY:
 <cleaned visible text, max N chars>
 ```
 
-**Why not a raw `browse cloud fetch | sed` pipeline?** `browse cloud fetch` returns a JSON envelope with the HTML embedded as an escaped string — a naive sed pipeline strips `<>` from the JSON wrapper too and destroys the content. It also strips `<meta>` tags, which on Framer/Next.js SPAs are often the only readable content. `extract_page.mjs` handles both correctly.
+**Why not a raw `browse cloud fetch | sed` pipeline?** Without `--output`, `browse cloud fetch` returns a JSON envelope with the HTML embedded as an escaped string. A naive sed pipeline strips `<>` from the wrapper and content, and it removes `<meta>` tags, which on Framer/Next.js SPAs are often the only readable content. `extract_page.mjs` uses `--output` to parse raw HTML directly.
 
 **When to use raw `browse cloud fetch`**: Only for small structured files where you want the JSON envelope intact — e.g. `sitemap.xml`, `robots.txt`, `llms.txt`. For any HTML page you'd feed to a model, use `extract_page.mjs`.
 
@@ -128,8 +128,8 @@ TOOL RULES — CRITICAL, FOLLOW EXACTLY:
 2. All searches: Bash → browse cloud search "..." --num-results 10
 3. All homepage/product-page content extraction:
    Bash → node {SKILL_DIR}/scripts/extract_page.mjs "URL" --max-chars 3000
-   This returns structured TITLE / META_DESCRIPTION / OG_DESCRIPTION / HEADINGS / BODY and auto-falls back to browse get markdown for JS-rendered or >1MB pages.
-   DO NOT hand-roll a `browse cloud fetch | sed` pipeline — it silently strips meta tags and doesn't parse the JSON envelope. Use `browse cloud fetch` raw only for sitemap.xml, robots.txt, llms.txt.
+   This returns structured TITLE / META_DESCRIPTION / OG_DESCRIPTION / HEADINGS / BODY and auto-falls back to browse get markdown when fetch fails or returns thin JS-rendered content.
+   DO NOT hand-roll a `browse cloud fetch | sed` pipeline — it strips meta tags and doesn't parse the stdout JSON envelope. Use `browse cloud fetch` raw only for sitemap.xml, robots.txt, llms.txt.
 4. BATCH all file writes: Write ALL markdown files in a SINGLE Bash call using chained heredocs (one permission prompt, not one per file).
 5. BANNED TOOLS: WebFetch, WebSearch, Write, Read, Glob, Grep — ALL BANNED.
    If you use ANY banned tool, the entire run fails. Use ONLY Bash.
@@ -150,7 +150,7 @@ For each sub-question (or just the homepage in quick mode):
 1. Run browse cloud search with relevant query
 2. Pick 1-2 most relevant URLs from results
 3. Extract page content: node {SKILL_DIR}/scripts/extract_page.mjs "URL" --max-chars 3000
-   (auto-handles the JSON envelope, meta tags, and the browse get markdown fallback)
+   (uses `--output` to avoid the stdout JSON envelope, preserves meta tags, and falls back to browse get markdown when needed)
 4. Smart page discovery: use `browse cloud fetch --allow-redirects` on /sitemap.xml or /llms.txt to find relevant URLs — these are small XML/text files where the raw JSON envelope is fine. For the actual HTML pages you discover, use extract_page.mjs.
 5. Extract findings: factual statements with source, confidence level
 6. Accumulate findings, move to next sub-question

--- a/skills/company-research/scripts/extract_page.mjs
+++ b/skills/company-research/scripts/extract_page.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // Extract structured page content for company research.
-// Fetches via `bb fetch` (raw HTML to a temp file), pulls title + meta tags
-// + visible body text, and auto-falls back to `bb browse` when content is thin.
+// Fetches via `browse cloud fetch` (raw HTML to a temp file), pulls title + meta tags
+// + visible body text, and auto-falls back to `browse get markdown` when content is thin.
 //
 // Usage: node extract_page.mjs <url> [--max-chars N]
 // Output (stdout): structured block consumable by a research subagent.
@@ -27,24 +27,24 @@ function parseArgs(argv) {
   return args;
 }
 
-function bbFetch(url, outFile) {
-  execFileSync("bb", ["fetch", "--allow-redirects", url, "--output", outFile], {
+function browseFetch(url, outFile) {
+  execFileSync("browse", ["cloud", "fetch", "--allow-redirects", url, "--output", outFile], {
     stdio: ["ignore", "ignore", "ignore"],
   });
 }
 
-function bbBrowseMarkdown(url) {
+function browseGetMarkdown(url) {
   try {
-    execFileSync("bb", ["browse", "--headless", "open", url], {
+    execFileSync("browse", ["open", url, "--local", "--headless"], {
       stdio: ["ignore", "ignore", "ignore"],
       timeout: 90000,
     });
-    const out = execFileSync("bb", ["browse", "--headless", "get", "markdown"], {
+    const out = execFileSync("browse", ["get", "markdown", "--local", "--headless"], {
       encoding: "utf8",
       timeout: 90000,
       maxBuffer: 50 * 1024 * 1024,
     });
-    // bb browse prints banners (e.g. "Update available...") before the JSON blob.
+    // browse prints banners (e.g. "Update available...") before the JSON blob.
     // Find the first '{' and try to JSON.parse from there.
     const start = out.indexOf("{");
     if (start < 0) return "";
@@ -122,11 +122,11 @@ function main() {
   let html = "";
   let fetchOk = false;
   try {
-    bbFetch(url, htmlFile);
+    browseFetch(url, htmlFile);
     html = readFileSync(htmlFile, "utf8");
     fetchOk = true;
   } catch (err) {
-    console.error(`[extract_page] bb fetch failed: ${err.message}`);
+    console.error(`[extract_page] browse cloud fetch failed: ${err.message}`);
   }
 
   const title = extractTitle(html);
@@ -136,10 +136,10 @@ function main() {
   const headings = extractHeadings(html);
   let body = extractVisibleText(html, maxChars);
 
-  // Thin content → JS-rendered SPA → fall back to bb browse.
+  // Thin content → JS-rendered SPA → fall back to browse get markdown.
   let fallbackUsed = false;
   if (body.length < THIN_CONTENT_THRESHOLD) {
-    const md = bbBrowseMarkdown(url);
+    const md = browseGetMarkdown(url);
     if (md && md.length > body.length) {
       body = md.replace(/\s+/g, " ").slice(0, maxChars);
       fallbackUsed = true;

--- a/skills/company-research/scripts/extract_page.mjs
+++ b/skills/company-research/scripts/extract_page.mjs
@@ -34,15 +34,19 @@ function browseFetch(url, outFile) {
 }
 
 function browseGetMarkdown(url) {
+  const session = `extract-page-${process.pid}-${Date.now()}`;
+  const env = { ...process.env, BROWSE_SESSION: session };
   try {
     execFileSync("browse", ["open", url, "--local", "--headless"], {
       stdio: ["ignore", "ignore", "ignore"],
       timeout: 90000,
+      env,
     });
     const out = execFileSync("browse", ["get", "markdown"], {
       encoding: "utf8",
       timeout: 90000,
       maxBuffer: 50 * 1024 * 1024,
+      env,
     });
     // browse prints banners (e.g. "Update available...") before the JSON blob.
     // Find the first '{' and try to JSON.parse from there.
@@ -62,6 +66,14 @@ function browseGetMarkdown(url) {
     return "";
   } catch (err) {
     return "";
+  } finally {
+    try {
+      execFileSync("browse", ["stop"], {
+        stdio: ["ignore", "ignore", "ignore"],
+        timeout: 15000,
+        env,
+      });
+    } catch {}
   }
 }
 

--- a/skills/company-research/scripts/extract_page.mjs
+++ b/skills/company-research/scripts/extract_page.mjs
@@ -39,7 +39,7 @@ function browseGetMarkdown(url) {
       stdio: ["ignore", "ignore", "ignore"],
       timeout: 90000,
     });
-    const out = execFileSync("browse", ["get", "markdown", "--local", "--headless"], {
+    const out = execFileSync("browse", ["get", "markdown"], {
       encoding: "utf8",
       timeout: 90000,
       maxBuffer: 50 * 1024 * 1024,

--- a/skills/company-research/scripts/list_urls.mjs
+++ b/skills/company-research/scripts/list_urls.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-// Deduplicates discovery URLs from bb search JSON output files.
+// Deduplicates discovery URLs from browse cloud search JSON output files.
 // Usage: node list_urls.mjs /tmp [--prefix company]
 // Reads all {prefix}_discovery_batch_*.json files, deduplicates by domain,
 // outputs one URL per line to stdout, stats to stderr.

--- a/skills/cookie-sync/SKILL.md
+++ b/skills/cookie-sync/SKILL.md
@@ -79,10 +79,14 @@ node .claude/skills/cookie-sync/scripts/cookie-sync.mjs --domains github.com,goo
 After syncing, use the `browse` CLI with the context ID:
 
 ```bash
-browse open https://mail.google.com --context-id <ctx-id> --persist
+SESSION_JSON="$(browse cloud sessions create --context-id <ctx-id> --persist --keep-alive)"
+SESSION_ID="$(echo "$SESSION_JSON" | jq -r .id)"
+CONNECT_URL="$(echo "$SESSION_JSON" | jq -r .connectUrl)"
+
+browse open https://mail.google.com --cdp "$CONNECT_URL"
 ```
 
-The `--persist` flag saves any new cookies or state changes back to the context, keeping the session fresh for next time.
+The `--persist` flag on `browse cloud sessions create` saves any new cookies or state changes back to the context when the cloud session is released, keeping the session fresh for next time.
 
 **Full workflow example:**
 
@@ -92,10 +96,15 @@ node .claude/skills/cookie-sync/scripts/cookie-sync.mjs --domains x.com,twitter.
 # Output: Context ID: ctx_abc123
 
 # Step 2: Browse authenticated Twitter
-browse open https://x.com/messages --context-id ctx_abc123 --persist
+SESSION_JSON="$(browse cloud sessions create --context-id ctx_abc123 --persist --keep-alive)"
+SESSION_ID="$(echo "$SESSION_JSON" | jq -r .id)"
+CONNECT_URL="$(echo "$SESSION_JSON" | jq -r .connectUrl)"
+
+browse open https://x.com/messages --cdp "$CONNECT_URL"
 browse snapshot
 browse screenshot
 browse stop
+browse cloud sessions update "$SESSION_ID" --status REQUEST_RELEASE
 ```
 
 ## Reusing Contexts for Scheduled Jobs
@@ -103,7 +112,7 @@ browse stop
 Contexts persist across sessions, making them ideal for scheduled/recurring tasks:
 
 1. **Once (laptop open):** Run cookie-sync → get a context ID
-2. **Scheduled jobs:** Use `browse open <url> --context-id <ctx-id> --persist` — no local Chrome needed
+2. **Scheduled jobs:** Create a Browserbase session with `browse cloud sessions create --context-id <ctx-id> --persist --keep-alive`, then attach with `browse open <url> --cdp <connectUrl>` — no local Chrome needed
 3. **Re-sync as needed:** When cookies expire, run cookie-sync again with `--context <ctx-id>` to refresh
 
 ## Troubleshooting

--- a/skills/cookie-sync/scripts/cookie-sync.mjs
+++ b/skills/cookie-sync/scripts/cookie-sync.mjs
@@ -13,7 +13,9 @@
 //   node scripts/cookie-sync.mjs --proxy "San Francisco,CA,US"          # use residential proxy with geolocation
 //
 // After syncing, use the browse CLI to open an authenticated session:
-//   browse open https://example.com --context-id <ctx-id> --persist
+//   SESSION_JSON="$(browse cloud sessions create --context-id <ctx-id> --persist --keep-alive)"
+//   CONNECT_URL="$(echo "$SESSION_JSON" | jq -r .connectUrl)"
+//   browse open https://example.com --cdp "$CONNECT_URL"
 //
 // Env vars:
 //   BROWSERBASE_API_KEY    — required
@@ -294,7 +296,11 @@ async function main() {
   console.log(`Context ID: ${contextId}`);
   console.log('');
   console.log('Browse authenticated sites with:');
-  console.log(`  browse open <url> --context-id ${contextId} --persist`);
+  console.log(`  SESSION_JSON="$(browse cloud sessions create --context-id ${contextId} --persist --keep-alive)"`);
+  console.log('  SESSION_ID="$(echo "$SESSION_JSON" | jq -r .id)"');
+  console.log('  CONNECT_URL="$(echo "$SESSION_JSON" | jq -r .connectUrl)"');
+  console.log('  browse open <url> --cdp "$CONNECT_URL"');
+  console.log('  # when done: browse stop && browse cloud sessions update "$SESSION_ID" --status REQUEST_RELEASE');
   console.log('');
   console.log('To refresh cookies later:');
   console.log(`  node cookie-sync.mjs --context ${contextId}`);

--- a/skills/event-prospecting/SKILL.md
+++ b/skills/event-prospecting/SKILL.md
@@ -35,7 +35,7 @@ Take a conference URL → get a ranked list of people the AE should talk to, wit
 
 **CRITICAL — Tool restrictions (applies to main agent AND all subagents)**:
 - All web searches: use `browse cloud search`. NEVER use WebSearch.
-- All page content extraction: use `node {SKILL_DIR}/scripts/extract_page.mjs "<url>"`. This script fetches via `browse cloud fetch`, parses title + meta tags + visible body text, and automatically falls back to `browse get markdown` when the page is JS-rendered or over 1MB. NEVER hand-roll a `browse cloud fetch | sed` pipeline. NEVER use WebFetch.
+- All page content extraction: use `node {SKILL_DIR}/scripts/extract_page.mjs "<url>"`. This script fetches via `browse cloud fetch --output`, parses title + meta tags + visible body text, and automatically falls back to `browse get markdown` when fetch fails or returns thin JS-rendered content. NEVER hand-roll a `browse cloud fetch | sed` pipeline. NEVER use WebFetch.
 - All research output: subagents write **one markdown file per company OR per person** to `{OUTPUT_DIR}/companies/{slug}.md` or `{OUTPUT_DIR}/people/{slug}.md` using bash heredoc. NEVER use the Write tool or `python3 -c`. See `references/example-research.md` for both file formats.
 - Report compilation: use `node {SKILL_DIR}/scripts/compile_report.mjs {OUTPUT_DIR} --open`.
 - **Subagents must use ONLY the Bash tool. No other tools allowed.**
@@ -302,7 +302,7 @@ Per person: harvest LinkedIn URL, recent activity (podcast / blog / talk / GitHu
 1. `browse cloud search "{name} {company} linkedin"` (always)
 2. `browse cloud search "{name} podcast OR talk OR blog 2026"` (deep+)
 3. `browse cloud search "{name} github"` (deeper)
-4. `browse cloud search "{name} site:x.com OR site:twitter.com"` (deeper)
+4. `browse cloud search "{name} site:x.com OR site:twitter.com"` (deeper, best-effort)
 
 Quick mode: skip Step 8 entirely. Deep mode: lanes 1-2. Deeper mode: lanes 1-4.
 

--- a/skills/event-prospecting/SKILL.md
+++ b/skills/event-prospecting/SKILL.md
@@ -27,7 +27,7 @@ metadata:
 
 Take a conference URL → get a ranked list of people the AE should talk to, with a "why reach out" rationale per person.
 
-**Required**: `BROWSERBASE_API_KEY` env var and the `browse` CLI installed (`npm install -g browse`). The unified `browse` binary handles both API calls (`browse cloud ...`) and local browser rendering (`browse open` / `browse get markdown`) for JS-heavy speaker pages.
+**Required**: `BROWSERBASE_API_KEY` env var and the `browse` CLI installed (`npm install -g browse`). Use `browse cloud ...` for API calls and `browse open` / `browse get markdown` for JS-heavy speaker pages.
 
 **Path rules**: Always use the full literal path in all Bash commands — NOT `~` or `$HOME` (both trigger "shell expansion syntax" approval prompts). Resolve the home directory once and use it everywhere. When constructing subagent prompts, replace `{SKILL_DIR}` with the full literal path (typically `/Users/jay/skills/skills/event-prospecting`).
 

--- a/skills/event-prospecting/SKILL.md
+++ b/skills/event-prospecting/SKILL.md
@@ -16,7 +16,7 @@ description: |
   "ai engineer summit prospects", "event prospecting",
   "scrape conference speakers", "who should I meet at".
 license: MIT
-compatibility: Requires bb CLI (@browserbasehq/cli) and BROWSERBASE_API_KEY env var. Also requires browse CLI (@browserbasehq/browse-cli) for JS-heavy pages.
+compatibility: Requires browse CLI (`npm install -g browse`) and BROWSERBASE_API_KEY env var. The same `browse` binary covers both API commands and JS-rendered page fallback.
 allowed-tools: Bash Agent AskUserQuestion
 metadata:
   author: browserbase
@@ -27,15 +27,15 @@ metadata:
 
 Take a conference URL → get a ranked list of people the AE should talk to, with a "why reach out" rationale per person.
 
-**Required**: `BROWSERBASE_API_KEY` env var, `bb` CLI installed (`@browserbasehq/cli`), and `browse` CLI installed (`@browserbasehq/browse-cli`) for JS-heavy speaker pages (most modern event sites).
+**Required**: `BROWSERBASE_API_KEY` env var and the `browse` CLI installed (`npm install -g browse`). The unified `browse` binary handles both API calls (`browse cloud ...`) and local browser rendering (`browse open` / `browse get markdown`) for JS-heavy speaker pages.
 
 **Path rules**: Always use the full literal path in all Bash commands — NOT `~` or `$HOME` (both trigger "shell expansion syntax" approval prompts). Resolve the home directory once and use it everywhere. When constructing subagent prompts, replace `{SKILL_DIR}` with the full literal path (typically `/Users/jay/skills/skills/event-prospecting`).
 
 **Output directory**: All event prospecting output goes to `~/Desktop/{event_slug}_prospects_{YYYY-MM-DD-HHMM}/`. Final deliverable is `index.html` (people grouped by company, ranked by company ICP), with `companies.html` and `people.html` (filterable) as alternate views, plus `results.csv` for cold-outbound import.
 
 **CRITICAL — Tool restrictions (applies to main agent AND all subagents)**:
-- All web searches: use `bb search`. NEVER use WebSearch.
-- All page content extraction: use `node {SKILL_DIR}/scripts/extract_page.mjs "<url>"`. This script fetches via `bb fetch`, parses title + meta tags + visible body text, and automatically falls back to `bb browse` when the page is JS-rendered or over 1MB. NEVER hand-roll a `bb fetch | sed` pipeline. NEVER use WebFetch.
+- All web searches: use `browse cloud search`. NEVER use WebSearch.
+- All page content extraction: use `node {SKILL_DIR}/scripts/extract_page.mjs "<url>"`. This script fetches via `browse cloud fetch`, parses title + meta tags + visible body text, and automatically falls back to `browse get markdown` when the page is JS-rendered or over 1MB. NEVER hand-roll a `browse cloud fetch | sed` pipeline. NEVER use WebFetch.
 - All research output: subagents write **one markdown file per company OR per person** to `{OUTPUT_DIR}/companies/{slug}.md` or `{OUTPUT_DIR}/people/{slug}.md` using bash heredoc. NEVER use the Write tool or `python3 -c`. See `references/example-research.md` for both file formats.
 - Report compilation: use `node {SKILL_DIR}/scripts/compile_report.mjs {OUTPUT_DIR} --open`.
 - **Subagents must use ONLY the Bash tool. No other tools allowed.**
@@ -45,7 +45,7 @@ Take a conference URL → get a ranked list of people the AE should talk to, wit
 - NEVER infer `product_description`, `industry`, or a person's `role_reason` from a site's fonts, framework, design system, or typography. These are cosmetic and say nothing about what the company sells or what the person does.
 - NEVER let the user's own ICP leak into a target's description. If you don't know what the target does, write `Unknown` — do not pattern-match them onto the ICP.
 - `product_description` MUST quote or paraphrase a specific phrase from `extract_page.mjs` output. If none of TITLE/META/OG/HEADINGS/BODY yield a recognizable product statement, write `Unknown — homepage content not accessible` and cap `icp_fit_score` at 3.
-- A person's `hook` MUST quote or paraphrase a specific finding from a `bb search` result (podcast title, blog headline, GitHub repo, talk abstract). If no public signal exists in the last 6 months, fall back to event-context (their talk title at this event).
+- A person's `hook` MUST quote or paraphrase a specific finding from a `browse cloud search` result (podcast title, blog headline, GitHub repo, talk abstract). If no public signal exists in the last 6 months, fall back to event-context (their talk title at this event).
 
 **CRITICAL — Minimize permission prompts**:
 - Subagents MUST batch ALL file writes into a SINGLE Bash call using chained heredocs. One Bash call = one permission prompt.
@@ -171,7 +171,7 @@ Expected: roughly 0.4-0.6× the speaker count (most events have ~2 speakers per 
 
 **Fast pass — one tool call per company, no deep research.** Score every company in `seed_companies.txt` against the user's ICP and write a thin triage stub to `companies/{slug}.md`. Companies with `icp_fit_score >= --icp-threshold` (default 6) advance to Step 7's deep research; the rest stay as triage stubs.
 
-**Dispatch pattern**: split `seed_companies.txt` into batches of ~10 and fan out N subagents in a SINGLE Agent batch (multiple Agent tool calls in one message). Each subagent runs the prompt from `references/workflow.md` → "ICP Triage" section. Hard cap: **1 tool call per company** (just `extract_page.mjs` on the homepage), enforced via the `# bb call N/1` comment pattern.
+**Dispatch pattern**: split `seed_companies.txt` into batches of ~10 and fan out N subagents in a SINGLE Agent batch (multiple Agent tool calls in one message). Each subagent runs the prompt from `references/workflow.md` → "ICP Triage" section. Hard cap: **1 tool call per company** (just `extract_page.mjs` on the homepage), enforced via the `# browse call N/1` comment pattern.
 
 ```bash
 # Build batch files: each batch line is "name|guessed_homepage|slug".
@@ -179,7 +179,7 @@ Expected: roughly 0.4-0.6× the speaker count (most events have ~2 speakers per 
 # https://{slug-without-spaces}.com as the canonical homepage. The triage subagent
 # is allowed to write product_description: "Unknown — homepage content not accessible"
 # and cap score at 3 if the guessed URL 404s — that's the documented fallback in
-# workflow.md (rule 3 of the ICP Triage prompt). Burning a real bb search to
+# workflow.md (rule 3 of the ICP Triage prompt). Burning a real browse cloud search to
 # discover the URL would bust the 1-call-per-company HARD CAP.
 node -e '
 const fs = require("fs");
@@ -206,7 +206,7 @@ Then in a single message, dispatch one Agent call per batch (up to 6 in parallel
 - `{USER_COMPANY}`, `{USER_PRODUCT}`, `{ICP_DESCRIPTION}` → from the loaded profile
 - `{EVENT_NAME}` → `recon.json` `.title`
 - `{COMPANY_LIST}` → contents of the batch file (e.g. `cat {OUTPUT_DIR}/_batch_triage_aa`)
-- `{TOTAL}` → number of lines in this batch (substitute into `# bb call N/{TOTAL}`)
+- `{TOTAL}` → number of lines in this batch (substitute into `# browse call N/{TOTAL}`)
 
 **Agent dispatch (skeleton, repeat per batch in one message)**:
 
@@ -299,10 +299,10 @@ grep -l "triage_only: false" {OUTPUT_DIR}/companies/*.md | wc -l
 
 Per person: harvest LinkedIn URL, recent activity (podcast / blog / talk / GitHub / X), and write `people/{slug}.md`. Hard cap: **4 tool calls per person**, three lanes:
 
-1. `bb search "{name} {company} linkedin"` (always)
-2. `bb search "{name} podcast OR talk OR blog 2026"` (deep+)
-3. `bb search "{name} github"` (deeper)
-4. `bb search "{name} site:x.com OR site:twitter.com"` (deeper)
+1. `browse cloud search "{name} {company} linkedin"` (always)
+2. `browse cloud search "{name} podcast OR talk OR blog 2026"` (deep+)
+3. `browse cloud search "{name} github"` (deeper)
+4. `browse cloud search "{name} site:x.com OR site:twitter.com"` (deeper)
 
 Quick mode: skip Step 8 entirely. Deep mode: lanes 1-2. Deeper mode: lanes 1-4.
 
@@ -385,7 +385,7 @@ Then in a single message, dispatch one Agent call per batch (up to 6 per message
 - `{SKILL_DIR}`, `{OUTPUT_DIR}`, `{DEPTH}` (`deep` | `deeper`)
 - `{USER_COMPANY}`, `{USER_PRODUCT}`, `{ICP_DESCRIPTION}`
 - `{EVENT_NAME}` (from `recon.json` `.title`)
-- `{LANES}` → `2` for deep mode, `4` for deeper mode (substituted into `# bb call N/{LANES}`)
+- `{LANES}` → `2` for deep mode, `4` for deeper mode (substituted into `# browse call N/{LANES}`)
 - `{PEOPLE_BATCH}` → contents of `_batch_people_aa` (each line a JSON record from `people.jsonl`)
 
 **Agent dispatch (skeleton, repeat per batch in one message)**:

--- a/skills/event-prospecting/references/event-platforms.md
+++ b/skills/event-prospecting/references/event-platforms.md
@@ -154,7 +154,7 @@ Eventbrite emits standard `Event` JSON-LD on every public event page. Speakers a
 
 **Known gotchas**
 
-- Eventbrite event pages are heavy — `bb fetch` may return >1MB and trigger the size guard. Use `browse get markdown` instead.
+- Eventbrite event pages are heavy — `browse cloud fetch` may return >1MB and trigger the size guard. Use `browse get markdown` instead.
 - Most Eventbrite events do NOT publish a speaker list at all. This platform is low-yield for prospecting.
 
 ---

--- a/skills/event-prospecting/references/event-platforms.md
+++ b/skills/event-prospecting/references/event-platforms.md
@@ -13,7 +13,7 @@
 
 ## Detection Priority
 
-`recon.mjs` probes the event URL once via `browse goto` + `browse eval`, then chooses the first matching platform from this list:
+`recon.mjs` probes the event URL once via `browse open` + `browse eval`, then chooses the first matching platform from this list:
 
 1. **Next.js / `__NEXT_DATA__`** — `document.getElementById('__NEXT_DATA__')` returns a `<script>` tag.
 2. **Sessionize** — `<meta name="generator">` content matches `/sessionize/i`.
@@ -154,7 +154,7 @@ Eventbrite emits standard `Event` JSON-LD on every public event page. Speakers a
 
 **Known gotchas**
 
-- Eventbrite event pages are heavy — `browse cloud fetch` may return >1MB and trigger the size guard. Use `browse get markdown` instead.
+- Eventbrite event pages can be heavy. If `browse cloud fetch` fails or returns thin content, use `browse get markdown` instead.
 - Most Eventbrite events do NOT publish a speaker list at all. This platform is low-yield for prospecting.
 
 ---

--- a/skills/event-prospecting/references/research-patterns.md
+++ b/skills/event-prospecting/references/research-patterns.md
@@ -39,9 +39,9 @@ This is the most important research in the pipeline. Every downstream decision d
 
 ### Page Discovery
 Discover site pages dynamically — do NOT hardcode paths like `/about` or `/customers`:
-1. Fetch `bb fetch --allow-redirects "{company website}/sitemap.xml"` — primary source, has ALL pages
+1. Fetch `browse cloud fetch --allow-redirects "{company website}/sitemap.xml"` — primary source, has ALL pages
 2. Scan sitemap URLs for keywords: `customer`, `case-stud`, `pricing`, `about`, `use-case`, `blog`, `docs`, `industry`, `solution`
-3. Optionally fetch `bb fetch --allow-redirects "{company website}/llms.txt"` for page descriptions
+3. Optionally fetch `browse cloud fetch --allow-redirects "{company website}/llms.txt"` for page descriptions
 4. Pick the 3-5 most relevant URLs from the sitemap and fetch those
 5. Sitemap is the source of truth. llms.txt is bonus context but often incomplete.
 
@@ -244,7 +244,7 @@ Identical to company-research's target research. The ICP-fit companies (typicall
 
 **Hard cap: 5 tool calls per company.** Budget breakdown for deep mode:
 - 1 call: `extract_page.mjs` on the homepage (re-extract; the triage version was scraped down to a 1-liner)
-- 2-3 calls: `bb search` for sub-questions from Priority 1 + 2 (product, tech stack, growth signals)
+- 2-3 calls: `browse cloud search` for sub-questions from Priority 1 + 2 (product, tech stack, growth signals)
 - 1-2 calls: `extract_page.mjs` on the most relevant search results (case study, blog post, careers page)
 
 Event-context tweaks the sub-questions. Instead of generic "What does {company} do?", the subagent asks "What is {company} doing with browser automation that's relevant to **Stripe Sessions' agent track**?" — the event name and any track/topic info from `recon.json` is woven into Priority 2 sub-questions.
@@ -254,10 +254,10 @@ The deep-research subagent OVERWRITES the triage stub with the richer file (fron
 ## Person Enrichment (Step 8 — speakers at ICP fits only)
 
 Per person at an ICP-fit company:
-- `bb search "{name} {company} linkedin"` — verify role + harvest LinkedIn URL (always)
-- `bb search "{name} podcast OR talk OR blog 2026"` — last 6 months for hooks (deep+)
-- `bb search "{name} github"` — open-source signal (deeper)
-- `bb search "{name} site:x.com OR site:twitter.com"` — recent posts (deeper)
+- `browse cloud search "{name} {company} linkedin"` — verify role + harvest LinkedIn URL (always)
+- `browse cloud search "{name} podcast OR talk OR blog 2026"` — last 6 months for hooks (deep+)
+- `browse cloud search "{name} github"` — open-source signal (deeper)
+- `browse cloud search "{name} site:x.com OR site:twitter.com"` — recent posts (deeper)
 
 **Hard cap: 4 tool calls per person.** Deep mode runs lanes 1-2 (max 2 calls). Deeper mode runs lanes 1-4 (max 4 calls). Quick mode skips Step 8 entirely.
 

--- a/skills/event-prospecting/references/research-patterns.md
+++ b/skills/event-prospecting/references/research-patterns.md
@@ -257,7 +257,7 @@ Per person at an ICP-fit company:
 - `browse cloud search "{name} {company} linkedin"` — verify role + harvest LinkedIn URL (always)
 - `browse cloud search "{name} podcast OR talk OR blog 2026"` — last 6 months for hooks (deep+)
 - `browse cloud search "{name} github"` — open-source signal (deeper)
-- `browse cloud search "{name} site:x.com OR site:twitter.com"` — recent posts (deeper)
+- `browse cloud search "{name} site:x.com OR site:twitter.com"` — best-effort recent posts (deeper)
 
 **Hard cap: 4 tool calls per person.** Deep mode runs lanes 1-2 (max 2 calls). Deeper mode runs lanes 1-4 (max 4 calls). Quick mode skips Step 8 entirely.
 

--- a/skills/event-prospecting/references/workflow.md
+++ b/skills/event-prospecting/references/workflow.md
@@ -26,7 +26,7 @@ Recon + extract are deterministic single-process scripts run by the main agent. 
 
 **HARD TOOL-CALL CAP: 1 tool call per company.** The only allowed call is `extract_page.mjs` on the company homepage. NO follow-up searches, NO sitemap discovery, NO secondary fetches. If the homepage returns thin content, write `Unknown` and cap the score at 3 — that is the correct behavior, not a failure.
 
-**ENFORCEMENT** — at the start of every Bash call, prepend a comment like `# bb call N/1` so the cap is visible in tool output. If a subagent emits more than `K` calls for a batch of `K` companies, the main agent's compile step will detect the over-budget run from the call log and flag it.
+**ENFORCEMENT** — at the start of every Bash call, prepend a comment like `# browse call N/1` so the cap is visible in tool output. If a subagent emits more than `K` calls for a batch of `K` companies, the main agent's compile step will detect the over-budget run from the call log and flag it.
 
 **Subagent prompt template** — substitute the curly-brace placeholders before dispatching:
 
@@ -52,8 +52,8 @@ TOOL RULES — CRITICAL, FOLLOW EXACTLY:
 2. The ONLY allowed extraction call is:
      node {SKILL_DIR}/scripts/extract_page.mjs "<homepage_url>" --max-chars 2000
 3. HARD TOOL-CALL CAP: ONE call per company. If a homepage returns FETCH_OK: false with empty BODY (e.g. the guessed URL 404s), write product_description: "Unknown — homepage content not accessible" and cap icp_fit_score at 3. DO NOT attempt a second call to "save" the company.
-4. ENFORCEMENT — at the start of EVERY Bash call, prepend a comment like `# bb call N/{TOTAL}` where N counts up and TOTAL is the number of companies in your batch. Example for a 10-company batch:
-     # bb call 1/10
+4. ENFORCEMENT — at the start of EVERY Bash call, prepend a comment like `# browse call N/{TOTAL}` where N counts up and TOTAL is the number of companies in your batch. Example for a 10-company batch:
+     # browse call 1/10
      node {SKILL_DIR}/scripts/extract_page.mjs "https://openai.com" --max-chars 2000
 5. BANNED TOOLS: WebFetch, WebSearch, Write, Read, Glob, Grep — ALL BANNED. Use ONLY Bash.
 6. NEVER use ~ or $HOME — full literal paths only.
@@ -70,9 +70,9 @@ ICP SCORING RUBRIC (event-aware):
 
 OUTPUT — write ALL company files in a SINGLE Bash call using chained heredocs:
 
-# bb call 1/{TOTAL}
+# browse call 1/{TOTAL}
 node {SKILL_DIR}/scripts/extract_page.mjs "{url1}" --max-chars 2000 && \
-# bb call 2/{TOTAL}
+# browse call 2/{TOTAL}
 node {SKILL_DIR}/scripts/extract_page.mjs "{url2}" --max-chars 2000 && \
 ... && \
 cat << 'COMPANY_MD' > {OUTPUT_DIR}/companies/{slug1}.md
@@ -109,10 +109,10 @@ Do NOT return raw homepage content or per-company reasoning to the main conversa
 
 **HARD TOOL-CALL CAP: 5 tool calls per company.** Budget breakdown:
 - 1 call: `extract_page.mjs` on the homepage
-- 2-3 calls: `bb search` for sub-questions (Priority 1 + selected Priority 2)
+- 2-3 calls: `browse cloud search` for sub-questions (Priority 1 + selected Priority 2)
 - 1-2 calls: `extract_page.mjs` on the most relevant search results (case study / blog / careers)
 
-**ENFORCEMENT** — at the start of every Bash call, prepend `# bb call N/{TOTAL}` where TOTAL is `5 × batch_size`. A 5-company batch caps at 25 total tool calls. The main agent's compile step monitors this from the call log.
+**ENFORCEMENT** — at the start of every Bash call, prepend `# browse call N/{TOTAL}` where TOTAL is `5 × batch_size`. A 5-company batch caps at 25 total tool calls. The main agent's compile step monitors this from the call log.
 
 **Subagent prompt template**:
 
@@ -132,16 +132,16 @@ COMPANIES TO RESEARCH (one per line, slug|website format):
 
 TOOL RULES — CRITICAL:
 1. You may ONLY use the Bash tool. No exceptions.
-2. All searches:  bb search "..." --num-results 10
+2. All searches:  browse cloud search "..." --num-results 10
 3. All page extractions:  node {SKILL_DIR}/scripts/extract_page.mjs "URL" --max-chars 3000
-   (handles JSON envelope, meta tags, JS-render fallback to bb browse)
-   DO NOT hand-roll a `bb fetch | sed` pipeline. Use raw `bb fetch` only for sitemap.xml / llms.txt.
+   (handles JSON envelope, meta tags, JS-render fallback to browse get markdown)
+   DO NOT hand-roll a `browse cloud fetch | sed` pipeline. Use raw `browse cloud fetch` only for sitemap.xml / llms.txt.
 4. HARD TOOL-CALL CAP: 5 calls per company. Budget:
      1× extract_page on homepage
-     2-3× bb search on sub-questions
+     2-3× browse cloud search on sub-questions
      1-2× extract_page on the best search result
    DO NOT exceed 5 calls per company. If you've burned the budget, synthesize from what you have.
-5. ENFORCEMENT — at the start of EVERY Bash call, prepend a comment like `# bb call N/5 (company: {slug})`. Reset N to 1 for each company in the batch.
+5. ENFORCEMENT — at the start of EVERY Bash call, prepend a comment like `# browse call N/5 (company: {slug})`. Reset N to 1 for each company in the batch.
 6. BATCH all writes: write ALL deep-research files in a SINGLE Bash call using chained heredocs.
 7. BANNED TOOLS: WebFetch, WebSearch, Write, Read, Glob, Grep — ALL BANNED.
 8. NEVER use ~ or $HOME — full literal paths.
@@ -161,11 +161,11 @@ Decompose into 2-3 sub-questions. Always include "What does {company} do?" (Prio
   - "Has {company} raised funding, launched products, or expanded recently?"
 
 Phase B — Research Loop:
-1. # bb call 1/5 — extract_page on homepage
-2. # bb call 2/5 — bb search for Priority 1 sub-question
-3. # bb call 3/5 — bb search for event-context sub-question
-4. # bb call 4/5 — extract_page on the most relevant search result
-5. # bb call 5/5 — (optional) one more search OR fetch if budget remains
+1. # browse call 1/5 — extract_page on homepage
+2. # browse call 2/5 — browse cloud search for Priority 1 sub-question
+3. # browse call 3/5 — browse cloud search for event-context sub-question
+4. # browse call 4/5 — extract_page on the most relevant search result
+5. # browse call 5/5 — (optional) one more search OR fetch if budget remains
 Accumulate findings: factual statement + source URL + confidence level (high/medium/low).
 
 Phase C — Synthesize:
@@ -217,19 +217,19 @@ Report back ONLY: "Deep research batch: {researched}/{total} companies, {finding
 ## Person Enrichment
 
 **HARD TOOL-CALL CAP: 4 tool calls per person.** Lanes:
-1. `bb search "{name} {company} linkedin"` — always (deep + deeper)
-2. `bb search "{name} podcast OR talk OR blog 2026"` — deep + deeper
-3. `bb search "{name} github"` — deeper only
-4. `bb search "{name} site:x.com OR site:twitter.com"` — deeper only
+1. `browse cloud search "{name} {company} linkedin"` — always (deep + deeper)
+2. `browse cloud search "{name} podcast OR talk OR blog 2026"` — deep + deeper
+3. `browse cloud search "{name} github"` — deeper only
+4. `browse cloud search "{name} site:x.com OR site:twitter.com"` — deeper only
 
 Deep mode: lanes 1-2 (max 2 calls/person). Deeper mode: lanes 1-4 (max 4 calls/person).
 
-**ENFORCEMENT** — every Bash call prepends `# bb call N/{LANES} (person: {slug})`, where LANES is 2 (deep) or 4 (deeper). Reset N to 1 for each person.
+**ENFORCEMENT** — every Bash call prepends `# browse call N/{LANES} (person: {slug})`, where LANES is 2 (deep) or 4 (deeper). Reset N to 1 for each person.
 
 **Subagent prompt template**:
 
 ```
-You are a person-enrichment subagent for the event-prospecting skill. For each person in your batch, run 2-4 bb searches to harvest LinkedIn + recent activity + GitHub + X presence, generate a hook + DM opener, and write {OUTPUT_DIR}/people/{slug}.md.
+You are a person-enrichment subagent for the event-prospecting skill. For each person in your batch, run 2-4 browse cloud searches to harvest LinkedIn + recent activity + GitHub + X presence, generate a hook + DM opener, and write {OUTPUT_DIR}/people/{slug}.md.
 
 CONTEXT:
 - User's company: {USER_COMPANY}
@@ -249,41 +249,41 @@ The `image` field is the speaker's headshot URL extracted from the event site (m
 
 TOOL RULES — CRITICAL:
 1. You may ONLY use the Bash tool. No exceptions.
-2. All searches:  bb search "..." --num-results 5
+2. All searches:  browse cloud search "..." --num-results 5
 3. HARD TOOL-CALL CAP per person:
      deep mode:    2 calls (lanes 1 + 2)
      deeper mode:  4 calls (lanes 1 + 2 + 3 + 4)
    DO NOT exceed the cap. If a lane fails (no useful result), DO NOT compensate by running a fifth call.
-4. ENFORCEMENT — at the start of EVERY Bash call, prepend a comment like `# bb call N/{LANES} (person: {slug})`. Reset N to 1 for each person in the batch.
+4. ENFORCEMENT — at the start of EVERY Bash call, prepend a comment like `# browse call N/{LANES} (person: {slug})`. Reset N to 1 for each person in the batch.
 5. BATCH all writes: write ALL people files in a SINGLE Bash call using chained heredocs.
 6. BANNED TOOLS: WebFetch, WebSearch, Write, Read, Glob, Grep — ALL BANNED.
 7. NEVER use ~ or $HOME — full literal paths.
 
 ANTI-HALLUCINATION RULES:
-- A person's `hook` MUST quote or paraphrase a SPECIFIC finding from a bb search result. NEVER infer from "they look senior" or "their company is AI-y".
+- A person's `hook` MUST quote or paraphrase a SPECIFIC finding from a browse cloud search result. NEVER infer from "they look senior" or "their company is AI-y".
 - If lanes 2-4 yield no public signal in the last 6 months, fall back to event-context (their talk title from the bio field). Event-context is always available and beats a fabricated hook.
 - The DM opener MUST reference the hook verbatim. If the hook is event-context, name the talk title. Do NOT name a podcast or blog post the person didn't actually appear in.
 
 LANE PROMPTS (run only the lanes for your DEPTH):
 
 Lane 1 (always):
-  # bb call 1/{LANES} (person: {slug})
-  bb search "\"{name}\" \"{company}\" linkedin" --num-results 5
+  # browse call 1/{LANES} (person: {slug})
+  browse cloud search "\"{name}\" \"{company}\" linkedin" --num-results 5
   → harvest LinkedIn URL + verify current title
 
 Lane 2 (deep + deeper):
-  # bb call 2/{LANES} (person: {slug})
-  bb search "\"{name}\" podcast OR talk OR blog 2026" --num-results 5
+  # browse call 2/{LANES} (person: {slug})
+  browse cloud search "\"{name}\" podcast OR talk OR blog 2026" --num-results 5
   → harvest most-recent activity. If a podcast/blog/talk URL appears, that's a candidate hook.
 
 Lane 3 (deeper only):
-  # bb call 3/{LANES} (person: {slug})
-  bb search "\"{name}\" github" --num-results 5
+  # browse call 3/{LANES} (person: {slug})
+  browse cloud search "\"{name}\" github" --num-results 5
   → harvest github.com/{handle} URL if present
 
 Lane 4 (deeper only):
-  # bb call 4/{LANES} (person: {slug})
-  bb search "\"{name}\" site:x.com OR site:twitter.com" --num-results 5
+  # browse call 4/{LANES} (person: {slug})
+  browse cloud search "\"{name}\" site:x.com OR site:twitter.com" --num-results 5
   → harvest x.com/{handle} URL + most recent post topic if shown
 
 HOOK SOURCE PRIORITY (run sequentially, stop at first hit):

--- a/skills/event-prospecting/references/workflow.md
+++ b/skills/event-prospecting/references/workflow.md
@@ -134,7 +134,7 @@ TOOL RULES — CRITICAL:
 1. You may ONLY use the Bash tool. No exceptions.
 2. All searches:  browse cloud search "..." --num-results 10
 3. All page extractions:  node {SKILL_DIR}/scripts/extract_page.mjs "URL" --max-chars 3000
-   (handles JSON envelope, meta tags, JS-render fallback to browse get markdown)
+   (uses `--output` to avoid the stdout JSON envelope, preserves meta tags, and falls back to browse get markdown when needed)
    DO NOT hand-roll a `browse cloud fetch | sed` pipeline. Use raw `browse cloud fetch` only for sitemap.xml / llms.txt.
 4. HARD TOOL-CALL CAP: 5 calls per company. Budget:
      1× extract_page on homepage
@@ -220,7 +220,7 @@ Report back ONLY: "Deep research batch: {researched}/{total} companies, {finding
 1. `browse cloud search "{name} {company} linkedin"` — always (deep + deeper)
 2. `browse cloud search "{name} podcast OR talk OR blog 2026"` — deep + deeper
 3. `browse cloud search "{name} github"` — deeper only
-4. `browse cloud search "{name} site:x.com OR site:twitter.com"` — deeper only
+4. `browse cloud search "{name} site:x.com OR site:twitter.com"` — deeper only, best-effort
 
 Deep mode: lanes 1-2 (max 2 calls/person). Deeper mode: lanes 1-4 (max 4 calls/person).
 
@@ -284,7 +284,7 @@ Lane 3 (deeper only):
 Lane 4 (deeper only):
   # browse call 4/{LANES} (person: {slug})
   browse cloud search "\"{name}\" site:x.com OR site:twitter.com" --num-results 5
-  → harvest x.com/{handle} URL + most recent post topic if shown
+  → attempt to find x.com/{handle} URL + most recent post topic; leave null if no direct profile appears
 
 HOOK SOURCE PRIORITY (run sequentially, stop at first hit):
 1. Recent activity (lane 2): podcast title / blog headline / talk title from the last 6 months. THIS IS THE BEST HOOK — concrete, dated, public.

--- a/skills/event-prospecting/scripts/extract_event.mjs
+++ b/skills/event-prospecting/scripts/extract_event.mjs
@@ -91,17 +91,17 @@ function extractFromNextData(paths) {
       image: pickImage(s),
     }));
   })()`;
-  // Don't JSON.parse goto's output — `browse goto` can emit non-JSON banners,
+  // Don't JSON.parse open's output — `browse open` can emit non-JSON banners,
   // and we don't use the return value. The matching `extractFromMarkdown` path
   // ignores it the same way.
-  browse('goto', recon.url);
+  browse('open', recon.url);
   browse('wait', 'timeout', '2000');
   const evalRes = JSON.parse(browse('eval', js));
   return evalRes.result || [];
 }
 
 function extractFromMarkdown() {
-  browse('goto', recon.url);
+  browse('open', recon.url);
   browse('wait', 'timeout', '2500');
   const md = JSON.parse(browse('get', 'markdown')).markdown || '';
   // Naive: find blocks of "#### {Name}\n\n{Role}\n\n{Company}\n\n[LinkedIn]({url})"

--- a/skills/event-prospecting/scripts/extract_page.mjs
+++ b/skills/event-prospecting/scripts/extract_page.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // Extract structured page content for company research.
-// Fetches via `bb fetch` (raw HTML to a temp file), pulls title + meta tags
-// + visible body text, and auto-falls back to `bb browse` when content is thin.
+// Fetches via `browse cloud fetch` (raw HTML to a temp file), pulls title + meta tags
+// + visible body text, and auto-falls back to `browse get markdown` when content is thin.
 //
 // Usage: node extract_page.mjs <url> [--max-chars N]
 // Output (stdout): structured block consumable by a research subagent.
@@ -27,24 +27,24 @@ function parseArgs(argv) {
   return args;
 }
 
-function bbFetch(url, outFile) {
-  execFileSync("bb", ["fetch", "--allow-redirects", url, "--output", outFile], {
+function browseFetch(url, outFile) {
+  execFileSync("browse", ["cloud", "fetch", "--allow-redirects", url, "--output", outFile], {
     stdio: ["ignore", "ignore", "ignore"],
   });
 }
 
-function bbBrowseMarkdown(url) {
+function browseGetMarkdown(url) {
   try {
-    execFileSync("bb", ["browse", "--headless", "open", url], {
+    execFileSync("browse", ["open", url, "--local", "--headless"], {
       stdio: ["ignore", "ignore", "ignore"],
       timeout: 90000,
     });
-    const out = execFileSync("bb", ["browse", "--headless", "get", "markdown"], {
+    const out = execFileSync("browse", ["get", "markdown", "--local", "--headless"], {
       encoding: "utf8",
       timeout: 90000,
       maxBuffer: 50 * 1024 * 1024,
     });
-    // bb browse prints banners (e.g. "Update available...") before the JSON blob.
+    // browse prints banners (e.g. "Update available...") before the JSON blob.
     // Find the first '{' and try to JSON.parse from there.
     const start = out.indexOf("{");
     if (start < 0) return "";
@@ -122,11 +122,11 @@ function main() {
   let html = "";
   let fetchOk = false;
   try {
-    bbFetch(url, htmlFile);
+    browseFetch(url, htmlFile);
     html = readFileSync(htmlFile, "utf8");
     fetchOk = true;
   } catch (err) {
-    console.error(`[extract_page] bb fetch failed: ${err.message}`);
+    console.error(`[extract_page] browse cloud fetch failed: ${err.message}`);
   }
 
   const title = extractTitle(html);
@@ -136,10 +136,10 @@ function main() {
   const headings = extractHeadings(html);
   let body = extractVisibleText(html, maxChars);
 
-  // Thin content → JS-rendered SPA → fall back to bb browse.
+  // Thin content → JS-rendered SPA → fall back to browse get markdown.
   let fallbackUsed = false;
   if (body.length < THIN_CONTENT_THRESHOLD) {
-    const md = bbBrowseMarkdown(url);
+    const md = browseGetMarkdown(url);
     if (md && md.length > body.length) {
       body = md.replace(/\s+/g, " ").slice(0, maxChars);
       fallbackUsed = true;

--- a/skills/event-prospecting/scripts/extract_page.mjs
+++ b/skills/event-prospecting/scripts/extract_page.mjs
@@ -34,15 +34,19 @@ function browseFetch(url, outFile) {
 }
 
 function browseGetMarkdown(url) {
+  const session = `extract-page-${process.pid}-${Date.now()}`;
+  const env = { ...process.env, BROWSE_SESSION: session };
   try {
     execFileSync("browse", ["open", url, "--local", "--headless"], {
       stdio: ["ignore", "ignore", "ignore"],
       timeout: 90000,
+      env,
     });
     const out = execFileSync("browse", ["get", "markdown"], {
       encoding: "utf8",
       timeout: 90000,
       maxBuffer: 50 * 1024 * 1024,
+      env,
     });
     // browse prints banners (e.g. "Update available...") before the JSON blob.
     // Find the first '{' and try to JSON.parse from there.
@@ -62,6 +66,14 @@ function browseGetMarkdown(url) {
     return "";
   } catch (err) {
     return "";
+  } finally {
+    try {
+      execFileSync("browse", ["stop"], {
+        stdio: ["ignore", "ignore", "ignore"],
+        timeout: 15000,
+        env,
+      });
+    } catch {}
   }
 }
 

--- a/skills/event-prospecting/scripts/extract_page.mjs
+++ b/skills/event-prospecting/scripts/extract_page.mjs
@@ -39,7 +39,7 @@ function browseGetMarkdown(url) {
       stdio: ["ignore", "ignore", "ignore"],
       timeout: 90000,
     });
-    const out = execFileSync("browse", ["get", "markdown", "--local", "--headless"], {
+    const out = execFileSync("browse", ["get", "markdown"], {
       encoding: "utf8",
       timeout: 90000,
       maxBuffer: 50 * 1024 * 1024,

--- a/skills/event-prospecting/scripts/recon.mjs
+++ b/skills/event-prospecting/scripts/recon.mjs
@@ -33,7 +33,7 @@ function browse(...subargs) {
 
 function probe() {
   // Navigate + settle
-  browse('goto', url);
+  browse('open', url);
   browse('wait', 'timeout', '2500');
   const titleRes = JSON.parse(browse('get', 'title'));
   const title = titleRes.title || '';

--- a/skills/functions/REFERENCE.md
+++ b/skills/functions/REFERENCE.md
@@ -129,7 +129,6 @@ cat .env
 
 # Or set for current shell
 export BROWSERBASE_API_KEY="your_key"
-export BROWSERBASE_PROJECT_ID="your_project"
 ```
 
 ### Dev server won't start

--- a/skills/functions/SKILL.md
+++ b/skills/functions/SKILL.md
@@ -6,7 +6,7 @@ license: MIT
 
 # Browserbase Functions
 
-Deploy serverless browser automation using the official `bb` CLI.
+Deploy serverless browser automation using the official `browse` CLI.
 
 ## Prerequisites
 
@@ -78,7 +78,7 @@ defineFn("my-function", async (context) => {
 ### 1. Start Dev Server
 
 ```bash
-pnpm bb dev index.ts
+browse functions dev index.ts
 ```
 
 Server runs at `http://127.0.0.1:14113`
@@ -98,7 +98,7 @@ The dev server auto-reloads on file changes. Use `console.log()` for debugging -
 ## Deploying
 
 ```bash
-pnpm bb publish index.ts
+browse functions publish index.ts
 ```
 
 Output:
@@ -115,7 +115,7 @@ Function ID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 | Command | Description |
 |---------|-------------|
 | `pnpm dlx @browserbasehq/sdk-functions init <name>` | Create new project |
-| `pnpm bb dev <file>` | Start local dev server |
-| `pnpm bb publish <file>` | Deploy to Browserbase |
+| `browse functions dev <file>` | Start local dev server |
+| `browse functions publish <file>` | Deploy to Browserbase |
 
 For invocation examples, common patterns, and troubleshooting, see [REFERENCE.md](REFERENCE.md).

--- a/skills/functions/SKILL.md
+++ b/skills/functions/SKILL.md
@@ -10,11 +10,10 @@ Deploy serverless browser automation using the official `browse` CLI.
 
 ## Prerequisites
 
-Get API key and Project ID from: https://browserbase.com/settings
+Get an API key from: https://browserbase.com/settings
 
 ```bash
 export BROWSERBASE_API_KEY="your_api_key"
-export BROWSERBASE_PROJECT_ID="your_project_id"
 ```
 
 ## Creating a Function Project
@@ -22,7 +21,7 @@ export BROWSERBASE_PROJECT_ID="your_project_id"
 ### 1. Initialize
 
 ```bash
-pnpm dlx @browserbasehq/sdk-functions init my-function
+browse functions init my-function
 cd my-function
 ```
 
@@ -38,7 +37,6 @@ my-function/
 
 ```bash
 echo "BROWSERBASE_API_KEY=$BROWSERBASE_API_KEY" >> .env
-echo "BROWSERBASE_PROJECT_ID=$BROWSERBASE_PROJECT_ID" >> .env
 ```
 
 ### 3. Install Dependencies
@@ -114,7 +112,7 @@ Function ID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 
 | Command | Description |
 |---------|-------------|
-| `pnpm dlx @browserbasehq/sdk-functions init <name>` | Create new project |
+| `browse functions init <name>` | Create new project |
 | `browse functions dev <file>` | Start local dev server |
 | `browse functions publish <file>` | Deploy to Browserbase |
 

--- a/skills/ui-test/EXAMPLES.md
+++ b/skills/ui-test/EXAMPLES.md
@@ -14,8 +14,7 @@ git diff HEAD~1 -- src/components/HeroSection.tsx
 # Shows: "Get Started" changed to "Start Free Trial"
 
 # Setup
-browse env local
-browse open http://localhost:3000/
+browse open http://localhost:3000/ --local
 browse wait load
 
 # BEFORE snapshot
@@ -60,8 +59,7 @@ browse stop
 **User request**: "I added email validation to the signup form. Test it thoroughly."
 
 ```bash
-browse env local
-browse open http://localhost:3000/signup
+browse open http://localhost:3000/signup --local
 browse wait load
 
 # ---- Test 1: Invalid email → error ----
@@ -138,7 +136,7 @@ browse wait load
 browse fill "input[name=email]" "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@test.com"
 browse snapshot
 # Check: does the input overflow its container? Is layout broken?
-browse screenshot /tmp/long-email.png
+browse screenshot --path /tmp/long-email.png
 # Visual check: input stays within bounds
 
 browse click @0-7
@@ -186,8 +184,7 @@ browse stop
 **User request**: "I added a confirmation modal to delete. Test it."
 
 ```bash
-browse env local
-browse open http://localhost:3000/dashboard
+browse open http://localhost:3000/dashboard --local
 browse wait load
 
 # ---- Test 1: Modal opens ----
@@ -268,8 +265,7 @@ browse stop
 **User request**: "Run accessibility tests on the settings page."
 
 ```bash
-browse env local
-browse open http://localhost:3000/settings
+browse open http://localhost:3000/settings --local
 browse wait load
 
 # ---- Test 1: axe-core audit ----
@@ -312,8 +308,7 @@ browse stop
 **User request**: "Does my app work on mobile?"
 
 ```bash
-browse env local
-browse open http://localhost:3000/
+browse open http://localhost:3000/ --local
 browse wait load
 
 # ---- Desktop baseline ----
@@ -321,7 +316,7 @@ browse viewport 1440 900
 browse wait timeout 500
 browse snapshot
 # Record desktop state: nav layout, content width, element positions
-browse screenshot /tmp/desktop.png --full-page
+browse screenshot --path /tmp/desktop.png --full-page
 
 # ---- Mobile ----
 browse viewport 375 812
@@ -331,7 +326,7 @@ browse snapshot
 # - Did nav collapse to hamburger? Or is it overflowing?
 # - Is content full-width? Or is there horizontal scroll?
 # - Are buttons large enough for touch (44px+)?
-browse screenshot /tmp/mobile.png --full-page
+browse screenshot --path /tmp/mobile.png --full-page
 
 # Check for horizontal overflow (deterministic)
 browse eval "document.documentElement.scrollWidth > document.documentElement.clientWidth"
@@ -348,7 +343,7 @@ browse eval "JSON.stringify(Array.from(document.querySelectorAll('button,a,[role
 # ---- Tablet ----
 browse viewport 768 1024
 browse wait timeout 1000
-browse screenshot /tmp/tablet.png --full-page
+browse screenshot --path /tmp/tablet.png --full-page
 
 browse stop
 ```
@@ -358,7 +353,7 @@ browse stop
 **User request**: "Are there any JS errors on my app?"
 
 ```bash
-browse env local
+browse open about:blank --local
 
 # Check each route for failed resource loads and JS errors
 # Note: console capture injected on about:blank gets wiped on navigation.
@@ -408,9 +403,12 @@ browse stop
 node .claude/skills/cookie-sync/scripts/cookie-sync.mjs --domains staging.myapp.com
 # Output: Context ID: ctx_7f3a9b2c
 
-# Step 2: Remote mode
-browse env remote
-browse open https://staging.myapp.com/dashboard --context-id ctx_7f3a9b2c --persist
+# Step 2: Remote mode with the synced context
+SESSION_JSON="$(browse cloud sessions create --context-id ctx_7f3a9b2c --persist --keep-alive)"
+SESSION_ID="$(echo "$SESSION_JSON" | jq -r .id)"
+CONNECT_URL="$(echo "$SESSION_JSON" | jq -r .connectUrl)"
+
+browse open https://staging.myapp.com/dashboard --cdp "$CONNECT_URL"
 browse wait load
 
 # Verify authenticated state
@@ -422,7 +420,7 @@ browse get url
 # STEP_PASS|remote-auth|authenticated dashboard loaded, user avatar present, URL is /dashboard
 
 # Run tests against authenticated pages
-browse open https://staging.myapp.com/settings --context-id ctx_7f3a9b2c
+browse open https://staging.myapp.com/settings
 browse wait load
 browse snapshot
 # Verify settings content loads
@@ -435,6 +433,7 @@ browse wait timeout 3000
 browse eval "axe.run().then(r => JSON.stringify({ violations: r.violations.length, passes: r.passes.length }))"
 
 browse stop
+browse cloud sessions update "$SESSION_ID" --status REQUEST_RELEASE
 ```
 
 ## Example 8: Exploratory Testing — Try to Break It
@@ -442,13 +441,12 @@ browse stop
 **User request**: "Explore my app and find bugs."
 
 ```bash
-browse env local
-browse open http://localhost:3000/
+browse open http://localhost:3000/ --local
 browse wait load
 
 # ---- First impressions ----
 browse snapshot
-browse screenshot /tmp/explore-home.png
+browse screenshot --path /tmp/explore-home.png
 
 # Console health check
 browse eval "JSON.stringify({errors: (window.__logs || []).length})"
@@ -481,7 +479,7 @@ browse snapshot
 # Extremely long input
 browse fill "textarea[name=message]" "This is a very long message that keeps going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going"
 browse snapshot
-browse screenshot /tmp/long-input.png
+browse screenshot --path /tmp/long-input.png
 # Check: does textarea grow? Overflow? Break layout?
 
 # Special characters
@@ -547,8 +545,11 @@ Use the Agent tool — send all three in a single message so they run concurrent
 Agent 1 prompt:
   "You are running UI tests on https://staging.myapp.com/signup.
    Use BROWSE_SESSION=signup for every browse command.
-   Start with: BROWSE_SESSION=signup browse env remote
-   Then: BROWSE_SESSION=signup browse open https://staging.myapp.com/signup --context-id ctx_7f3a9b2c
+   Start with:
+     SESSION_JSON="$(browse cloud sessions create --context-id ctx_7f3a9b2c --keep-alive)"
+     SESSION_ID="$(echo "$SESSION_JSON" | jq -r .id)"
+     CONNECT_URL="$(echo "$SESSION_JSON" | jq -r .connectUrl)"
+     BROWSE_SESSION=signup browse open https://staging.myapp.com/signup --cdp "$CONNECT_URL"
 
    Run these tests using the before/after snapshot pattern:
    1. [happy] Fill valid email, submit, verify success
@@ -559,26 +560,32 @@ Agent 1 prompt:
    For each test: snapshot BEFORE, act, snapshot AFTER, compare, emit:
      STEP_PASS|<id>|<evidence>  or  STEP_FAIL|<id>|<expected> → <actual>
 
-   When done: BROWSE_SESSION=signup browse stop"
+   When done: BROWSE_SESSION=signup browse stop; browse cloud sessions update "$SESSION_ID" --status REQUEST_RELEASE"
 
 Agent 2 prompt:
   "You are running UI tests on https://staging.myapp.com/dashboard.
    Use BROWSE_SESSION=dashboard for every browse command.
-   Start with: BROWSE_SESSION=dashboard browse env remote
-   Then: BROWSE_SESSION=dashboard browse open https://staging.myapp.com/dashboard --context-id ctx_7f3a9b2c
+   Start with:
+     SESSION_JSON="$(browse cloud sessions create --context-id ctx_7f3a9b2c --keep-alive)"
+     SESSION_ID="$(echo "$SESSION_JSON" | jq -r .id)"
+     CONNECT_URL="$(echo "$SESSION_JSON" | jq -r .connectUrl)"
+     BROWSE_SESSION=dashboard browse open https://staging.myapp.com/dashboard --cdp "$CONNECT_URL"
 
    Run these tests:
    1. Check empty state — is there a message and CTA, or blank?
    2. Check data display — table columns, row count, formatting
    3. Check console errors — inject capture, interact, check __logs
 
-   Emit STEP_PASS/STEP_FAIL markers. When done: BROWSE_SESSION=dashboard browse stop"
+   Emit STEP_PASS/STEP_FAIL markers. When done: BROWSE_SESSION=dashboard browse stop; browse cloud sessions update "$SESSION_ID" --status REQUEST_RELEASE"
 
 Agent 3 prompt:
   "You are running accessibility tests on https://staging.myapp.com/settings.
    Use BROWSE_SESSION=a11y for every browse command.
-   Start with: BROWSE_SESSION=a11y browse env remote
-   Then: BROWSE_SESSION=a11y browse open https://staging.myapp.com/settings --context-id ctx_7f3a9b2c
+   Start with:
+     SESSION_JSON="$(browse cloud sessions create --context-id ctx_7f3a9b2c --keep-alive)"
+     SESSION_ID="$(echo "$SESSION_JSON" | jq -r .id)"
+     CONNECT_URL="$(echo "$SESSION_JSON" | jq -r .connectUrl)"
+     BROWSE_SESSION=a11y browse open https://staging.myapp.com/settings --cdp "$CONNECT_URL"
 
    Run these tests:
    1. axe-core audit — load script, run, check violations
@@ -586,7 +593,7 @@ Agent 3 prompt:
    3. Keyboard nav — Tab through all elements, verify focus order
    4. Broken images — check naturalWidth on all img elements
 
-   Emit STEP_PASS/STEP_FAIL markers. When done: BROWSE_SESSION=a11y browse stop"
+   Emit STEP_PASS/STEP_FAIL markers. When done: BROWSE_SESSION=a11y browse stop; browse cloud sessions update "$SESSION_ID" --status REQUEST_RELEASE"
 ```
 
 **Step 4: Merge results**
@@ -636,9 +643,9 @@ BROWSE_SESSION=a11y browse stop 2>/dev/null
 - **Use structured markers** — `STEP_PASS|id|evidence` or `STEP_FAIL|id|expected → actual|screenshot-path`
 - **Screenshot every failure** — save to `.context/ui-test-screenshots/<step-id>.png` so devs can see what broke
 - **Local for localhost** — never send localhost traffic through Browserbase
-- **Default localhost run** — start with `browse env local` for clean, reproducible QA
-- **Use `--auto-connect` selectively** — only when a localhost test explicitly needs existing local Chrome login/cookies/state (`browse env local --auto-connect`)
-- **Explicit local CDP attach** — use `browse env local <port|url>` when you must target a specific local browser instance
+- **Default localhost run** — start with `browse open <url> --local` for clean, reproducible QA
+- **Use `--auto-connect` selectively** — only when a localhost test explicitly needs existing local Chrome login/cookies/state (`browse open <url> --auto-connect`)
+- **Explicit local CDP attach** — use `browse open <url> --cdp <port|url>` when you must target a specific local browser instance
 - **Always `browse stop` when done** — for parallel runs, stop every named session
 - **`.then()` not `await`** — browse eval doesn't support top-level await
 - **Parallelize with `BROWSE_SESSION`** — each named session gets its own Browserbase browser; fan out via Agent tool

--- a/skills/ui-test/README.md
+++ b/skills/ui-test/README.md
@@ -44,7 +44,7 @@ which browse || npm install -g browse
 ```
 
 - **Localhost** → `browse open <url> --local` (no API key needed)
-- **Need existing local login/cookies/state on localhost** → `browse open <url> --auto-connect` (auto-discover local Chrome, fallback to isolated)
+- **Need existing local login/cookies/state on localhost** → `browse open <url> --auto-connect` (requires an existing debuggable local Chrome)
 - **Need explicit local CDP attach** → `browse open <url> --cdp <port|url>`
 - **Deployed sites** → `browse open <url> --remote` (uses Browserbase cloud browsers)
 - **Parallel** → `BROWSE_SESSION=<name>` for independent concurrent sessions

--- a/skills/ui-test/README.md
+++ b/skills/ui-test/README.md
@@ -43,13 +43,13 @@ npx skills add browserbase/ui-test
 which browse || npm install -g browse
 ```
 
-- **Localhost** → `browse env local` (no API key needed)
-- **Need existing local login/cookies/state on localhost** → `browse env local --auto-connect` (auto-discover local Chrome, fallback to isolated)
-- **Need explicit local CDP attach** → `browse env local <port|url>`
-- **Deployed sites** → `browse env remote` (uses Browserbase cloud browsers)
+- **Localhost** → `browse open <url> --local` (no API key needed)
+- **Need existing local login/cookies/state on localhost** → `browse open <url> --auto-connect` (auto-discover local Chrome, fallback to isolated)
+- **Need explicit local CDP attach** → `browse open <url> --cdp <port|url>`
+- **Deployed sites** → `browse open <url> --remote` (uses Browserbase cloud browsers)
 - **Parallel** → `BROWSE_SESSION=<name>` for independent concurrent sessions
 
-For default localhost QA, start with `browse env local` for clean, reproducible runs.
+For default localhost QA, pass `--local` on the first `browse open` for clean, reproducible runs.
 
 ## Project Structure
 

--- a/skills/ui-test/README.md
+++ b/skills/ui-test/README.md
@@ -40,7 +40,7 @@ npx skills add browserbase/ui-test
 ## Browser Execution
 
 ```bash
-which browse || npm install -g @browserbasehq/browse-cli
+which browse || npm install -g browse
 ```
 
 - **Localhost** → `browse env local` (no API key needed)
@@ -77,6 +77,6 @@ No YAML files, no generated test suites, no artifacts. The agent reads the diff 
 
 ## Requirements
 
-- `browse` CLI (`npm install -g @browserbasehq/browse-cli`)
+- `browse` CLI (`npm install -g browse`)
 - For remote testing: `BROWSERBASE_API_KEY` environment variable
 - A running web app (localhost or deployed URL)

--- a/skills/ui-test/SKILL.md
+++ b/skills/ui-test/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   author: browserbase
   version: "0.4.0"
 allowed-tools: Bash Read Glob Grep Agent
-compatibility: "Requires the browse CLI (`npm install -g @browserbasehq/browse-cli`). For remote testing: BROWSERBASE_API_KEY and cookie-sync skill."
+compatibility: "Requires the browse CLI (`npm install -g browse`). For remote testing: BROWSERBASE_API_KEY and cookie-sync skill."
 ---
 
 # UI Test — Agentic UI Testing Skill
@@ -175,7 +175,7 @@ browse screenshot --path .context/ui-test-screenshots/modal-open.png
 ## Setup
 
 ```bash
-which browse || npm install -g @browserbasehq/browse-cli
+which browse || npm install -g browse
 ```
 
 ### Avoid permission fatigue

--- a/skills/ui-test/SKILL.md
+++ b/skills/ui-test/SKILL.md
@@ -200,24 +200,23 @@ The first pattern covers plain `browse` commands. The second covers parallel ses
 
 | Target | Mode | Command | Auth |
 |--------|------|---------|------|
-| `localhost` / `127.0.0.1` | Local | `browse env local` | None needed (clean isolated local browser by default) |
-| Deployed/staging site | Remote | `browse env remote` | cookie-sync → `--context-id` |
+| `localhost` / `127.0.0.1` | Local | `browse open <url> --local` | None needed (clean isolated local browser by default) |
+| Deployed/staging site | Remote | `browse open <url> --remote` | Browserbase credentials; use contexts where supported |
 
-**Rule: If the target URL contains `localhost` or `127.0.0.1`, always use `browse env local`.**
+**Rule: If the target URL contains `localhost` or `127.0.0.1`, pass `--local` on the first `browse open`.**
 
 ### Local Mode (default for localhost)
 
 ```bash
-browse env local
-browse open http://localhost:3000
+browse open http://localhost:3000 --local
 ```
 
-`browse env local` uses a clean isolated local browser by default, which is best for reproducible localhost QA runs.
+`browse open ... --local` uses a clean isolated local browser by default, which is best for reproducible localhost QA runs.
 
 Use local-mode variants only when needed:
 
-- `browse env local --auto-connect` — auto-discover existing local Chrome, fallback to isolated. Use this only when the test explicitly needs existing local login/cookies/state.
-- `browse env local <port|url>` — attach to a specific CDP target (explicit local browser attach).
+- `browse open <url> --auto-connect` — auto-discover existing local Chrome, fallback to isolated. Use this only when the test explicitly needs existing local login/cookies/state.
+- `browse open <url> --cdp <port|url>` — attach to a specific CDP target (explicit local browser attach).
 
 ### Remote Mode (deployed sites via cookie-sync)
 
@@ -226,9 +225,8 @@ Use local-mode variants only when needed:
 node .claude/skills/cookie-sync/scripts/cookie-sync.mjs --domains your-app.com
 # Output: Context ID: ctx_abc123
 
-# Step 2: Switch to remote mode
-browse env remote
-browse open https://staging.your-app.com --context-id ctx_abc123 --persist
+# Step 2: Open in remote mode
+browse open https://staging.your-app.com --remote
 browse snapshot
 # ... run tests ...
 browse stop
@@ -336,14 +334,14 @@ Changed: src/components/SignupForm.tsx (added email validation)
 browse stop 2>/dev/null
 mkdir -p .context/ui-test-screenshots
 # localhost/default QA → clean, reproducible local run
-browse env local
+browse open http://localhost:3000 --local
 ```
 
 For each test, follow the **before/after pattern**:
 
 ```bash
 # Navigate
-browse open http://localhost:3000/path
+browse open http://localhost:3000/path --local
 browse wait load
 
 # BEFORE snapshot
@@ -583,7 +581,7 @@ For worked examples with exact commands, read [EXAMPLES.md](EXAMPLES.md) if you 
 3. **Before/after for every interaction** — snapshot, act, snapshot, compare
 4. **Screenshot every failure** — `browse screenshot` immediately on STEP_FAIL, save to `.context/ui-test-screenshots/<step-id>.png`
 5. **Deterministic checks first** — axe-core, console errors, form labels before visual judgment
-6. **For localhost, start with clean local mode** — use `browse env local` first for reproducible runs; use `--auto-connect` only when existing local state is required
+6. **For localhost, start with clean local mode** — pass `--local` on the first `browse open` for reproducible runs; use `--auto-connect` only when existing local state is required
 7. **Always `browse stop` when done** — for parallel runs, stop every named session
 8. **Report failures with reproduction steps** — action, expected, actual, screenshot path, suggestion
 9. **Parallelize independent tests** — use Workflow C with named sessions when testing multiple pages or categories on a deployed site

--- a/skills/ui-test/SKILL.md
+++ b/skills/ui-test/SKILL.md
@@ -215,7 +215,7 @@ browse open http://localhost:3000 --local
 
 Use local-mode variants only when needed:
 
-- `browse open <url> --auto-connect` — auto-discover existing local Chrome, fallback to isolated. Use this only when the test explicitly needs existing local login/cookies/state.
+- `browse open <url> --auto-connect` — auto-discover an existing debuggable local Chrome. Use this only when the test explicitly needs existing local login/cookies/state.
 - `browse open <url> --cdp <port|url>` — attach to a specific CDP target (explicit local browser attach).
 
 ### Remote Mode (deployed sites via cookie-sync)
@@ -225,11 +225,16 @@ Use local-mode variants only when needed:
 node .claude/skills/cookie-sync/scripts/cookie-sync.mjs --domains your-app.com
 # Output: Context ID: ctx_abc123
 
-# Step 2: Open in remote mode
-browse open https://staging.your-app.com --remote
+# Step 2: Open in remote mode with the synced context
+SESSION_JSON="$(browse cloud sessions create --context-id ctx_abc123 --persist --keep-alive)"
+SESSION_ID="$(echo "$SESSION_JSON" | jq -r .id)"
+CONNECT_URL="$(echo "$SESSION_JSON" | jq -r .connectUrl)"
+
+browse open https://staging.your-app.com --cdp "$CONNECT_URL"
 browse snapshot
 # ... run tests ...
 browse stop
+browse cloud sessions update "$SESSION_ID" --status REQUEST_RELEASE
 ```
 
 Cookie-sync flags: `--domains`, `--context`, `--stealth`, `--proxy "City,ST,US"`

--- a/skills/ui-test/references/browser-recipes.md
+++ b/skills/ui-test/references/browser-recipes.md
@@ -123,17 +123,17 @@ browse wait load
 # Mobile (iPhone SE)
 browse viewport 375 812
 browse wait timeout 1000
-browse screenshot /tmp/mobile.png --full-page
+browse screenshot --path /tmp/mobile.png --full-page
 
 # Tablet (iPad)
 browse viewport 768 1024
 browse wait timeout 1000
-browse screenshot /tmp/tablet.png --full-page
+browse screenshot --path /tmp/tablet.png --full-page
 
 # Desktop
 browse viewport 1440 900
 browse wait timeout 1000
-browse screenshot /tmp/desktop.png --full-page
+browse screenshot --path /tmp/desktop.png --full-page
 ```
 
 After capturing, read each screenshot with the Read tool and evaluate:
@@ -183,7 +183,7 @@ Navigate to a page/section with no data and screenshot it:
 ```bash
 browse open "TARGET_URL"  # e.g., /sessions with no sessions
 browse wait load
-browse screenshot /tmp/empty-state.png --full-page
+browse screenshot --path /tmp/empty-state.png --full-page
 browse snapshot  # check if there's helpful text/CTA
 ```
 

--- a/skills/ui-test/references/parallel-testing.md
+++ b/skills/ui-test/references/parallel-testing.md
@@ -11,21 +11,19 @@ The `--session` flag (or `BROWSE_SESSION` env var) gives each `browse` command i
 ```bash
 # Session "signup" gets its own browser
 # For localhost/default QA, use clean local mode first
-BROWSE_SESSION=signup browse env local
-BROWSE_SESSION=signup browse open http://localhost:3000/signup
+BROWSE_SESSION=signup browse open http://localhost:3000/signup --local
 
 # Session "dashboard" gets a completely separate browser
-BROWSE_SESSION=dashboard browse env local
-BROWSE_SESSION=dashboard browse open http://localhost:3000/dashboard
+BROWSE_SESSION=dashboard browse open http://localhost:3000/dashboard --local
 
 # They don't share state — each has its own page, cookies, refs
 ```
 
 Local mode variants follow the CLI contract:
 
-- `browse env local` — clean isolated local browser (default; preferred for reproducible localhost testing)
-- `browse env local --auto-connect` — auto-discover local Chrome, fallback to isolated (use only when a test needs existing local login/cookies/state)
-- `browse env local <port|url>` — explicit CDP attach to a specific local browser target
+- `browse open <url> --local` — clean isolated local browser (default; preferred for reproducible localhost testing)
+- `browse open <url> --auto-connect` — auto-discover local Chrome, fallback to isolated (use only when a test needs existing local login/cookies/state)
+- `browse open <url> --cdp <port|url>` — explicit CDP attach to a specific local browser target
 
 ### When to use parallel vs sequential
 
@@ -58,7 +56,7 @@ Use the Agent tool to fan out. Each agent gets a unique session name and runs it
 Launch agents in parallel (use Agent tool with multiple invocations in one message):
 
 Agent 1 — prompt: "Run signup form tests using BROWSE_SESSION=signup.
-  Use `browse env local` first (localhost URL). Run these tests: [list tests].
+  Start with `BROWSE_SESSION=signup browse open <localhost URL> --local`. Run these tests: [list tests].
   Follow the before/after assertion protocol.
   On any STEP_FAIL, immediately take a screenshot:
     BROWSE_SESSION=signup browse screenshot --path .context/ui-test-screenshots/signup-<step-id>.png
@@ -66,7 +64,7 @@ Agent 1 — prompt: "Run signup form tests using BROWSE_SESSION=signup.
   Run `BROWSE_SESSION=signup browse stop` when done."
 
 Agent 2 — prompt: "Run dashboard tests using BROWSE_SESSION=dashboard.
-  Use `browse env local` first (localhost URL). Run these tests: [list tests].
+  Start with `BROWSE_SESSION=dashboard browse open <localhost URL> --local`. Run these tests: [list tests].
   Follow the before/after assertion protocol.
   On any STEP_FAIL, immediately take a screenshot:
     BROWSE_SESSION=dashboard browse screenshot --path .context/ui-test-screenshots/dashboard-<step-id>.png
@@ -74,7 +72,7 @@ Agent 2 — prompt: "Run dashboard tests using BROWSE_SESSION=dashboard.
   Run `BROWSE_SESSION=dashboard browse stop` when done."
 
 Agent 3 — prompt: "Run accessibility audit using BROWSE_SESSION=a11y.
-  Use `browse env local` first (localhost URL). Run these tests: [list tests].
+  Start with `BROWSE_SESSION=a11y browse open <localhost URL> --local`. Run these tests: [list tests].
   Follow the before/after assertion protocol.
   On any STEP_FAIL, immediately take a screenshot:
     BROWSE_SESSION=a11y browse screenshot --path .context/ui-test-screenshots/a11y-<step-id>.png
@@ -84,8 +82,8 @@ Agent 3 — prompt: "Run accessibility audit using BROWSE_SESSION=a11y.
 
 **Critical rules for parallel agents:**
 - Every `browse` command in the agent MUST be prefixed with `BROWSE_SESSION=<name>`
-- If the target URL is localhost/127.0.0.1, each agent should start with `browse env local` for clean/reproducible runs
-- Use `browse env local --auto-connect` only when the test explicitly needs existing local Chrome state
+- If the target URL is localhost/127.0.0.1, each agent should start with `browse open <url> --local` for clean/reproducible runs
+- Use `browse open <url> --auto-connect` only when the test explicitly needs existing local Chrome state
 - Each agent must call `browse stop` when done (with its session name)
 - Pass the full test steps and assertion protocol to each agent — they don't have the skill context
 - Include the before/after snapshot pattern in each agent's prompt
@@ -129,12 +127,16 @@ If testing authenticated pages, sync cookies once and share the context ID acros
 node .claude/skills/cookie-sync/scripts/cookie-sync.mjs --domains staging.app.com
 # Output: Context ID: ctx_abc123
 
-# Each session uses the same context ID
-BROWSE_SESSION=settings browse env remote
-BROWSE_SESSION=settings browse open https://staging.app.com/settings --context-id ctx_abc123
+# Each named browse session attaches to its own Browserbase session with the same context ID.
+SETTINGS_JSON="$(browse cloud sessions create --context-id ctx_abc123 --keep-alive)"
+SETTINGS_ID="$(echo "$SETTINGS_JSON" | jq -r .id)"
+SETTINGS_CDP="$(echo "$SETTINGS_JSON" | jq -r .connectUrl)"
+BROWSE_SESSION=settings browse open https://staging.app.com/settings --cdp "$SETTINGS_CDP"
 
-BROWSE_SESSION=profile browse env remote
-BROWSE_SESSION=profile browse open https://staging.app.com/profile --context-id ctx_abc123
+PROFILE_JSON="$(browse cloud sessions create --context-id ctx_abc123 --keep-alive)"
+PROFILE_ID="$(echo "$PROFILE_JSON" | jq -r .id)"
+PROFILE_CDP="$(echo "$PROFILE_JSON" | jq -r .connectUrl)"
+BROWSE_SESSION=profile browse open https://staging.app.com/profile --cdp "$PROFILE_CDP"
 ```
 
 ### Cleanup
@@ -145,4 +147,6 @@ Always stop all sessions when done, even if a test fails:
 BROWSE_SESSION=signup browse stop 2>/dev/null
 BROWSE_SESSION=dashboard browse stop 2>/dev/null
 BROWSE_SESSION=a11y browse stop 2>/dev/null
+browse cloud sessions update "$SETTINGS_ID" --status REQUEST_RELEASE 2>/dev/null
+browse cloud sessions update "$PROFILE_ID" --status REQUEST_RELEASE 2>/dev/null
 ```

--- a/skills/ui-test/references/parallel-testing.md
+++ b/skills/ui-test/references/parallel-testing.md
@@ -22,7 +22,7 @@ BROWSE_SESSION=dashboard browse open http://localhost:3000/dashboard --local
 Local mode variants follow the CLI contract:
 
 - `browse open <url> --local` — clean isolated local browser (default; preferred for reproducible localhost testing)
-- `browse open <url> --auto-connect` — auto-discover local Chrome, fallback to isolated (use only when a test needs existing local login/cookies/state)
+- `browse open <url> --auto-connect` — auto-discover an existing debuggable local Chrome (use only when a test needs existing local login/cookies/state)
 - `browse open <url> --cdp <port|url>` — explicit CDP attach to a specific local browser target
 
 ### When to use parallel vs sequential


### PR DESCRIPTION
## Summary

The `@browserbasehq/cli` (`bb`) and `@browserbasehq/browse-cli` packages were merged into a single `browse` package shipped via `npm install -g browse`. This PR updates skill docs, examples, and scripts that referenced the old packages, the `bb` command, or stale unified-CLI command shapes.

**Command surface migration**

| Old | New |
| --- | --- |
| `bb fetch \| search \| sessions \| projects \| contexts \| extensions` | `browse cloud <subcommand>` |
| `bb functions <subcommand>` | `browse functions <subcommand>` |
| `bb templates <subcommand>` | `browse templates <subcommand>` |
| `bb skills install` | `browse skills install` |
| `bb browse <subcommand>` | top-level `browse <subcommand>` (`browse open`, `browse get`, `browse click`, …) |
| `pnpm bb dev \| publish` | `browse functions dev \| publish` |
| `# bb call N/TOTAL` enforcement comments | `# browse call N/TOTAL` |
| `npm i -g @browserbasehq/cli` / `@browserbasehq/browse-cli` | `npm i -g browse` |
| old browser lifecycle examples (`browse env`, `browse newpage`, `browse pages`, `browse tab_switch`, positional screenshots, global `--ws`) | `browse open ... --local/--remote/--auto-connect/--cdp`, `browse tab ...`, `browse screenshot --path`, per-command `--cdp` |

**Out of scope (intentionally untouched)**

- SDK variable names like `const bb = new Browserbase(...)` — these are Browserbase JS/Python SDK instances, not CLI references.
- The `x-bb-api-key` HTTP header used by the Browserbase API.
- Local script filenames `bb-capture.mjs` / `bb-finalize.mjs` (the contents shell out to `browse cloud sessions …` now).
- The `skills/browserbase-cli/` directory name (renaming would break installed skill paths).

## Files

35 files changed: skill docs/references/examples plus helper scripts including `extract_page.mjs`, `list_urls.mjs`, `bb-capture.mjs`, `bb-finalize.mjs`, `snapshot-loop.mjs`, `autobrowse/scripts/evaluate.mjs`, and cookie-sync output guidance.

## E2E Test Matrix

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `npm install -g --prefix <temp prefix> browse@latest && browse --version && browse --help` | Installed `browse@0.6.0`; help showed `cloud`, `functions`, `skills`, `templates`, plus top-level browser commands such as `open`, `get`, `click`, `snapshot`, `status`, and `stop`. | Proves the package users install exposes the unified command taxonomy. |
| Local browser lifecycle: `browse open <data fixture> --local --headless --session <temp>`, `browse fill`, `browse click`, `browse get text`, `browse screenshot --path <png>`, `browse reload`, `browse stop`, `browse status` | Open returned `mode: managed-local` and fixture title; fill/click changed the page text to `Hello <input>`; screenshot wrote a PNG; stop returned `stopped: true`; final status showed `browserConnected: false`. | Proves the new local lifecycle docs work with the current per-command `--local`/`--headless` flags. |
| Remote browser lifecycle: `browse open https://example.com --remote --session <temp>`, `browse get title`, `browse get text body`, `browse stop` | Open returned `mode: remote`, title `Example Domain`, and text from the page; stop returned `stopped: true`. | Proves Browserbase startup works with `--remote` instead of stale `browse env remote`. |
| Browser command replacements: `browse open https://example.com --local --headless`, `browse snapshot --compact`, `browse screenshot --path <png>`, `browse tab list`, `browse mouse ... --help` | Snapshot printed refs; screenshot wrote a PNG; `tab list` returned one tab for Example Domain; mouse subcommands expose `mouse drag` and `mouse scroll`. | Proves corrected browser, ui-test, and autobrowse command examples match `browse@0.6.0`. |
| UI/browser command surface fixture: `browse open <fixture> --local --headless`, `browse fill`, `browse fill --press-enter`, `browse select`, `browse is visible`, `browse eval <promise>.then(...)`, `browse viewport`, `browse mouse scroll`, `browse screenshot --path --full-page`, `browse tab new`, `browse tab switch` | Title was `UI E2E`; plain fill left `SUBMITTED_BEFORE_ENTER=no`; `--press-enter` produced `submitted:go:b`; select value was `b`; visibility was `true`; async eval returned `then-ok`; scrollY became `700`; screenshot wrote 13,880 bytes; tab count became 2; switching returned from `Example Domain` to `UI E2E`. | Proves the migrated browser/ui-test/autobrowse examples for Enter behavior, tabs, viewport screenshots, async eval, visibility checks, and mouse scroll work against a real local page. |
| `browse cloud fetch https://example.com --allow-redirects --output <html>` and `browse cloud search "browserbase docs" --num-results 2 --output <json>` | Fetch returned `ok: true`, `statusCode: 200`, `contentType: text/html`, `sizeBytes: 528`; search returned `ok: true`, `resultCount: 2`, first title `Introducing Browserbase - Browserbase Documentation`. | Proves Fetch/Search API command migrations and `--output` behavior. |
| Platform resources: `browse cloud projects list`; `browse cloud sessions create/get/debug/logs/update`; `browse cloud contexts create/get/delete`; `browse cloud extensions upload/get/delete` with a minimal extension ZIP | Projects returned one visible project; sessions created RUNNING sessions and release returned `COMPLETED`; contexts create/get/delete passed; extension upload/get/delete passed. `contexts update` returned the API deprecation message, so docs now caution against that path. | Proves platform command groups work with real credentials and highlights the one deprecated context-upload path. |
| Browser Trace: `node skills/browser-trace/scripts/bb-capture.mjs --new <run>`, `browse open https://example.com --cdp <target>`, `node .../stop-capture.mjs`, `node .../bb-finalize.mjs --release` | Capture created a Browserbase session; final artifacts included `session.json`, `logs.json`, CDP raw events, 2 screenshots, 2 DOM dumps, 2 index rows with `https://example.com/`, final session status `COMPLETED`, and non-empty CDP bytes. | Proves migrated `browse cloud sessions ...` calls and the fixed sampler path (`--cdp` + JSON parsing) work end-to-end. |
| Browser-to-API capture/spec flow: launch local CDP Chrome, `node skills/browser-trace/scripts/start-capture.mjs <port> api-e2e 1`, `browse open about:blank --cdp <port>`, `browse network on`, drive a page that fetches JSONPlaceholder APIs, snapshot `browse network path` into the run, `node .../stop-capture.mjs`, `node .../bisect-cdp.mjs`, `node skills/browser-to-api/scripts/discover.mjs --run <run> --origins jsonplaceholder.typicode.com --title "E2E API"` | Page text became `todo=1 posts=10`; discover logged `requests:3`, `responses:3`, `bodiesAttached:2`, `kept:2`, `endpoints:2`, `client:true`; generated `openapi.json`, `openapi.yaml`, `client.mjs`, `report.md`, self-contained `index.html` (9,522 bytes), and paths `/posts` plus `/todos/{id}`. | Proves the migrated `browse network on/path/off` + `browse open --cdp` docs compose with browser-trace and browser-to-api to generate a real OpenAPI artifact with response bodies. |
| Company/event research scripts: `browse cloud search ... --output <discovery json>`, `node skills/company-research/scripts/list_urls.mjs <dir> --prefix company`, `node skills/company-research/scripts/extract_page.mjs https://browserbase.com`, `node skills/event-prospecting/scripts/extract_page.mjs https://browserbase.com` | Search wrote result JSON; `list_urls.mjs` emitted deduped URLs; both extractors returned `FETCH_OK: true`, `FALLBACK_TO_BROWSE: false`, `TITLE: Browserbase`, and `BODY_CHARS: 800`. | Proves script migrations to `browse cloud search/fetch` work on real web data. |
| Functions flow: `browse functions init <temp project>`, verify generated package scripts, `browse functions publish index.ts --dry-run`, `browse functions dev index.ts --port <temp>`, `curl /v1/functions/my-function/invoke` | Init created a project whose scripts are `browse functions dev index.ts` and `browse functions publish index.ts`; dry-run listed package files; dev returned `runtimeConnected: true`; invoke returned `Fetched top Hacker News titles` with live titles. | Proves Functions init/dev/publish command migration and local runtime invocation. |
| Templates/skills flow: `browse templates list --tag Python --source Browserbase --json`, `browse templates find amazon --json`, `browse templates clone form-filling --language typescript <dir>`, `browse templates clone amazon-product-scraping --language python <dir>`, `HOME=<temp> browse skills install` | Template list returned 24 Browserbase/Python-tagged templates; find returned Amazon templates; TS and Python clones created expected project files; skills install wrote `browse/SKILL.md` under the temp home. | Proves corrected template list filters, clone language flags, and skills installer command. |
| Cookie Sync real context flow: install skill deps, launch local CDP Chrome with one `example.com` cookie, run `CDP_URL=<local Chrome> node skills/cookie-sync/scripts/cookie-sync.mjs --domains example.com`, then verify through `browse cloud sessions create --context-id <redacted> --persist --keep-alive`, `browse open https://example.com --cdp <connectUrl>`, `browse eval "document.cookie"` | Script connected to local Chrome, exported 1 cookie, filtered to 1 `example.com` cookie, created a Browserbase context, injected 1 cookie, and printed the migrated `browse cloud sessions create` / `browse open --cdp` workflow. The verification Browserbase session returned `e2e_sync=pr111` from `document.cookie`; the test session and context were cleaned up. | Proves cookie-sync's migrated post-sync instructions work with a real persistent context and that cookies survive into a Browserbase session opened through the new `browse` command surface. |
| Autobrowse inner-agent harness: `node skills/autobrowse/scripts/evaluate.mjs --task mini-form --workspace <temp workspace> --env local --model claude-haiku-4-5-20251001` against a live localhost form | Real Anthropic tool loop completed with `status: completed`, `stop_reason: end_turn`, 8 turns, ~17.1s, and final JSON `{"title":"Mini Form","resultText":"Hello Ada","success":true}`. Trace commands included `browse stop`, `browse open http://127.0.0.1:<port>/ --local`, `browse snapshot`, `browse fill "#name" "Ada" --press-enter`, `browse get title`, and `browse get text "#result"`. | Proves the migrated autobrowse prompt/tool harness drives the real `browse` CLI command shapes successfully; remote multi-task orchestration remains covered by the separate remote lifecycle and command-surface tests, not this local form smoke. |
| Browse stop mode-switch behavior: start local with `BROWSE_SESSION=<temp> browse open https://example.com --local --headless`, then attempt `browse open ... --remote` without stopping; separately open remote twice without stopping, then attempt local without stopping | Local-to-remote without stop exited 1 with `already running in managed-local mode. Run browse stop ... before changing modes.` Remote-to-remote without stop succeeded with `mode: remote` and `https://example.org/`. Remote-to-local without stop exited 1 with `already running in remote mode. Run browse stop ... before changing modes.` | Proves `browse stop` is required for active daemon mode switches, but not for same-mode navigation; supports narrowing the autobrowse caveat from unconditional “mandatory” to clean-run / possible mode-switch guidance. |
| Expert caveat validation: `browse open <url> --auto-connect` with no debuggable Chrome; `browse screenshot` without `--path`; `browse mouse drag/scroll --help`; `browse open --help`; stale-command grep across skills | `--auto-connect` exited with `No debuggable local browser found`; plain `browse screenshot` help says base64 is printed without `--path`; mouse help exposes `browse mouse drag/scroll` and `--return-xpath`; open help shows no `goto`; stale-command grep found no legacy `browse env`, `browse goto`, `browse drag/scroll`, `--no-press-enter`, old `bb` command shapes, or old package refs in the migrated surface. | Proves the corrected generic browser guidance matches `browse@0.6.0`; this specifically removed false fallback, alias, screenshot-path, and mouse-command caveats. |
| Existing Browserbase session attach: create keep-alive session, try `browse open ... --remote --session <Browserbase session id>`, then attach with `browse open ... --cdp <connectUrl> --session <name>` and run `browse get title --session <name>` | `--remote --session <Browserbase id>` exited 1 with `Driver daemon socket was not ready after 30000ms`; `--cdp <connectUrl>` returned `mode: cdp`, title `Example Domain`, and follow-up `browse get title` returned `Example Domain` without repeating `--cdp`. | Proves `--session` names the local browse daemon and is not a Browserbase-session attach flag; trace docs now use `connectUrl` for existing session reuse. |
| Functions and project-ID validation: `browse functions init my-function`; `env -u BROWSERBASE_PROJECT_ID browse functions publish my-function/index.ts --dry-run` with API key loaded | Init created `.env` containing only `BROWSERBASE_API_KEY` and package scripts `dev: browse functions dev index.ts`, `deploy: browse functions publish index.ts`; publish dry-run succeeded and listed packaged files without `BROWSERBASE_PROJECT_ID`. | Proves Functions docs should prefer `browse functions init` and not require `BROWSERBASE_PROJECT_ID` for the verified init/dry-run paths. |
| Research/event extraction fallback validation: keep default daemon active in remote mode, then run `node skills/company-research/scripts/extract_page.mjs <large Gutenberg page>`; run `BROWSE_SESSION=<temp> node skills/event-prospecting/scripts/recon.mjs https://example.com <out>` | Fetch failed for the large page, fallback used an isolated named browse session and returned `FALLBACK_TO_BROWSE: true`, `BODY_CHARS: 500`; recon wrote `recon.json` with title `Example Domain`, platform `custom`, strategy `markdown`. | Proves extraction fallback is no longer poisoned by an existing default daemon and event recon uses the real `browse open` command instead of the nonexistent `goto` alias. |
| Lifecycle docs propagation: repo-wide stale-command grep plus real `browse open --local`, `browse screenshot --path`, `browse tab ...`, `browse network ...`, `node --check skills/cookie-sync/scripts/cookie-sync.mjs`; independent subagent CDP persistence smoke | Stale-command grep only found expected `browse cloud sessions create --context-id` docs; CLI smoke passed; subagent confirmed `browse open --cdp` followed by plain `browse get`/`click` keeps `mode: "cdp"`. | Proves the post-review lifecycle cleanup and corrected `--cdp` daemon behavior across related skills. |
| Cleanup greps: `rg '@browserbasehq/cli\|@browserbasehq/browse-cli' <changed files>`; `rg '<old bb command patterns>' <changed files>`; stale-command grep across changed files | Old package grep had no matches; old `bb` command grep had no matches; stale command grep found no `browse env`, `browse newpage`, `browse pages`, `browse tab_switch`, `--no-press-enter`, `--api-url`, `--project-id`, `--advanced-stealth`, `browse --ws`, or `browse --connect` refs in the PR surface. Remaining `bb-` matches are only helper filenames such as `bb-capture.mjs`/`bb-finalize.mjs` and the unrelated `bb-usage` skill row. | Proves the migration removed old package refs and the E2E-discovered stale command shapes from the PR surface. |
| Static checks: `node --check` on changed JS entrypoints (browser-trace helpers, autobrowse evaluate, company/event extractors, cookie-sync, browser-to-api discover); `npm ci && node scripts/evaluate.mjs --help` inside `skills/autobrowse`; `git diff --check origin/main..HEAD` | Node syntax checks passed; autobrowse dependencies installed cleanly and `evaluate.mjs --help` printed usage/options; `git diff --check` passed. | Proves edited JS entrypoints parse and basic CLI entrypoints load; static checks support but do not replace the real command flows above. |


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly documentation/example updates, but it also changes helper scripts used for tracing and content extraction; incorrect flag/command migrations could break automation workflows and tooling used in debugging.
> 
> **Overview**
> Updates skill documentation and examples repo-wide to reflect the unified `browse` npm package and its new command taxonomy, replacing legacy `bb`/`@browserbasehq/browse-cli` references with `browse` and `browse cloud ...` equivalents.
> 
> Aligns browser-driving guidance with the new lifecycle/flags (**mode chosen on `browse open` via `--local`/`--remote`/`--cdp`/`--auto-connect`**), updates renamed commands (`tab ...`, `mouse ...`) and screenshot/fill flag changes (`--path`, `--press-enter`).
> 
> Migrates supporting scripts to the new CLI surface (e.g., browser-trace `bb-*.mjs` now shells out to `browse cloud sessions ...`; sampler uses `--cdp` and parses JSON fields; research extractors use `browse cloud fetch` with a `browse get markdown` fallback and ensure session cleanup).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78e64ec16b63ac4909eab39195877b76af3afefd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->





