### PR TITLE
autobrowse: add opt-in --browser-trace integration

### DIFF
--- a/skills/autobrowse/SKILL.md
+++ b/skills/autobrowse/SKILL.md
@@ -136,6 +136,7 @@ RUN_ID="run-$(printf '%03d' "$N")"
 TRACE_ROOT="./autobrowse/traces/<task-name>/$RUN_ID"
 mkdir -p "$TRACE_ROOT"
 export O11Y_ROOT="$TRACE_ROOT/.o11y"   # park browser-trace output inside the autobrowse run dir
+export O11Y_RUN_ID="$RUN_ID"           # tells the browse CLI which run dir to write descriptors.ndjson into
 
 # b. ATTACH BROWSER-TRACE — passive observer; runs in background
 node ${CLAUDE_SKILL_DIR}/../browser-trace/scripts/bb-capture.mjs "$sid" "$RUN_ID" &
@@ -160,7 +161,7 @@ node ${CLAUDE_SKILL_DIR}/scripts/unify-trace.mjs \
 browse cloud sessions update "$sid" --status REQUEST_RELEASE
 ```
 
-This writes the inner-agent trace to `./autobrowse/traces/<task-name>/latest/` and the CDP bisect to `./autobrowse/traces/<task-name>/latest/.o11y/<run-id>/`.
+This writes the inner-agent trace to `./autobrowse/traces/<task-name>/latest/` and the CDP bisect to `./autobrowse/traces/<task-name>/latest/.o11y/<run-id>/`. The traced `browse` CLI also emits per-command rich node descriptors to `.o11y/<run-id>/cdp/descriptors.ndjson` (one JSON object per page-driving call: target tag/id/role/accessibleName/attributes/xpath/bounding-rect). The descriptors file feeds downstream codegen; it is **not** required for hypothesis formation — skip it when reading the trace.
 
 ### Read the trace
 

--- a/skills/autobrowse/SKILL.md
+++ b/skills/autobrowse/SKILL.md
@@ -20,6 +20,7 @@ Invocation is flexible — both explicit flags and free-form natural language wo
 ```
 /autobrowse --task google-flights
 /autobrowse --task google-flights --iterations 10 --env remote
+/autobrowse --task google-flights --browser-trace
 /autobrowse --tasks google-flights,amazon-add-to-cart
 /autobrowse --all
 
@@ -28,6 +29,8 @@ Invocation is flexible — both explicit flags and free-form natural language wo
 /autobrowse book a flight on delta.com
 /autobrowse fix the existing google-flights skill
 ```
+
+`--browser-trace` (default off, remote-only): pairs each iteration with the sibling `browser-trace` skill — wraps the inner agent in a CDP capture for per-page network/console/page-lifecycle evidence. Implies `--env remote`; errors if combined with `--env local`. Requires the sibling `browser-trace` skill present at `${CLAUDE_SKILL_DIR}/../browser-trace/`, and the `BROWSERBASE_API_KEY` env var.
 
 When the user drops a URL or free-form instruction instead of `--task <name>`:
 - If an existing task in `${WORKSPACE}/tasks/` clearly matches the site/intent, use it.
@@ -44,6 +47,7 @@ Check what was passed:
 - `--tasks a,b,c` or `--all` → multi-task mode (spawn sub-agents)
 - `--iterations N` → how many evaluate → improve cycles (default: 5)
 - `--env local|remote` → browser environment (default: local; use remote for bot-protected sites)
+- `--browser-trace` → opt in to the browser-trace integration (default off). Implies `--env remote`. If `--env local --browser-trace` are both passed explicitly, error with: `browser-trace requires Browserbase; drop --env local or drop --browser-trace.`
 
 If the user passed free-form text instead, map it to one of the above before continuing.
 
@@ -100,6 +104,8 @@ Check that `./autobrowse/tasks/<task>/task.md` exists (scaffold it from the temp
 
 ### Run the inner agent
 
+**Default path (no `--browser-trace`)** — single command, no orchestration:
+
 ```bash
 node ${CLAUDE_SKILL_DIR}/scripts/evaluate.mjs --task <task-name> --workspace ./autobrowse
 # or for bot-protected sites:
