### PR TITLE
autobrowse: tear down self-owned browser session on exit

### DIFF
--- a/skills/autobrowse/scripts/evaluate.mjs
+++ b/skills/autobrowse/scripts/evaluate.mjs
@@ -271,6 +271,27 @@ function executeCommand(command) {
   }
 }
 
+// evaluate.mjs leaves the browser session running by default so a caller can
+// attach (e.g. browser-trace bisect in the browse.sh pipeline). But when WE
+// created the session — no caller-managed session attached via BROWSE_SESSION
+// or --session — nothing else will clean it up, and the inner agent only
+// *might* run `browse stop` (LLMs routinely skip the trailing cleanup step).
+// So tear down the daemon ourselves: killing it drops the CDP connection, and
+// our own `browse open` runs without --keep-alive, so the remote session ends.
+function ownsSession() {
+  return !process.env.BROWSE_SESSION && !getArg("session");
+}
+
+function teardownOwnedSession() {
+  if (!ownsSession()) return;
+  try {
+    execFileSync("browse", ["stop"], { timeout: 15_000, stdio: "ignore" });
+    console.error("Stopped browser session (evaluate.mjs owned it).");
+  } catch {
+    // best-effort — never fail the run over cleanup
+  }
+}
+
 function buildSystemPrompt(strategy, traceDir, browseEnv) {
   const openFlag = browseEnv === "remote" ? "--remote" : "--local";
   const envDesc = browseEnv === "remote"
@@ -610,10 +631,12 @@ async function main() {
     tokens_out: totalOutputTokens,
     trace_dir: traceDir,
   };
+  teardownOwnedSession();
   console.log(JSON.stringify(result));
 }
 
 main().catch((err) => {
   console.error("Fatal error:", err);
+  teardownOwnedSession();
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
`evaluate.mjs` left the browser session running when the inner-agent loop ended — relying on the agent to voluntarily `browse stop`, which LLMs routinely skip after emitting their final answer. On `--env remote` that leaks a Browserbase session until idle-timeout (cost + concurrency). Found while running a real signup task end-to-end.

It now runs `browse stop` on both the success and fatal-error paths, **only when evaluate.mjs owns the session** — i.e. no caller-managed session is attached via `BROWSE_SESSION` or `--session`.

## Why the guard matters
The browse.sh skill-factory pipeline intentionally keeps the session alive *after* evaluate.mjs so `browser-trace` can attach and bisect ("don't release before bisecting"), then releases its own `--keep-alive` session explicitly. That path sets `BROWSE_SESSION`, so `ownsSession()` returns false and we don't interfere. Only standalone/local runs (which create an ad-hoc non-keep-alive session) get auto-torn-down.

## Verification
- `ownsSession()` logic: true when nothing attached; false when `BROWSE_SESSION` set or `--session` passed.
- Live: `browse open --remote` → `browse status` shows `browserConnected: true` → `browse stop` → `browserConnected: false`. Our `browse open` runs without `--keep-alive`, so the remote session ends on disconnect.

Independent of the inbox feature (browserbase/skills#119) — branched off `main`. Surfaced during that testing but reviewable on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Best-effort cleanup with an explicit guard for caller-managed sessions; failures during stop are ignored and do not affect run outcome.
> 
> **Overview**
> `evaluate.mjs` now runs **`browse stop`** on both the normal completion path and the fatal-error handler when the harness **owns** the browser session (no `BROWSE_SESSION` env and no `--session` arg). That closes the gap where the inner agent often never runs cleanup, which especially leaked **remote (Browserbase)** sessions until idle timeout.
> 
> When a caller attaches a managed session (e.g. skill-factory / browser-trace bisect), teardown is **skipped** so the session can stay alive for follow-up steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e473b74829134c6ff81fa55bc057f0eee93dee4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->