### PR TITLE
docs(browser-trace): fix broken command, malformed timestamp, and typos

### DIFF
--- a/skills/browser-trace/EXAMPLES.md
+++ b/skills/browser-trace/EXAMPLES.md
@@ -220,4 +220,4 @@ jq -c 'select(.params.frameId == .params.loaderId or .params.frameId != null)
 jq '.proxyBytes' browserbase/session.json
 ```
 
-**Key idea**: `bb-capture.mjs <session-id>` (no `--new`) only adds an tracer; it never sends action commands. The production worker keeps running. `bb-finalize.mjs` *without* `--release` leaves the session alive when you're done.
+**Key idea**: `bb-capture.mjs <session-id>` (no `--new`) only adds a tracer; it never sends action commands. The production worker keeps running. `bb-finalize.mjs` *without* `--release` leaves the session alive when you're done.

--- a/skills/browser-trace/REFERENCE.md
+++ b/skills/browser-trace/REFERENCE.md
@@ -305,7 +305,7 @@ grep -lr 'api\.example\.com' .o11y/*/cdp/network/requests.jsonl
 # Search DOM dumps for an element class that came and went
 rg -l 'class="error-banner"' .o11y/<run-id>/dom/
 
-# Tail the firehose live (re-run start-capture is fine — it appends to raw.ndjson? no, it overwrites)
+# Tail the firehose live (note: re-running start-capture overwrites raw.ndjson, it does not append)
 tail -f .o11y/<run-id>/cdp/raw.ndjson | jq -c '{m:.method, u:.params.request.url // .params.frame.url // ""}'
 ```
 
@@ -328,5 +328,5 @@ The interval-second arg to `start-capture.mjs` controls only the sampler. The fi
 | Browserbase session ends as soon as tracer connects | tracer was the only client; no automation attached          | create with `--keep-alive`, attach automation with `browse open --cdp <connectUrl> --session <name>` first   |
 | `index.jsonl` shows `"url": ""`                 | sampler `browse get url` failed transiently                   | benign; happens during navigation transitions                 |
 | Screenshots empty / huge / inconsistent sizes  | viewport not set                                              | `browse viewport 1920 1080 --cdp <target>` once before capture |
-| `raw.ndjson` grows but bisect buckets empty    | wrong domains; e.g. you wanted DOM but didn't enable it       | `O11Y_DOMAINS="Network Console Runtime Log Page DOM" bash start-capture.mjs ...` |
+| `raw.ndjson` grows but bisect buckets empty    | wrong domains; e.g. you wanted DOM but didn't enable it       | `O11Y_DOMAINS="Network Console Runtime Log Page DOM" node scripts/start-capture.mjs ...` |
 | Loop process leaks after crash                  | `stop-capture.mjs` not run                                     | `pkill -f snapshot-loop.mjs`; PID files in `<run-dir>` are stale  |

--- a/skills/browser-trace/SKILL.md
+++ b/skills/browser-trace/SKILL.md
@@ -220,7 +220,7 @@ jq -c 'select(.params.type == "error")' .o11y/<run>/cdp/console/logs.jsonl
 jq -r '.params.frame.url' .o11y/<run>/cdp/page/navigations.jsonl
 
 # Find the screenshot taken closest to a timestamp (e.g., when an exception fired)
-ls .o11y/<run>/screenshots/ | sort | awk -v t=20260427T1714123NZ '
+ls .o11y/<run>/screenshots/ | sort | awk -v t=20260427T171412Z '
   $0 >= t { print; exit }'
 ```
 


### PR DESCRIPTION
Four documentation-only corrections to the `browser-trace` skill — no behavior change.

| File | Before | After |
|---|---|---|
| `REFERENCE.md` (troubleshooting) | `bash start-capture.mjs ...` | `node scripts/start-capture.mjs ...` |
| `SKILL.md` (screenshot-by-timestamp recipe) | `awk -v t=20260427T1714123NZ` | `awk -v t=20260427T171412Z` |
| `EXAMPLES.md` (Example 5 key idea) | "only adds an tracer" | "only adds a tracer" |
| `REFERENCE.md` (bash cheatsheet) | `# ... it appends to raw.ndjson? no, it overwrites` | `# note: re-running start-capture overwrites raw.ndjson, it does not append` |

Rationale:
- The scripts are Node ESM modules; `bash start-capture.mjs` cannot execute them. Every other example correctly uses `node scripts/start-capture.mjs`.
- `20260427T1714123NZ` is not a valid value in the skill's own `%Y%m%dT%H%M%SZ` timestamp format used everywhere else.
- Grammar typo.
- Leftover self-correcting draft note replaced with a direct statement of the documented overwrite behavior.

Found while installing and reading through the skill end-to-end.