@@ -107,6 +113,40 @@ node ${CLAUDE_SKILL_DIR}/scripts/evaluate.mjs --task <task-name> --workspace ./a
 ```
 
 This runs the browser session and writes a full trace to `./autobrowse/traces/<task>/latest/`.
+
+**Traced path (`--browser-trace`, remote only)** — the outer harness pre-creates a Browserbase session, attaches `bb-capture` as a passive observer, and passes the session's `connectUrl` to `evaluate.mjs` so every inner `browse` call uses `--cdp $connectUrl --session autobrowse-main` (the canonical browser-trace pattern that gives observers full Network/Console events). Run this block once per iteration with `$N` set to the 1-indexed iteration number:
+
+```bash
+# a. SESSION SETUP — pre-create the keep-alive session and derive its connectUrl
+sid=$(browse cloud sessions create --keep-alive --verified --proxies \
+  | node -e "let s='';process.stdin.on('data',c=>s+=c).on('end',()=>process.stdout.write(JSON.parse(s).id))")
+connect_url=$(browse cloud sessions get "$sid" \
+  | node -e "let s='';process.stdin.on('data',c=>s+=c).on('end',()=>process.stdout.write(JSON.parse(s).connectUrl))")
+
+RUN_ID="run-$(printf '%03d' "$N")"
+TRACE_ROOT="./autobrowse/traces/<task-name>/$RUN_ID"
+mkdir -p "$TRACE_ROOT"
+export O11Y_ROOT="$TRACE_ROOT/.o11y"   # park browser-trace output inside the autobrowse run dir
+
+# b. ATTACH BROWSER-TRACE — passive observer; runs in background
+node ${CLAUDE_SKILL_DIR}/../browser-trace/scripts/bb-capture.mjs "$sid" "$RUN_ID" &
+sleep 2
+
+# c. RUN AUTOBROWSE — connectUrl flag tells evaluate.mjs to inject --cdp/--session
+#    into every inner browse call. The inner agent never sees --remote.
+node ${CLAUDE_SKILL_DIR}/scripts/evaluate.mjs \
+  --task <task-name> --workspace ./autobrowse --env remote \
+  --connect-url "$connect_url" --run-number "$N"
+
+# d. STOP + BISECT — order matters; bisect needs the session to still exist
+node ${CLAUDE_SKILL_DIR}/../browser-trace/scripts/stop-capture.mjs "$RUN_ID"
+node ${CLAUDE_SKILL_DIR}/../browser-trace/scripts/bisect-cdp.mjs "$RUN_ID"
+
+# e. RELEASE
+browse cloud sessions update "$sid" --status REQUEST_RELEASE
+```
+
+This writes the inner-agent trace to `./autobrowse/traces/<task-name>/latest/` and the CDP bisect to `./autobrowse/traces/<task-name>/latest/.o11y/<run-id>/`.
 
 ### Read the trace
 
@@ -120,6 +160,19 @@ If the agent failed or got stuck, look deeper:
 - Read `./autobrowse/traces/<task-name>/latest/trace.json` — search for the failure turn
 - Read screenshots around the failure point with the Read tool
 
+**When `--browser-trace` was used** — `cdp/summary.json` is the primary structured-evidence source. Read it first for per-page network/console counts; fall back to the command log and screenshots only when you need extra context:
+
+```bash
+# Per-page bisect — network/console/page-lifecycle bucketed by navigation
+cat ./autobrowse/traces/<task-name>/latest/.o11y/<run-id>/cdp/summary.json
+
+# Drill into a specific failing page (failed XHRs, console errors, etc.)
+export O11Y_ROOT=./autobrowse/traces/<task-name>/latest/.o11y
+node ${CLAUDE_SKILL_DIR}/../browser-trace/scripts/query.mjs <run-id> list
+node ${CLAUDE_SKILL_DIR}/../browser-trace/scripts/query.mjs <run-id> errors
+node ${CLAUDE_SKILL_DIR}/../browser-trace/scripts/query.mjs <run-id> page 2 network/failed
+```
+
 ### Form one hypothesis
 
 Find the exact turn where things went wrong. What single heuristic would have prevented it?
@@ -129,6 +182,7 @@ Examples:
 - "Navigate directly to `/pay-invoice/` — skip the landing page entirely"
 - "Use `browse fill #field_3 value` not `browse type` — this field clears on focus"
 - "The page shows a spinner at turn 8 — add `browse wait timeout 2000` before snapshot"
+- (when using `--browser-trace`) "Page 3's `cdp/summary.json` shows 3 failed XHRs to `/api/availability` returning 403 — the site is fingerprinting; the next iter needs `--verified --proxies`."
 
 ### Update strategy.md
 
@@ -280,3 +334,4 @@ Write the file `./autobrowse/reports/YYYY-MM-DD-HH-MM-<tasks>.md` with:
 - **Build on wins** — keep what worked, add to it
 - **Trust the trace** — the inner agent shows exactly what it saw and did
 - **Graduate to `~/.claude/skills/`** — the only file you write there is the final graduated `SKILL.md`
+- **Don't release before bisecting** — under `--browser-trace`, the order at the end of each iteration is non-negotiable: `stop-capture` → `bisect-cdp` → `browse cloud sessions update REQUEST_RELEASE`. Bisect depends on the session still existing when the trace stops.

--- a/skills/autobrowse/SKILL.md
+++ b/skills/autobrowse/SKILL.md
@@ -147,9 +147,14 @@ node ${CLAUDE_SKILL_DIR}/scripts/evaluate.mjs \
   --task <task-name> --workspace ./autobrowse --env remote \
   --connect-url "$connect_url" --run-number "$N"
 
-# d. STOP + BISECT — order matters; bisect needs the session to still exist
+# d. STOP + BISECT + UNIFY — order matters; bisect needs the session to still
+#    exist, and unify-trace joins the bisect output with autobrowse's trace.json
+#    into a single time-ordered NDJSON the outer agent reads first each iter.
 node ${CLAUDE_SKILL_DIR}/../browser-trace/scripts/stop-capture.mjs "$RUN_ID"
 node ${CLAUDE_SKILL_DIR}/../browser-trace/scripts/bisect-cdp.mjs "$RUN_ID"
+node ${CLAUDE_SKILL_DIR}/scripts/unify-trace.mjs \
+  --trace-dir "$TRACE_ROOT" \
+  --o11y-dir "$O11Y_ROOT/$RUN_ID"
 
 # e. RELEASE
 browse cloud sessions update "$sid" --status REQUEST_RELEASE
@@ -169,45 +174,37 @@ If the agent failed or got stuck, look deeper:
 - Read `./autobrowse/traces/<task-name>/latest/trace.json` — search for the failure turn
 - Read screenshots around the failure point with the Read tool
 
-**When `--browser-trace` was used** — you now have **two complementary traces** and must cross-reference both before forming a hypothesis. They answer different questions:
-
-| File | Answers | Granularity |
-|---|---|---|
-| `summary.md` + `trace.json` | What did the **agent do**? (commands, reasoning, return values) | Per turn |
-| `.o11y/<run-id>/cdp/summary.json` | What did the **browser do**? (navigations, network requests, console errors) | Per page |
-
-The cross-reference pattern: skim `cdp/summary.json`'s `pages[]` for the page where things went wrong (high `network.failed`, console exceptions, unexpected URL). Then jump back to `trace.json` and find the turn whose command triggered that page (matching by URL or timing). That gives you both the *cause* (the command the agent issued) and the *effect* (what the browser actually did in response).
+**When `--browser-trace` was used — start with `unified-events.jsonl`.** The harness joins the agent's turn log and the browser's CDP firehose into one time-ordered NDJSON stream at the run root. One file, source-tagged (`source: "agent" | "browser"`), interleaved by wall-clock timestamp. Skim it top-to-bottom; the failure cause is usually one or two adjacent lines (the agent issued command X, the browser responded with Y).
 
 ```bash
-# Per-page bisect — network/console/page-lifecycle bucketed by navigation
-cat ./autobrowse/traces/<task-name>/latest/.o11y/<run-id>/cdp/summary.json
-
-# Drill into a specific failing page (failed XHRs, console errors, etc.)
-export O11Y_ROOT=./autobrowse/traces/<task-name>/latest/.o11y
-node ${CLAUDE_SKILL_DIR}/../browser-trace/scripts/query.mjs <run-id> list
-node ${CLAUDE_SKILL_DIR}/../browser-trace/scripts/query.mjs <run-id> errors
-node ${CLAUDE_SKILL_DIR}/../browser-trace/scripts/query.mjs <run-id> page 2 network/failed
+cat ./autobrowse/traces/<task-name>/latest/unified-events.jsonl
 ```
 
-Then back to `trace.json` for the turn that produced that page:
+The structured files (`trace.json`, `.o11y/<run-id>/cdp/*`) are **also agent-consumable as drill-downs** when the unified stream points at something you need more of:
 
-```bash
-# Example: page 2 had failed XHRs to /api/availability — which turn navigated there?
-node -e "JSON.parse(require('fs').readFileSync('./autobrowse/traces/<task-name>/latest/trace.json')).filter(e=>e.command?.includes('/api/availability')||e.output?.includes('/api/availability')).forEach(e=>console.log('turn',e.turn,e.command||e.output?.slice(0,80)))"
-```
+| Need | Drill-down file or command |
+|---|---|
+| Per-page totals + timing (events, network counts, errors by page) | `.o11y/<run-id>/cdp/summary.json` |
+| All failed network requests in one place | `.o11y/<run-id>/cdp/network/failed.jsonl` |
+| Full console exception payloads (stacktraces, etc.) | `.o11y/<run-id>/cdp/console/exceptions.jsonl` |
+| Per-page slice (only events on page N) | `.o11y/<run-id>/cdp/pages/<pid>/` |
+| Full reasoning text / untruncated tool outputs for a specific turn | `trace.json` (filter by `turn === N`) |
+| Ad-hoc grouped query (e.g. top hosts, errors-by-page) | `O11Y_ROOT=./autobrowse/traces/<task-name>/latest/.o11y node ${CLAUDE_SKILL_DIR}/../browser-trace/scripts/query.mjs <run-id> <cmd>` |
+
+The unified stream is the default; drill into structured files only when you need a grouped query, a full-text payload, or filtering the stream can't give you.
 
 ### Form one hypothesis
 
 Find the exact turn where things went wrong. What single heuristic would have prevented it?
 
-Under `--browser-trace`, base the hypothesis on **both signals**: the agent's command log (`trace.json` → what was attempted) *and* the browser's CDP record (`cdp/summary.json` → what actually happened). A hypothesis grounded only in the command log might say "the click didn't work" — grounded in both, it can say "the click went through but `/api/checkout` returned 403, so the next iter needs to wait for the auth cookie or switch to `--verified --proxies`."
+Under `--browser-trace`, the hypothesis must cite a **specific event from `unified-events.jsonl`** (line number or timestamp) — or name the drill-down file if you had to descend into one. This keeps updates evidence-grounded rather than vibes-driven. A hypothesis based only on the agent's commands might say "the click didn't work"; grounded in the unified stream, it can say "line 47 of unified-events.jsonl: `browse open` was followed by `Network.responseReceived` status 403 on `/api/checkout` — switch to `--verified --proxies`."
 
 Examples:
 - "After clicking the dropdown, wait 1s — options animate in before they're clickable"
 - "Navigate directly to `/pay-invoice/` — skip the landing page entirely"
 - "Use `browse fill #field_3 value` not `browse type` — this field clears on focus"
 - "The page shows a spinner at turn 8 — add `browse wait timeout 2000` before snapshot"
-- (when using `--browser-trace`) "Page 3's `cdp/summary.json` shows 3 failed XHRs to `/api/availability` returning 403 — the site is fingerprinting; the next iter needs `--verified --proxies`."
+- (with `--browser-trace`) "At line 47 of unified-events.jsonl, 3 consecutive `Network.responseReceived` events on `/api/availability` returned 403 right after `browse open` — the site is fingerprinting; the next iter needs `--verified --proxies`."
 
 ### Update strategy.md
 

--- a/skills/autobrowse/SKILL.md
+++ b/skills/autobrowse/SKILL.md
@@ -117,6 +117,15 @@ This runs the browser session and writes a full trace to `./autobrowse/traces/<t
 **Traced path (`--browser-trace`, remote only)** — the outer harness pre-creates a Browserbase session, attaches `bb-capture` as a passive observer, and passes the session's `connectUrl` to `evaluate.mjs` so every inner `browse` call uses `--cdp $connectUrl --session autobrowse-main` (the canonical browser-trace pattern that gives observers full Network/Console events). Run this block once per iteration with `$N` set to the 1-indexed iteration number:
 
 ```bash
+# Preflight — fail fast if browser-trace isn't installed alongside autobrowse.
+BT_DIR="${CLAUDE_SKILL_DIR}/../browser-trace"
+if [ ! -f "$BT_DIR/scripts/bb-capture.mjs" ]; then
+  echo "ERROR: --browser-trace requires the browser-trace skill at $BT_DIR." >&2
+  echo "Install it by cloning github.com/browserbase/skills and copying skills/browser-trace/" >&2
+  echo "into the same parent directory as autobrowse (e.g. ~/.claude/skills/browser-trace/)." >&2
+  exit 1
+fi
+
 # a. SESSION SETUP — pre-create the keep-alive session and derive its connectUrl
 sid=$(browse cloud sessions create --keep-alive --verified --proxies \
   | node -e "let s='';process.stdin.on('data',c=>s+=c).on('end',()=>process.stdout.write(JSON.parse(s).id))")
@@ -160,7 +169,14 @@ If the agent failed or got stuck, look deeper:
 - Read `./autobrowse/traces/<task-name>/latest/trace.json` — search for the failure turn
 - Read screenshots around the failure point with the Read tool
 
-**When `--browser-trace` was used** — `cdp/summary.json` is the primary structured-evidence source. Read it first for per-page network/console counts; fall back to the command log and screenshots only when you need extra context:
+**When `--browser-trace` was used** — you now have **two complementary traces** and must cross-reference both before forming a hypothesis. They answer different questions:
+
+| File | Answers | Granularity |
+|---|---|---|
+| `summary.md` + `trace.json` | What did the **agent do**? (commands, reasoning, return values) | Per turn |
+| `.o11y/<run-id>/cdp/summary.json` | What did the **browser do**? (navigations, network requests, console errors) | Per page |
+
+The cross-reference pattern: skim `cdp/summary.json`'s `pages[]` for the page where things went wrong (high `network.failed`, console exceptions, unexpected URL). Then jump back to `trace.json` and find the turn whose command triggered that page (matching by URL or timing). That gives you both the *cause* (the command the agent issued) and the *effect* (what the browser actually did in response).
 
 ```bash
 # Per-page bisect — network/console/page-lifecycle bucketed by navigation
@@ -173,9 +189,18 @@ node ${CLAUDE_SKILL_DIR}/../browser-trace/scripts/query.mjs <run-id> errors
 node ${CLAUDE_SKILL_DIR}/../browser-trace/scripts/query.mjs <run-id> page 2 network/failed
 ```
 
+Then back to `trace.json` for the turn that produced that page:
+
+```bash
+# Example: page 2 had failed XHRs to /api/availability — which turn navigated there?
+node -e "JSON.parse(require('fs').readFileSync('./autobrowse/traces/<task-name>/latest/trace.json')).filter(e=>e.command?.includes('/api/availability')||e.output?.includes('/api/availability')).forEach(e=>console.log('turn',e.turn,e.command||e.output?.slice(0,80)))"
+```
+
 ### Form one hypothesis
 
 Find the exact turn where things went wrong. What single heuristic would have prevented it?
+
+Under `--browser-trace`, base the hypothesis on **both signals**: the agent's command log (`trace.json` → what was attempted) *and* the browser's CDP record (`cdp/summary.json` → what actually happened). A hypothesis grounded only in the command log might say "the click didn't work" — grounded in both, it can say "the click went through but `/api/checkout` returned 403, so the next iter needs to wait for the auth cookie or switch to `--verified --proxies`."
 
 Examples:
 - "After clicking the dropdown, wait 1s — options animate in before they're clickable"

--- a/skills/autobrowse/SKILL.md
+++ b/skills/autobrowse/SKILL.md
@@ -80,7 +80,7 @@ ls ./autobrowse/tasks/
 
 If running multiple tasks, use the Agent tool to spawn one sub-agent per task simultaneously. Each sub-agent receives a self-contained prompt to run the full autobrowse loop for its task:
 
-> "You are running the autobrowse skill for task `<name>`. Workspace: `<absolute-path-to-workspace>` (e.g. `/path/to/project/autobrowse`). Run `<N>` iterations of: evaluate → read trace → improve strategy.md → repeat. Use `--env <env>`. Pass `--workspace <workspace>` to every evaluate.mjs invocation. Follow the autobrowse loop instructions exactly.
+> "You are running the autobrowse skill for task `<name>`. Workspace: `<absolute-path-to-workspace>` (e.g. `/path/to/project/autobrowse`). Run `<N>` iterations of: evaluate → read trace → improve strategy.md → repeat. Use `--env <env>`. Pass `--workspace <workspace>` to every evaluate.mjs invocation. If the parent invocation used `--browser-trace`, you MUST use the traced-path block of the SKILL.md loop for every iteration (pre-create session, attach bb-capture, pass `--connect-url` to evaluate.mjs, stop+bisect, release) — do not fall back to the default single-command path. Follow the autobrowse loop instructions exactly.
 >
 > When graduating, install the skill to `~/.claude/skills/<task-name>/SKILL.md` with proper agentskills frontmatter (name + description). Do not just copy strategy.md — write a self-contained skill.
 >

--- a/skills/autobrowse/scripts/evaluate.mjs
+++ b/skills/autobrowse/scripts/evaluate.mjs
@@ -16,6 +16,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import crypto from "node:crypto";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SKILL_DIR = path.resolve(__dirname, "..");
@@ -23,7 +24,7 @@ const SKILL_DIR = path.resolve(__dirname, "..");
 // ── Config ─────────────────────────────────────────────────────────
 
 const DEFAULT_MODEL = "claude-sonnet-4-6";
-const MAX_TURNS = 30;
+const MAX_TURNS = Number(process.env.MAX_TURNS) || 30;
 const MAX_TOKENS = 4096;
 const EXEC_TIMEOUT_MS = 30_000;
 
@@ -256,7 +257,15 @@ const PAGE_DRIVING_VERBS = new Set([
   "open", "snapshot", "screenshot", "click", "type", "fill", "press", "select",
   "wait", "get", "reload", "back", "forward", "mouse", "tab",
 ]);
-const TRACE_BROWSE_SESSION = "autobrowse-main";
+
+// Per-process local daemon name. Derived from a hash of the connectUrl so two
+// evaluate.mjs invocations driving different Browserbase sessions (e.g. SKILL.md
+// Step-3 parallel sub-agents) use distinct local daemons and don't collide on
+// the "autobrowse-main" socket. crypto.createHash is sync, fast, no deps.
+function deriveBrowseSessionName(connectUrl) {
+  const hash = crypto.createHash("sha1").update(connectUrl).digest("hex").slice(0, 8);
+  return `autobrowse-${hash}`;
+}
 
 function rewriteArgsForTrace(args, connectUrl) {
   // No-op when not in trace mode or when the first arg isn't a page-driving
@@ -272,7 +281,7 @@ function rewriteArgsForTrace(args, connectUrl) {
     if (out[i] === "--remote" || out[i] === "--local") out.splice(i, 1);
   }
   if (!hasFlag("--cdp")) out.push("--cdp", connectUrl);
-  if (!hasFlag("--session") && !hasFlag("-s")) out.push("--session", TRACE_BROWSE_SESSION);
+  if (!hasFlag("--session") && !hasFlag("-s")) out.push("--session", deriveBrowseSessionName(connectUrl));
   return out;
 }
 

--- a/skills/autobrowse/scripts/evaluate.mjs
+++ b/skills/autobrowse/scripts/evaluate.mjs
@@ -81,6 +81,13 @@ Options:
   --env local|remote   Browser environment (default: local)
   --model <model>      Claude model for the inner agent (default: ${DEFAULT_MODEL})
   --run-number N       Force a specific run number (default: auto-increment)
+  --connect-url <url>  Browserbase wss connectUrl; when set, every inner browse
+                       call is rewritten to attach via --cdp <url> --session
+                       autobrowse-main, and browse stop is suppressed. Used by
+                       the outer harness when --browser-trace is active so a
+                       sibling bb-capture observer can see Network/Console
+                       events (the --remote attach path routes those only to
+                       the driving client).
   --help               Show this help message
 
 Environment variables:
@@ -241,7 +248,35 @@ function parseCommand(command) {
   return { args };
 }
 
-function executeCommand(command) {
+// browse subcommands that drive a page through a local daemon — these need
+// the --cdp/--session injection when --connect-url is set. Excludes commands
+// that don't touch the daemon (cloud/cdp/status) or that would tear it down
+// (stop).
+const PAGE_DRIVING_VERBS = new Set([
+  "open", "snapshot", "screenshot", "click", "type", "fill", "press", "select",
+  "wait", "get", "reload", "back", "forward", "mouse", "tab",
+]);
+const TRACE_BROWSE_SESSION = "autobrowse-main";
+
+function rewriteArgsForTrace(args, connectUrl) {
+  // No-op when not in trace mode or when the first arg isn't a page-driving
+  // verb (cloud, cdp, etc. pass through unchanged).
+  if (!connectUrl || args.length === 0) return args;
+  const verb = args[0];
+  if (!PAGE_DRIVING_VERBS.has(verb)) return args;
+
+  const out = args.slice();
+  const hasFlag = (name) => out.some((a, i) => a === name && i > 0);
+  // Remove --remote / --local — they'd conflict with --cdp.
+  for (let i = out.length - 1; i > 0; i--) {
+    if (out[i] === "--remote" || out[i] === "--local") out.splice(i, 1);
+  }
+  if (!hasFlag("--cdp")) out.push("--cdp", connectUrl);
+  if (!hasFlag("--session") && !hasFlag("-s")) out.push("--session", TRACE_BROWSE_SESSION);
+  return out;
+}
+
+function executeCommand(command, connectUrl) {
   // Security: only allow the browse CLI and execute it without a shell so
   // metacharacters are treated as literal arguments instead of extra commands.
   const parsed = parseCommand(command);
@@ -254,9 +289,18 @@ function executeCommand(command) {
     return { output: `BLOCKED: only browse commands are allowed. Got: ${command.slice(0, 50)}`, error: true, duration_ms: 0 };
   }
 
+  // Suppress `browse stop` under --browser-trace: the outer harness owns the
+  // session and daemon; tearing the named daemon down would orphan the trace
+  // observer and block the rest of the iteration.
+  if (connectUrl && args[0] === "stop") {
+    return { output: '{"stopped":true,"suppressed":"browse-trace mode owns the session"}', error: false, duration_ms: 0 };
+  }
+
+  const finalArgs = rewriteArgsForTrace(args, connectUrl);
+
   const start = Date.now();
   try {
-    const output = execFileSync(executable, args, {
+    const output = execFileSync(executable, finalArgs, {
       encoding: "utf-8",
       timeout: EXEC_TIMEOUT_MS,
       stdio: ["pipe", "pipe", "pipe"],
@@ -271,9 +315,16 @@ function executeCommand(command) {
   }
 }
 
-function buildSystemPrompt(strategy, traceDir, browseEnv) {
-  const openFlag = browseEnv === "remote" ? "--remote" : "--local";
-  const envDesc = browseEnv === "remote"
+function buildSystemPrompt(strategy, traceDir, browseEnv, connectUrl) {
+  // Under --browser-trace (connectUrl set), the outer harness owns the
+  // Browserbase session and a sibling bb-capture observer is attached. Every
+  // browse call is rewritten by executeCommand to attach via
+  // --cdp $connectUrl --session autobrowse-main, and `browse stop` is a no-op.
+  // The inner agent must NOT pass --remote/--local or run browse stop.
+  const openFlag = connectUrl ? "" : (browseEnv === "remote" ? "--remote" : "--local");
+  const envDesc = connectUrl
+    ? `**Traced session managed by the outer harness.** Do not run \`browse stop\`. Do not pass \`--remote\` or \`--local\` — the harness routes every browse call through the trace-attached connection automatically. Just write \`browse open <url>\`, \`browse snapshot\`, etc.`
+    : (browseEnv === "remote"
     ? `Use **remote mode** (Browserbase) — Browserbase Identity, Verified browsers, CAPTCHA solving, residential proxies:
 \`\`\`
 browse stop
@@ -283,7 +334,7 @@ Run \`browse stop\` first when a prior daemon may be active; active sessions do 
     : `Use **local mode** — runs on local Chrome:
 \`\`\`
 browse open <url> --local
-\`\`\``;
+\`\`\``);
 
   return `You are a browser automation agent. You navigate websites using the browse CLI via the execute tool.
 
@@ -392,6 +443,11 @@ async function main() {
   }
 
   const browseEnv = getArg("env", "local");
+  const connectUrl = getArg("connect-url");
+  if (connectUrl && browseEnv !== "remote") {
+    console.error("ERROR: --connect-url requires --env remote");
+    process.exit(1);
+  }
   const client = new Anthropic();
   const runNumber = getNextRunNumber(tracesDir);
   const runId = `run-${String(runNumber).padStart(3, "0")}`;
@@ -401,12 +457,12 @@ async function main() {
 
   const strategy = fs.readFileSync(strategyFile, "utf-8");
   const task = fs.readFileSync(taskFile, "utf-8");
-  const systemPrompt = buildSystemPrompt(strategy, traceDir, browseEnv);
+  const systemPrompt = buildSystemPrompt(strategy, traceDir, browseEnv, connectUrl);
 
   console.error(`\n${"=".repeat(60)}`);
   console.error(`  AUTOBROWSE — ${taskName} — Run ${runNumber}`);
   console.error(`${"=".repeat(60)}`);
-  console.error(`Model: ${model} | Env: ${browseEnv} | Max turns: ${MAX_TURNS} | Trace: ${traceDir}\n`);
+  console.error(`Model: ${model} | Env: ${browseEnv}${connectUrl ? " (traced)" : ""} | Max turns: ${MAX_TURNS} | Trace: ${traceDir}\n`);
 
   const trace = [];
   const messages = [
@@ -486,7 +542,7 @@ async function main() {
 
       console.error(`  [${turn}] exec: ${command.slice(0, 120)}`);
 
-      const { output, error, duration_ms } = executeCommand(command);
+      const { output, error, duration_ms } = executeCommand(command, connectUrl);
 
       if (error) {
         console.error(`  [${turn}] error: ${output.slice(0, 100)}`);

--- a/skills/autobrowse/scripts/unify-trace.mjs
+++ b/skills/autobrowse/scripts/unify-trace.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+// unify-trace.mjs — join autobrowse's trace.json (per-turn agent log) with
+// browser-trace's CDP firehose into one time-ordered NDJSON stream.
+//
+// Output: <trace-dir>/unified-events.jsonl — the primary artifact an outer
+// agent reads when iterating with --browser-trace. Drill-down files
+// (trace.json, .o11y/<run>/cdp/*) remain untouched and continue to back
+// queries that need full payloads or grouped slices.
+//
+// Wall-clock alignment matches bisect-cdp.mjs: anchor on the first CDP
+// monotonic timestamp, then add manifest.started_at. TimeSinceEpoch events
+// (e.g. Console.messageAdded) carry a ms-since-epoch timestamp directly.
+//
+// Method filtering: emit only events that aid hypothesis formation. Skip
+// noisy/redundant methods (Network.dataReceived, frame Started/Stopped
+// Loading, ExtraInfo events, Runtime.executionContextCreated). The full
+// firehose is one drill-down away in cdp/raw.ndjson.
+//
+// Usage:
+//   node unify-trace.mjs --trace-dir <run-root> --o11y-dir <.o11y/<run-id>>
+
+import fs from "node:fs";
+import path from "node:path";
+
+function getArg(name) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : null;
+}
+
+const traceDir = getArg("trace-dir");
+const o11yDir = getArg("o11y-dir");
+if (!traceDir || !o11yDir) {
+  console.error("usage: unify-trace.mjs --trace-dir <run-root> --o11y-dir <.o11y/<run-id>>");
+  process.exit(2);
+}
+
+const tracePath = path.join(traceDir, "trace.json");
+const rawPath = path.join(o11yDir, "cdp", "raw.ndjson");
+const manifestPath = path.join(o11yDir, "manifest.json");
+
+for (const p of [tracePath, rawPath, manifestPath]) {
+  if (!fs.existsSync(p)) {
+    console.error(`missing input: ${p}`);
+    process.exit(1);
+  }
+}
+
+const trace = JSON.parse(fs.readFileSync(tracePath, "utf-8"));
+const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
+const rawLines = fs.readFileSync(rawPath, "utf-8").trim().split("\n").filter(Boolean);
+const cdpEvents = rawLines.map((l) => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean);
+
+const startedMs = manifest.started_at ? new Date(manifest.started_at).getTime() : null;
+
+const isMonotonic = (ts) => ts != null && ts < 1e9;
+const anchorCdp = cdpEvents.map((e) => e?.params?.timestamp).find(isMonotonic) ?? null;
+
+function cdpTsToMs(ev) {
+  const ts = ev?.params?.timestamp;
+  if (ts == null) return null;
+  if (isMonotonic(ts)) {
+    if (anchorCdp == null || startedMs == null) return null;
+    return Math.floor((ts - anchorCdp) * 1000 + startedMs);
+  }
+  return Math.floor(ts);
+}
+
+function topNavUrl(ev) {
+  return ev?.method === "Page.frameNavigated" && !ev?.params?.frame?.parentId
+    ? ev.params.frame.url ?? null
+    : null;
+}
+let pid = -1;
+const pageIdByIndex = [];
+for (let i = 0; i < cdpEvents.length; i++) {
+  if (topNavUrl(cdpEvents[i]) != null) pid += 1;
+  pageIdByIndex[i] = pid < 0 ? 0 : pid;
+}
+
+const SKIP_METHODS = new Set([
+  "Network.dataReceived",
+  "Network.loadingFinished",
+  "Network.requestWillBeSentExtraInfo",
+  "Network.responseReceivedExtraInfo",
+  "Network.resourceChangedPriority",
+  "Network.policyUpdated",
+  "Page.frameStartedLoading",
+  "Page.frameStoppedLoading",
+  "Page.frameRequestedNavigation",
+  "Page.javascriptDialogOpening",
+  "Page.javascriptDialogClosed",
+  "Runtime.executionContextCreated",
+  "Runtime.executionContextDestroyed",
+  "Runtime.executionContextsCleared",
+  "Target.targetInfoChanged",
+  "Target.detachedFromTarget",
+  "Log.entryAdded",
+]);
+
+function truncate(s, n = 500) {
+  if (typeof s !== "string") return s;
+  return s.length > n ? s.slice(0, n) + "…" : s;
+}
+
+function summarizeCdp(ev, page_id) {
+  const m = ev.method;
+  const p = ev.params || {};
+  const base = { source: "browser", method: m, page_id };
+  switch (m) {
+    case "Network.requestWillBeSent":
+      return { ...base, url: p.request?.url, request_method: p.request?.method, type: p.type, redirect_response_status: p.redirectResponse?.status };
+    case "Network.responseReceived":
+      return { ...base, url: p.response?.url, status: p.response?.status, mime: p.response?.mimeType, type: p.type };
+    case "Network.loadingFailed":
+      return { ...base, type: p.type, error: p.errorText, canceled: p.canceled };
+    case "Network.webSocketCreated":
+      return { ...base, url: p.url };
+    case "Page.frameStartedNavigating":
+      return { ...base, url: p.url };
+    case "Page.frameNavigated":
+      return { ...base, url: p.frame?.url, parent_id: p.frame?.parentId || null };
+    case "Page.lifecycleEvent":
+      return { ...base, name: p.name };
+    case "Page.domContentEventFired":
+    case "Page.loadEventFired":
+      return base;
+    case "Page.navigatedWithinDocument":
+      return { ...base, url: p.url };
+    case "Page.fileChooserOpened":
+      return { ...base, mode: p.mode };
+    case "Console.messageAdded":
+      return { ...base, level: p.message?.level, text: truncate(p.message?.text) };
+    case "Runtime.consoleAPICalled":
+      return { ...base, level: p.type, text: truncate((p.args || []).map((a) => a.value ?? a.description ?? "").join(" ")) };
+    case "Runtime.exceptionThrown":
+      return { ...base, text: truncate(p.exceptionDetails?.text || p.exceptionDetails?.exception?.description || ""), url: p.exceptionDetails?.url, line: p.exceptionDetails?.lineNumber };
+    case "Target.attachedToTarget":
+    case "Target.targetCreated":
+      return { ...base, target_id: p.targetInfo?.targetId || p.targetId, type: p.targetInfo?.type, url: p.targetInfo?.url };
+    default:
+      return base;
+  }
+}
+
+const browserRows = [];
+for (let i = 0; i < cdpEvents.length; i++) {
+  const ev = cdpEvents[i];
+  if (!ev.method || SKIP_METHODS.has(ev.method)) continue;
+  const ts_ms = cdpTsToMs(ev);
+  if (ts_ms == null) continue;
+  const row = summarizeCdp(ev, pageIdByIndex[i]);
+  browserRows.push({ _ts_ms: ts_ms, ts: new Date(ts_ms).toISOString(), ...row });
+}
+
+const agentRows = [];
+for (const entry of trace) {
+  const ts_ms = entry.timestamp ? new Date(entry.timestamp).getTime() : null;
+  if (ts_ms == null) continue;
+  const base = { source: "agent", turn: entry.turn, role: null };
+  if (entry.role === "assistant" && entry.reasoning) {
+    base.role = "reasoning";
+    base.text = truncate(entry.reasoning);
+  } else if (entry.role === "assistant" && entry.tool_name) {
+    base.role = "tool_call";
+    base.tool = entry.tool_name;
+    base.command = entry.tool_input?.command;
+  } else if (entry.role === "tool_result") {
+    base.role = "tool_result";
+    base.command = entry.command;
+    base.ok = !entry.error;
+    base.duration_ms = entry.duration_ms;
+    base.output_preview = truncate(entry.output);
+  } else {
+    continue;
+  }
+  agentRows.push({ _ts_ms: ts_ms, ts: new Date(ts_ms).toISOString(), ...base });
+}
+
+const all = [...browserRows, ...agentRows].sort((a, b) => a._ts_ms - b._ts_ms);
+
+const outPath = path.join(traceDir, "unified-events.jsonl");
+const out = fs.openSync(outPath, "w");
+for (const row of all) {
+  const { _ts_ms, ...rest } = row;
+  fs.writeSync(out, JSON.stringify(rest) + "\n");
+}
+fs.closeSync(out);
+
+console.log(`unified: ${all.length} events (${browserRows.length} browser, ${agentRows.length} agent) → ${outPath}`);


### PR DESCRIPTION
## Summary

- Wire the sibling `browser-trace` skill into the autobrowse loop behind a default-off `--browser-trace` flag (remote-only; implies `--env remote`).
- `evaluate.mjs` gains a `--connect-url <wss>` flag that injects `--cdp $connect_url --session autobrowse-main` into every inner `browse` call and suppresses `browse stop` so the named daemon survives the iteration.
- The `--cdp` attach mode is the key fix: `--remote` routes `Network.*`/`Console.*` events only to the driving client, leaving the trace observer with just a few `Page.lifecycleEvent`s. `--cdp` gives the observer the full per-page firehose — matching the canonical pattern in `browser-trace`'s SKILL.md.

## What you get

Verified end-to-end on `news.ycombinator.com`:
- Inner agent: 3 turns, $0.08, status `completed`.
- Trace: **78 CDP events, 7 Network requests** captured with real URLs (`news.ycombinator.com`, `news.css`, `hn.js`, …); per-page bisect shows `{"requests":7,"failed":0,"byType":{"Document":1,"Image":3,...}}`.
- No leftover Browserbase sessions; clean release each iter.

Compare to default mode (without `--browser-trace`) which is byte-for-byte unchanged.

## Files changed

- `skills/autobrowse/scripts/evaluate.mjs` — `+65`: new flag, `rewriteArgsForTrace` argv injector, `browse stop` suppression, conditional system prompt.
- `skills/autobrowse/SKILL.md` — `+55`: opt-in flag wired into the loop (six surgical edits — entry points, args, run-the-inner-agent split, read-the-trace subsection, hypothesis example, rules).
- `browser-trace` skill — **unchanged**.

## Test plan

- [x] Default-path regression: `/autobrowse --task <existing> --env remote` (no flag) — behavior identical to today.
- [x] `--browser-trace` requires remote: `evaluate.mjs --connect-url … --env local` errors out cleanly.
- [x] Single traced iteration on HN: trace captures all 7 Network requests + lifecycle events; `pages[0].url == "https://news.ycombinator.com/"`, not `(initial)`.
- [x] `browse stop` defense: harness suppresses it so the named daemon survives.
- [x] No session leaks after the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote Browserbase session lifecycle and browse CLI invocation; mistakes could leak sessions or break parallel runs, but default path is unchanged and teardown order is documented.
> 
> **Overview**
> Adds an opt-in **`--browser-trace`** path to autobrowse that pairs each remote iteration with the sibling **browser-trace** skill: pre-create a Browserbase session, run **`bb-capture`**, drive the inner agent via **`evaluate.mjs --connect-url`**, then **stop → bisect → unify → release** (session must stay alive until bisect finishes).
> 
> **`evaluate.mjs`** rewrites page-driving **`browse`** calls to attach with **`--cdp`** and a per-**connectUrl** session name (parallel-safe), strips **`--remote`/`--local`**, and no-ops **`browse stop`** so the outer harness owns the session. Default runs without the flag are unchanged.
> 
> New **`unify-trace.mjs`** merges agent **`trace.json`** with CDP into **`unified-events.jsonl`** for time-ordered, evidence-based **`strategy.md`** updates; **`SKILL.md`** documents the traced loop, drill-downs, and stricter hypotheses citing that file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c33cbdcc4137db763c184c3d71c2a0230b41713. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->