### PR TITLE
feat(autobrowse): scripts/codegen.mjs — multi-framework runnable-script generator

### DIFF
--- a/skills/autobrowse/.gitignore
+++ b/skills/autobrowse/.gitignore
@@ -2,5 +2,6 @@ node_modules/
 .env
 tasks/
 traces/
+codegen-cache/
 *.log
 .DS_Store

--- a/skills/autobrowse/SKILL.md
+++ b/skills/autobrowse/SKILL.md
@@ -223,6 +223,50 @@ Read the new summary. Did it pass? Make clear progress?
 - **Pass or progress** → keep, next iteration
 - **No progress or regression** → revert strategy.md to the previous version and try a different hypothesis
 
+### Generate a runnable script (optional)
+
+Once the task has converged, you can produce a deterministic, runnable script
+in one or more frameworks via `scripts/codegen.mjs`. This is one shot of an
+LLM call per framework, cached by content hash, with optional verify-against-
+fresh-session and rewrite-on-failure.
+
+```bash
+node ${CLAUDE_SKILL_DIR}/scripts/codegen.mjs \
+  --task <name> \
+  --workspace ./autobrowse \
+  --frameworks playwright,stagehand \
+  --verify
+```
+
+Each framework gets its own subdirectory under `tasks/<name>/<framework>/`
+with the emitted script and a self-contained scaffold (`package.json`,
+`tsconfig.json`). The directory is runnable standalone with
+`cd tasks/<name>/playwright && npm install && npx tsx <name>.ts` — the only
+runtime requirement is `BROWSERBASE_API_KEY` (plus `ANTHROPIC_API_KEY` for
+the Stagehand target).
+
+Builtin frameworks: `playwright`, `stagehand`. Add a custom framework with
+`--prompt-template <path> --frameworks custom` (and provide your own runner
+or pass `--no-verify`).
+
+Common flags:
+
+| Flag | Purpose |
+|---|---|
+| `--frameworks a,b,...` | Comma-separated; default `playwright` |
+| `--verify` / `--no-verify` | Run the produced script against a fresh BB session; default `--verify` |
+| `--max-retries N` | Rewrite-on-verify-failure cap; default 2 |
+| `--cache-only` | Error if cache miss (CI-friendly) |
+| `--force` | Bust the cache |
+| `--dry-run` | Estimate prompt size + cost; don't call the LLM |
+| `--run <id>` | Force a specific `run-NNN` (default: latest passing) |
+
+Output is one JSON line per framework on stdout. Non-zero exit if any
+selected framework's final state is `passed: false`.
+
+See `references/playwright-cdp-bridge.md` for the canonical
+`connectOverCDP` patterns the emitted scripts follow.
+
 ### After all iterations — publish if ready
 
 If the task passed on 2+ of the last 3 iterations **or has reached the max iteration limit**, install it as a Claude Code skill. **Do not just copy strategy.md** — the skill must be self-contained and useful to someone who has never seen this codebase. If graduating at max iterations without a clean pass, note the known failure point but still document everything learned.

--- a/skills/autobrowse/codegen/prompts/playwright.md
+++ b/skills/autobrowse/codegen/prompts/playwright.md
@@ -1,0 +1,55 @@
+# Playwright codegen — system prompt
+
+You are converting a converged autobrowse trace into a runnable Playwright
+script. Your output is the **complete contents of a `.ts` file**, nothing
+else: no preamble, no closing remarks, no markdown fences.
+
+## Constraints
+
+- **Self-contained.** The script must run with only `BROWSERBASE_API_KEY` in
+  the environment. No reliance on autobrowse state, no reading from
+  workspace files.
+- **CDP attach, never `chromium.launch()`.** Follow the
+  `Playwright ↔ Browserbase bridge` reference verbatim for the
+  create-session / connectOverCDP / release dance.
+- **No `browser.close()`.** Release the session via
+  `browse cloud sessions update <id> --status REQUEST_RELEASE` in `finally`.
+- **Final stdout line is JSON.** `{"success":true,"data":...}` on success
+  or `{"success":false,"error":"..."}` on failure. The runner parses this
+  line — don't emit any other JSON-looking lines after it.
+- **Snap on errors.** Wrap `main()` in `try { … } catch (err) { await snap(page, '99-error'); throw err; }`. Honor `process.env.SCREENSHOT_DIR` for snap output.
+- **Locator preferences in order:** `data-testid` attribute → role + name →
+  id → text → xpath. Prefer Playwright's auto-waiting (`locator.click()`,
+  `locator.fill()`) over explicit waits when possible.
+- **Use the descriptor data when available.** Each `descriptors.ndjson` entry
+  describes the actual DOM target the agent interacted with — pick locators
+  from those `attributes` / `role` / `accessibleName` fields rather than
+  inventing them.
+- **Use the trace's network signals.** Where the unified events show a slow
+  XHR after an action, insert `page.waitForResponse(...)` rather than
+  arbitrary sleeps.
+
+## Output schema
+
+The script must define a Zod schema that mirrors the `# Output` section of
+the task.md provided in context, and validate the extracted data through
+that schema before printing the final `success: true` line.
+
+## Imports / runtime
+
+```typescript
+import { chromium, type Browser, type Page } from "playwright";
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { z } from "zod";
+import "dotenv/config";
+```
+
+`playwright` and `zod` are already in the scaffolded `package.json`. Do not
+add other dependencies.
+
+## What to emit
+
+Output the complete `.ts` file content. Start with imports, end with a call
+to `main()`. Nothing before the first import, nothing after the last
+closing brace. No markdown fences.

--- a/skills/autobrowse/codegen/prompts/playwright.md
+++ b/skills/autobrowse/codegen/prompts/playwright.md
@@ -4,101 +4,7 @@ You are converting a converged autobrowse trace into a runnable Playwright
 script. Your output is the **complete contents of a `.ts` file**, nothing
 else: no preamble, no closing remarks, no markdown fences.
 
-## Approach selection — API path vs browser path
-
-Before writing anything, decide which Playwright surface fits the workflow.
-Read the trace, the `recommended_method` in task.md (if present), and the
-unified events.
-
-**Use the API path** (Playwright's `request` / `APIRequestContext` — no
-browser, no Browserbase session) when:
-
-- The workflow is fundamentally HTTP RPC: a JSON-RPC server (MCP), a public
-  REST endpoint, or any flow where the converged trace shows `browse cloud
-  fetch` calls succeeding and zero meaningful DOM interaction.
-- `recommended_method` in task.md is `api`, `mcp`, or `fetch` AND the
-  underlying service exposes a callable endpoint (not just a static URL the
-  agent walked through a browser).
-- The data needed for the output schema is fully present in the HTTP
-  response body — no client-side rendering required.
-
-This is the cheaper, faster, more deterministic path. A few ms per call vs
-several seconds for browser startup, no proxy minutes burned, no session
-to release.
-
-**Use the browser path** (the `chromium.connectOverCDP` pattern in the
-cdp-bridge reference) when:
-
-- The trace shows real DOM interaction (`browse click`, `browse fill`,
-  `browse get text <selector>`, repeated snapshot/click cycles).
-- The data lives in client-rendered DOM, an inline JS object, or a SPA's
-  widget state — not in the initial HTML response.
-- Auth/session state must be acquired interactively, or the site is gated
-  by an anti-bot challenge that only a stealth browser clears.
-
-**When in doubt, use the browser path** — it's the safer default and
-always works if the data is reachable.
-
----
-
-## API-path scripts (when approach selection picked the API path)
-
-### Imports
-
-```typescript
-import { request, type APIRequestContext } from "playwright";
-import { z } from "zod";
-import "dotenv/config";
-```
-
-`playwright` and `zod` are already in the scaffolded `package.json`.
-
-### Constraints
-
-- **No browser, no Browserbase session, no `connectOverCDP`.** Create an
-  `APIRequestContext` with `await request.newContext({ baseURL: "..." })`.
-- **Throw on bad HTTP status** — there's no `expect()` without the test
-  runner; do `if (res.status() !== 200) throw new Error(...)`.
-- **Validate output through Zod** before printing the final `success: true`
-  line, same as browser-path scripts.
-- **Final stdout line is the same JSON contract**: `{"success":true,"data":...}`
-  or `{"success":false,"error":"..."}`.
-- **Snap is a no-op** for API-path scripts (no `page` to screenshot). Omit
-  the snap helper entirely; the runner's `SCREENSHOT_DIR` is unused.
-
-### Skeleton
-
-```typescript
-async function main() {
-  const api = await request.newContext({
-    baseURL: "https://example.com",
-    extraHTTPHeaders: { "Content-Type": "application/json" },
-  });
-  try {
-    // … per-endpoint calls, e.g.:
-    const res = await api.post("/api/foo", { data: { /* params */ } });
-    if (res.status() !== 200) {
-      throw new Error(`/api/foo HTTP ${res.status()}: ${await res.text()}`);
-    }
-    const parsed = OutputSchema.parse(await res.json());
-    console.log(JSON.stringify({ success: true, data: parsed }));
-  } finally {
-    await api.dispose();
-  }
-}
-
-main().catch((err) => {
-  console.error(err);
-  console.log(JSON.stringify({ success: false, error: String(err?.message ?? err) }));
-  process.exit(1);
-});
-```
-
----
-
-## Browser-path scripts (when approach selection picked the browser path)
-
-### Constraints
+## Constraints
 
 - **Self-contained.** The script must run with only `BROWSERBASE_API_KEY` in
   the environment. No reliance on autobrowse state, no reading from
@@ -123,7 +29,13 @@ main().catch((err) => {
   XHR after an action, insert `page.waitForResponse(...)` rather than
   arbitrary sleeps.
 
-### Imports
+## Output schema
+
+The script must define a Zod schema that mirrors the `# Output` section of
+the task.md provided in context, and validate the extracted data through
+that schema before printing the final `success: true` line.
+
+## Imports / runtime
 
 ```typescript
 import { chromium, type Browser, type Page } from "playwright";
@@ -135,14 +47,6 @@ import "dotenv/config";
 
 `playwright` and `zod` are already in the scaffolded `package.json`. Do not
 add other dependencies.
-
----
-
-## Output schema (both paths)
-
-The script must define a Zod schema that mirrors the `# Output` section of
-the task.md provided in context, and validate the extracted data through
-that schema before printing the final `success: true` line.
 
 ## What to emit
 

--- a/skills/autobrowse/codegen/prompts/playwright.md
+++ b/skills/autobrowse/codegen/prompts/playwright.md
@@ -4,7 +4,101 @@ You are converting a converged autobrowse trace into a runnable Playwright
 script. Your output is the **complete contents of a `.ts` file**, nothing
 else: no preamble, no closing remarks, no markdown fences.
 
-## Constraints
+## Approach selection — API path vs browser path
+
+Before writing anything, decide which Playwright surface fits the workflow.
+Read the trace, the `recommended_method` in task.md (if present), and the
+unified events.
+
+**Use the API path** (Playwright's `request` / `APIRequestContext` — no
+browser, no Browserbase session) when:
+
+- The workflow is fundamentally HTTP RPC: a JSON-RPC server (MCP), a public
+  REST endpoint, or any flow where the converged trace shows `browse cloud
+  fetch` calls succeeding and zero meaningful DOM interaction.
+- `recommended_method` in task.md is `api`, `mcp`, or `fetch` AND the
+  underlying service exposes a callable endpoint (not just a static URL the
+  agent walked through a browser).
+- The data needed for the output schema is fully present in the HTTP
+  response body — no client-side rendering required.
+
+This is the cheaper, faster, more deterministic path. A few ms per call vs
+several seconds for browser startup, no proxy minutes burned, no session
+to release.
+
+**Use the browser path** (the `chromium.connectOverCDP` pattern in the
+cdp-bridge reference) when:
+
+- The trace shows real DOM interaction (`browse click`, `browse fill`,
+  `browse get text <selector>`, repeated snapshot/click cycles).
+- The data lives in client-rendered DOM, an inline JS object, or a SPA's
+  widget state — not in the initial HTML response.
+- Auth/session state must be acquired interactively, or the site is gated
+  by an anti-bot challenge that only a stealth browser clears.
+
+**When in doubt, use the browser path** — it's the safer default and
+always works if the data is reachable.
+
+---
+
+## API-path scripts (when approach selection picked the API path)
+
+### Imports
+
+```typescript
+import { request, type APIRequestContext } from "playwright";
+import { z } from "zod";
+import "dotenv/config";
+```
+
+`playwright` and `zod` are already in the scaffolded `package.json`.
+
+### Constraints
+
+- **No browser, no Browserbase session, no `connectOverCDP`.** Create an
+  `APIRequestContext` with `await request.newContext({ baseURL: "..." })`.
+- **Throw on bad HTTP status** — there's no `expect()` without the test
+  runner; do `if (res.status() !== 200) throw new Error(...)`.
+- **Validate output through Zod** before printing the final `success: true`
+  line, same as browser-path scripts.
+- **Final stdout line is the same JSON contract**: `{"success":true,"data":...}`
+  or `{"success":false,"error":"..."}`.
+- **Snap is a no-op** for API-path scripts (no `page` to screenshot). Omit
+  the snap helper entirely; the runner's `SCREENSHOT_DIR` is unused.
+
+### Skeleton
+
+```typescript
+async function main() {
+  const api = await request.newContext({
+    baseURL: "https://example.com",
+    extraHTTPHeaders: { "Content-Type": "application/json" },
+  });
+  try {
+    // … per-endpoint calls, e.g.:
+    const res = await api.post("/api/foo", { data: { /* params */ } });
+    if (res.status() !== 200) {
+      throw new Error(`/api/foo HTTP ${res.status()}: ${await res.text()}`);
+    }
+    const parsed = OutputSchema.parse(await res.json());
+    console.log(JSON.stringify({ success: true, data: parsed }));
+  } finally {
+    await api.dispose();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  console.log(JSON.stringify({ success: false, error: String(err?.message ?? err) }));
+  process.exit(1);
+});
+```
+
+---
+
+## Browser-path scripts (when approach selection picked the browser path)
+
+### Constraints
 
 - **Self-contained.** The script must run with only `BROWSERBASE_API_KEY` in
   the environment. No reliance on autobrowse state, no reading from
@@ -29,13 +123,7 @@ else: no preamble, no closing remarks, no markdown fences.
   XHR after an action, insert `page.waitForResponse(...)` rather than
   arbitrary sleeps.
 
-## Output schema
-
-The script must define a Zod schema that mirrors the `# Output` section of
-the task.md provided in context, and validate the extracted data through
-that schema before printing the final `success: true` line.
-
-## Imports / runtime
+### Imports
 
 ```typescript
 import { chromium, type Browser, type Page } from "playwright";
@@ -47,6 +135,14 @@ import "dotenv/config";
 
 `playwright` and `zod` are already in the scaffolded `package.json`. Do not
 add other dependencies.
+
+---
+
+## Output schema (both paths)
+
+The script must define a Zod schema that mirrors the `# Output` section of
+the task.md provided in context, and validate the extracted data through
+that schema before printing the final `success: true` line.
 
 ## What to emit
 

--- a/skills/autobrowse/codegen/prompts/stagehand.md
+++ b/skills/autobrowse/codegen/prompts/stagehand.md
@@ -4,42 +4,67 @@ You are converting a converged autobrowse trace into a runnable Stagehand
 script. Your output is the **complete contents of a `.ts` file**, nothing
 else: no preamble, no closing remarks, no markdown fences.
 
+This targets **Stagehand v3** (`@browserbasehq/stagehand` 3.x). The v3 API
+differs from older examples — follow the patterns below exactly.
+
 ## Constraints
 
-- **Self-contained.** The script must run with only `BROWSERBASE_API_KEY`
-  and `ANTHROPIC_API_KEY` in the environment.
-- **Stagehand attaches via the same CDP `connectUrl`** — create the session
-  with `browse cloud sessions create --keep-alive --verified --proxies`,
-  then construct a `Stagehand` instance pointing at the existing session
-  (`browserbaseSessionID`). Do not launch a fresh browser.
-- **`page.act("...")` for actions, `page.extract({ schema })` for data.**
-  Use Zod schemas. Prefer natural-language intent strings over
-  `page.locator(...).click()` — the whole point of Stagehand is the LLM
-  picks the locator at runtime.
-- **One natural-language action per call.** Don't compound
-  ("click X and fill Y"); chain individual `act` calls so each one is
-  retryable in isolation.
-- **Schema-backed extract.** Define one or more Zod schemas mirroring the
-  `# Output` section of task.md. Validate before emitting the final
-  `success: true` line.
-- **Use the descriptors as natural-language hints.** Where the descriptor
-  shows `accessibleName: "Continue"`, the corresponding `act` should say
-  `"click the Continue button"`. The whole agent-friendly nature of
-  Stagehand means specific locators aren't required.
-- **Snap on errors.** Wrap `main()` in
-  `try { … } catch (err) { await snap(page, '99-error'); throw err; }`.
-  Honor `process.env.SCREENSHOT_DIR`.
+- **Self-contained.** The script must run with `BROWSERBASE_API_KEY` and
+  `ANTHROPIC_API_KEY` in the environment.
+- **Stagehand owns its own Browserbase session.** Construct it with
+  `env: "BROWSERBASE"` and let it create the session — do NOT pre-create a
+  session via the `browse` CLI and do NOT pass `browserbaseSessionID`. The
+  constructor shape is:
+  ```typescript
+  const stagehand = new Stagehand({
+    env: "BROWSERBASE",
+    apiKey: process.env.BROWSERBASE_API_KEY,        // ← BROWSERBASE key (NOT the Anthropic key); project inferred from it
+    model: {                                        // ← LLM config lives here, not at top level
+      modelName: "anthropic/claude-sonnet-4-6",     // ← provider-prefixed; do not invent model names
+      apiKey: process.env.ANTHROPIC_API_KEY,
+    },
+  });
+  await stagehand.init();
+  ```
+  The top-level `apiKey` is the **Browserbase** API key (the project is
+  inferred from it — no `projectId` needed). There is no `browserbaseAPIKey`
+  field and no top-level `modelName` — using the Anthropic key as `apiKey`
+  makes session lookup fail with a 404.
+- **Get the page from the context, not `stagehand.page`.**
+  ```typescript
+  const page = stagehand.context.pages()[0] ?? (await stagehand.context.newPage());
+  await page.goto(url, { waitUntil: "domcontentloaded" });
+  ```
+  `page` supports `goto`, `waitForTimeout`, `waitForSelector`, `screenshot`.
+- **`act` and `extract` are methods on the `stagehand` instance, not the page.**
+  - Actions: `await stagehand.act("click the Continue button")`
+  - Data: `await stagehand.extract("<instruction>", zodSchema)` — pass the Zod
+    schema as the second argument; it returns the parsed object.
+  Prefer natural-language intent strings — the whole point of Stagehand is the
+  LLM picks the locator at runtime.
+- **One natural-language action per `act` call.** Don't compound
+  ("click X and fill Y"); chain individual `act` calls so each is retryable.
+- **Schema-backed extract.** Define Zod schemas mirroring the `# Output`
+  section of task.md and validate before emitting the final `success: true`
+  line.
+- **Use the descriptors as natural-language hints.** Where a descriptor shows
+  `accessibleName: "Continue"`, the corresponding `act` should say
+  `"click the Continue button"`. Specific locators aren't required.
+- **Snap on errors.** Wrap the body in
+  `try { … } catch (err) { await snap(page, '99-error'); … }`, honoring
+  `process.env.SCREENSHOT_DIR`. `snap` should be a no-op when the dir is unset.
 - **Final stdout line is JSON.** `{"success":true,"data":...}` on success,
-  `{"success":false,"error":"..."}` on failure. The runner parses this.
-- **Release the session via `browse cloud sessions update … --status
-  REQUEST_RELEASE`** in `finally`. Do NOT call `stagehand.close()` — see
-  the cdp-bridge reference for why.
+  `{"success":false,"error":"..."}` on failure. The runner parses this — emit
+  no other JSON-looking lines after it.
+- **Tear down with `await stagehand.close()` in `finally`.** Since Stagehand
+  created and owns the session, `close()` is the correct teardown — do NOT use
+  `browse cloud sessions update … REQUEST_RELEASE` (that's only for the
+  CDP-attach pattern where you created the session yourself).
 
 ## Imports / runtime
 
 ```typescript
 import { Stagehand } from "@browserbasehq/stagehand";
-import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { z } from "zod";
 import "dotenv/config";

--- a/skills/autobrowse/codegen/prompts/stagehand.md
+++ b/skills/autobrowse/codegen/prompts/stagehand.md
@@ -1,0 +1,55 @@
+# Stagehand codegen — system prompt
+
+You are converting a converged autobrowse trace into a runnable Stagehand
+script. Your output is the **complete contents of a `.ts` file**, nothing
+else: no preamble, no closing remarks, no markdown fences.
+
+## Constraints
+
+- **Self-contained.** The script must run with only `BROWSERBASE_API_KEY`
+  and `ANTHROPIC_API_KEY` in the environment.
+- **Stagehand attaches via the same CDP `connectUrl`** — create the session
+  with `browse cloud sessions create --keep-alive --verified --proxies`,
+  then construct a `Stagehand` instance pointing at the existing session
+  (`browserbaseSessionID`). Do not launch a fresh browser.
+- **`page.act("...")` for actions, `page.extract({ schema })` for data.**
+  Use Zod schemas. Prefer natural-language intent strings over
+  `page.locator(...).click()` — the whole point of Stagehand is the LLM
+  picks the locator at runtime.
+- **One natural-language action per call.** Don't compound
+  ("click X and fill Y"); chain individual `act` calls so each one is
+  retryable in isolation.
+- **Schema-backed extract.** Define one or more Zod schemas mirroring the
+  `# Output` section of task.md. Validate before emitting the final
+  `success: true` line.
+- **Use the descriptors as natural-language hints.** Where the descriptor
+  shows `accessibleName: "Continue"`, the corresponding `act` should say
+  `"click the Continue button"`. The whole agent-friendly nature of
+  Stagehand means specific locators aren't required.
+- **Snap on errors.** Wrap `main()` in
+  `try { … } catch (err) { await snap(page, '99-error'); throw err; }`.
+  Honor `process.env.SCREENSHOT_DIR`.
+- **Final stdout line is JSON.** `{"success":true,"data":...}` on success,
+  `{"success":false,"error":"..."}` on failure. The runner parses this.
+- **Release the session via `browse cloud sessions update … --status
+  REQUEST_RELEASE`** in `finally`. Do NOT call `stagehand.close()` — see
+  the cdp-bridge reference for why.
+
+## Imports / runtime
+
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { z } from "zod";
+import "dotenv/config";
+```
+
+`@browserbasehq/stagehand` and `zod` are already in the scaffolded
+`package.json`. Do not add other dependencies.
+
+## What to emit
+
+Output the complete `.ts` file content. Start with imports, end with a call
+to `main()`. Nothing before the first import, nothing after the last
+closing brace. No markdown fences.

--- a/skills/autobrowse/codegen/runners/lib/tsx-runner.mjs
+++ b/skills/autobrowse/codegen/runners/lib/tsx-runner.mjs
@@ -9,6 +9,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import * as crypto from "node:crypto";
 import { spawnSync } from "node:child_process";
 
 export function getArg(name) {
@@ -51,8 +52,21 @@ export function runTsxTarget(opts) {
     if (err) emitAndExit({ passed: false, error: err });
   }
 
-  // Install deps once per outDir (the scaffold's package.json pins versions).
-  if (!fs.existsSync(path.join(outDir, "node_modules"))) {
+  // Install deps when package.json changes. Gating purely on node_modules
+  // existing is wrong when two frameworks share an --out dir: framework #2's
+  // dropScaffold merges its deps into the existing package.json, but the
+  // node_modules from framework #1's install is still missing them. We hash
+  // package.json and compare against a stamp under node_modules/ to detect
+  // that and re-install.
+  const pkgPath = path.join(outDir, "package.json");
+  const stampPath = path.join(outDir, "node_modules", ".codegen-pkg-hash");
+  const pkgHash = fs.existsSync(pkgPath)
+    ? crypto.createHash("sha256").update(fs.readFileSync(pkgPath)).digest("hex")
+    : null;
+  const stampedHash = fs.existsSync(stampPath)
+    ? fs.readFileSync(stampPath, "utf-8").trim()
+    : null;
+  if (pkgHash && pkgHash !== stampedHash) {
     process.stderr.write(`[runner.${label}] installing deps in ${outDir}\n`);
     const install = spawnSync("npm", ["install", "--silent", "--no-audit", "--no-fund"], {
       cwd: outDir,
@@ -63,6 +77,10 @@ export function runTsxTarget(opts) {
     if (install.status !== 0) {
       emitAndExit({ passed: false, error: `npm install exited ${install.status}` });
     }
+    try {
+      fs.mkdirSync(path.dirname(stampPath), { recursive: true });
+      fs.writeFileSync(stampPath, pkgHash);
+    } catch {}
   }
 
   // Per-run screenshot dir, exposed to the script via SCREENSHOT_DIR so its

--- a/skills/autobrowse/codegen/runners/lib/tsx-runner.mjs
+++ b/skills/autobrowse/codegen/runners/lib/tsx-runner.mjs
@@ -1,0 +1,112 @@
+// tsx-runner.mjs — shared logic for codegen target runners that boot a tsx
+// script in a scaffolded output dir and parse its trailing JSON line.
+//
+// Playwright and Stagehand runners (and any future TS target that follows the
+// same {"success":boolean,"data":...} contract) call runTsxTarget with their
+// per-framework tweaks: a label for stderr prefix, extra env (e.g.
+// PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1), and an optional preflight check (e.g.
+// "ANTHROPIC_API_KEY required for Stagehand").
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { spawnSync } from "node:child_process";
+
+export function getArg(name) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : null;
+}
+
+// Emit a JSON result line on stdout and exit. Centralized so the contract
+// (single {passed:bool,...} JSON line, exit 0/2) is consistent across runners.
+function emitAndExit(result) {
+  console.log(JSON.stringify(result));
+  process.exit(result.passed ? 0 : 2);
+}
+
+/**
+ * Run a tsx target script against a fresh BB session.
+ *
+ * @param {object} opts
+ * @param {string} opts.label                 stderr prefix, e.g. "playwright"
+ * @param {Record<string,string>} [opts.extraEnv]  merged into the run's env
+ * @param {Record<string,string>} [opts.installEnv] merged into npm install's env
+ * @param {() => string|null} [opts.preflight]  return error message to fail fast
+ */
+export function runTsxTarget(opts) {
+  const { label, extraEnv = {}, installEnv = {}, preflight } = opts;
+  const outDir = getArg("out-dir");
+  const script = getArg("script");
+
+  if (!outDir || !script) {
+    emitAndExit({ passed: false, error: "runner missing --out-dir or --script" });
+  }
+
+  const scriptPath = path.join(outDir, script);
+  if (!fs.existsSync(scriptPath)) {
+    emitAndExit({ passed: false, error: `script not found at ${scriptPath}` });
+  }
+
+  if (preflight) {
+    const err = preflight();
+    if (err) emitAndExit({ passed: false, error: err });
+  }
+
+  // Install deps once per outDir (the scaffold's package.json pins versions).
+  if (!fs.existsSync(path.join(outDir, "node_modules"))) {
+    process.stderr.write(`[runner.${label}] installing deps in ${outDir}\n`);
+    const install = spawnSync("npm", ["install", "--silent", "--no-audit", "--no-fund"], {
+      cwd: outDir,
+      stdio: ["ignore", "inherit", "inherit"],
+      env: { ...process.env, ...installEnv },
+      timeout: 3 * 60 * 1000,
+    });
+    if (install.status !== 0) {
+      emitAndExit({ passed: false, error: `npm install exited ${install.status}` });
+    }
+  }
+
+  // Per-run screenshot dir, exposed to the script via SCREENSHOT_DIR so its
+  // snap() helper can write progress / failure shots somewhere we can find.
+  const screenshotDir = path.join(outDir, "screenshots", `verify-${Date.now()}`);
+  fs.mkdirSync(screenshotDir, { recursive: true });
+
+  process.stderr.write(`[runner.${label}] running ${scriptPath}\n`);
+  const run = spawnSync("npx", ["tsx", script], {
+    cwd: outDir,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+    env: { ...process.env, ...extraEnv, SCREENSHOT_DIR: screenshotDir },
+    timeout: 5 * 60 * 1000,
+  });
+
+  const stdout = run.stdout ?? "";
+  const stderr = run.stderr ?? "";
+
+  // Parse the script's trailing JSON line — walk backward through lines and
+  // take the last one that parses as JSON with a boolean `success` field.
+  let parsed = null;
+  const lines = stdout.trim().split("\n").filter(Boolean);
+  for (let i = lines.length - 1; i >= 0; i--) {
+    try {
+      const candidate = JSON.parse(lines[i]);
+      if (typeof candidate?.success === "boolean") {
+        parsed = candidate;
+        break;
+      }
+    } catch {}
+  }
+
+  const passed = run.status === 0 && parsed?.success === true;
+  const result = {
+    passed,
+    exit_code: run.status,
+    script_output: parsed,
+    screenshot_dir: screenshotDir,
+    stderr_tail: stderr.slice(-2000),
+  };
+  if (!passed) {
+    result.error = parsed?.error
+      || (run.status !== 0 ? `script exited ${run.status}` : "script did not emit success:true");
+  }
+  emitAndExit(result);
+}

--- a/skills/autobrowse/codegen/runners/lib/tsx-runner.mjs
+++ b/skills/autobrowse/codegen/runners/lib/tsx-runner.mjs
@@ -68,10 +68,16 @@ export function runTsxTarget(opts) {
     : null;
   if (pkgHash && pkgHash !== stampedHash) {
     process.stderr.write(`[runner.${label}] installing deps in ${outDir}\n`);
+    // Always set PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 here, regardless of which
+    // runner we are. In shared --out mode, framework #2 (e.g. stagehand) gets
+    // playwright merged into its package.json by dropScaffold, so even runners
+    // that don't list playwright in installEnv would still trigger its
+    // postinstall and try to fetch hundreds of MB of chromium — exhausting
+    // the 3min install budget. We never need bundled browsers (always CDP).
     const install = spawnSync("npm", ["install", "--silent", "--no-audit", "--no-fund"], {
       cwd: outDir,
       stdio: ["ignore", "inherit", "inherit"],
-      env: { ...process.env, ...installEnv },
+      env: { ...process.env, PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1", ...installEnv },
       timeout: 3 * 60 * 1000,
     });
     if (install.status !== 0) {

--- a/skills/autobrowse/codegen/runners/playwright.mjs
+++ b/skills/autobrowse/codegen/runners/playwright.mjs
@@ -3,104 +3,27 @@
 /**
  * playwright.mjs — Runner for the Playwright codegen target.
  *
- * Invoked by codegen.mjs's verify step. Installs deps if needed, runs the
- * emitted <task>.ts via tsx against a fresh BB session, and emits a JSON
- * result line.
+ * Invoked by codegen.mjs's verify step. Installs the scaffolded deps if
+ * needed, spawns `npx tsx <script>` against a fresh BB session, and emits
+ * a single {"passed":boolean, ...} JSON line on stdout.
  *
  * Contract:
- *   - Reads --out-dir <path>      (the scaffolded output dir)
- *   - Reads --script <basename>   (file inside --out-dir to run, e.g. acme.ts)
- *   - Spawns `npx tsx <basename>` with PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
- *   - SCREENSHOT_DIR is set so the script can call snap() into a per-run dir
- *   - Returns: prints a single JSON line {"passed":boolean, ...} on stdout
+ *   --out-dir <path>      the scaffolded output dir
+ *   --script <basename>   file inside --out-dir to run (e.g. acme.ts)
  *
- * The script being run is expected to print a `{"success":true,"data":...}`
- * JSON line as its last stdout. We parse that to determine pass/fail.
+ * Shared with stagehand.mjs via lib/tsx-runner.mjs — only differences are
+ * the label and the PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD trick (so playwright's
+ * postinstall doesn't try to fetch chromium; we use connectOverCDP).
  */
 
-import * as fs from "node:fs";
-import * as path from "node:path";
-import { spawnSync } from "node:child_process";
+import { runTsxTarget } from "./lib/tsx-runner.mjs";
 
-function getArg(name) {
-  const i = process.argv.indexOf(`--${name}`);
-  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : null;
-}
-
-const OUT_DIR = getArg("out-dir");
-const SCRIPT = getArg("script");
-
-if (!OUT_DIR || !SCRIPT) {
-  console.log(JSON.stringify({ passed: false, error: "runner missing --out-dir or --script" }));
-  process.exit(2);
-}
-
-const scriptPath = path.join(OUT_DIR, SCRIPT);
-if (!fs.existsSync(scriptPath)) {
-  console.log(JSON.stringify({ passed: false, error: `script not found at ${scriptPath}` }));
-  process.exit(2);
-}
-
-// ── npm install once per outDir ───────────────────────────────────
-
-if (!fs.existsSync(path.join(OUT_DIR, "node_modules"))) {
-  process.stderr.write(`[runner.playwright] installing deps in ${OUT_DIR}\n`);
-  const install = spawnSync("npm", ["install", "--silent", "--no-audit", "--no-fund"], {
-    cwd: OUT_DIR,
-    stdio: ["ignore", "inherit", "inherit"],
-    env: { ...process.env, PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1" },
-    timeout: 3 * 60 * 1000,
-  });
-  if (install.status !== 0) {
-    console.log(JSON.stringify({ passed: false, error: `npm install exited ${install.status}` }));
-    process.exit(2);
-  }
-}
-
-// ── run the script ────────────────────────────────────────────────
-
-const screenshotDir = path.join(OUT_DIR, "screenshots", `verify-${Date.now()}`);
-fs.mkdirSync(screenshotDir, { recursive: true });
-
-process.stderr.write(`[runner.playwright] running ${scriptPath}\n`);
-const run = spawnSync("npx", ["tsx", SCRIPT], {
-  cwd: OUT_DIR,
-  encoding: "utf-8",
-  stdio: ["ignore", "pipe", "pipe"],
-  env: {
-    ...process.env,
-    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1",
-    SCREENSHOT_DIR: screenshotDir,
-  },
-  timeout: 5 * 60 * 1000,
+runTsxTarget({
+  label: "playwright",
+  // PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 is required at install time too,
+  // otherwise the playwright postinstall pulls hundreds of MB of browser
+  // binaries that we never use (we always connectOverCDP to a remote BB
+  // session). Set it for both install and run.
+  installEnv: { PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1" },
+  extraEnv: { PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1" },
 });
-
-const stdout = run.stdout ?? "";
-const stderr = run.stderr ?? "";
-
-// Final stdout line should be {"success":true,...} or {"success":false,...}.
-let parsed = null;
-const lines = stdout.trim().split("\n").filter(Boolean);
-for (let i = lines.length - 1; i >= 0; i--) {
-  try {
-    const candidate = JSON.parse(lines[i]);
-    if (typeof candidate?.success === "boolean") {
-      parsed = candidate;
-      break;
-    }
-  } catch {}
-}
-
-const passed = run.status === 0 && parsed?.success === true;
-const result = {
-  passed,
-  exit_code: run.status,
-  script_output: parsed,
-  screenshot_dir: screenshotDir,
-  stderr_tail: stderr.slice(-2000),
-};
-if (!passed) {
-  result.error = parsed?.error || (run.status !== 0 ? `script exited ${run.status}` : "script did not emit success:true");
-}
-console.log(JSON.stringify(result));
-process.exit(passed ? 0 : 2);

--- a/skills/autobrowse/codegen/runners/playwright.mjs
+++ b/skills/autobrowse/codegen/runners/playwright.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+
+/**
+ * playwright.mjs — Runner for the Playwright codegen target.
+ *
+ * Invoked by codegen.mjs's verify step. Installs deps if needed, runs the
+ * emitted <task>.ts via tsx against a fresh BB session, and emits a JSON
+ * result line.
+ *
+ * Contract:
+ *   - Reads --out-dir <path>  (the scaffolded output dir)
+ *   - Reads --task <name>     (used to find <task>.ts)
+ *   - Spawns `npx tsx <task>.ts` with PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+ *   - SCREENSHOT_DIR is set so the script can call snap() into a per-run dir
+ *   - Returns: prints a single JSON line {"passed":boolean, ...} on stdout
+ *
+ * The script being run is expected to print a `{"success":true,"data":...}`
+ * JSON line as its last stdout. We parse that to determine pass/fail.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { spawnSync } from "node:child_process";
+
+function getArg(name) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : null;
+}
+
+const OUT_DIR = getArg("out-dir");
+const TASK = getArg("task");
+
+if (!OUT_DIR || !TASK) {
+  console.log(JSON.stringify({ passed: false, error: "runner missing --out-dir or --task" }));
+  process.exit(2);
+}
+
+const scriptPath = path.join(OUT_DIR, `${TASK}.ts`);
+if (!fs.existsSync(scriptPath)) {
+  console.log(JSON.stringify({ passed: false, error: `script not found at ${scriptPath}` }));
+  process.exit(2);
+}
+
+// ── npm install once per outDir ───────────────────────────────────
+
+if (!fs.existsSync(path.join(OUT_DIR, "node_modules"))) {
+  process.stderr.write(`[runner.playwright] installing deps in ${OUT_DIR}\n`);
+  const install = spawnSync("npm", ["install", "--silent", "--no-audit", "--no-fund"], {
+    cwd: OUT_DIR,
+    stdio: ["ignore", "inherit", "inherit"],
+    env: { ...process.env, PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1" },
+    timeout: 3 * 60 * 1000,
+  });
+  if (install.status !== 0) {
+    console.log(JSON.stringify({ passed: false, error: `npm install exited ${install.status}` }));
+    process.exit(2);
+  }
+}
+
+// ── run the script ────────────────────────────────────────────────
+
+const screenshotDir = path.join(OUT_DIR, "screenshots", `verify-${Date.now()}`);
+fs.mkdirSync(screenshotDir, { recursive: true });
+
+process.stderr.write(`[runner.playwright] running ${scriptPath}\n`);
+const run = spawnSync("npx", ["tsx", `${TASK}.ts`], {
+  cwd: OUT_DIR,
+  encoding: "utf-8",
+  stdio: ["ignore", "pipe", "pipe"],
+  env: {
+    ...process.env,
+    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1",
+    SCREENSHOT_DIR: screenshotDir,
+  },
+  timeout: 5 * 60 * 1000,
+});
+
+const stdout = run.stdout ?? "";
+const stderr = run.stderr ?? "";
+
+// Final stdout line should be {"success":true,...} or {"success":false,...}.
+let parsed = null;
+const lines = stdout.trim().split("\n").filter(Boolean);
+for (let i = lines.length - 1; i >= 0; i--) {
+  try {
+    const candidate = JSON.parse(lines[i]);
+    if (typeof candidate?.success === "boolean") {
+      parsed = candidate;
+      break;
+    }
+  } catch {}
+}
+
+const passed = run.status === 0 && parsed?.success === true;
+const result = {
+  passed,
+  exit_code: run.status,
+  script_output: parsed,
+  screenshot_dir: screenshotDir,
+  stderr_tail: stderr.slice(-2000),
+};
+if (!passed) {
+  result.error = parsed?.error || (run.status !== 0 ? `script exited ${run.status}` : "script did not emit success:true");
+}
+console.log(JSON.stringify(result));
+process.exit(passed ? 0 : 2);

--- a/skills/autobrowse/codegen/runners/playwright.mjs
+++ b/skills/autobrowse/codegen/runners/playwright.mjs
@@ -8,9 +8,9 @@
  * result line.
  *
  * Contract:
- *   - Reads --out-dir <path>  (the scaffolded output dir)
- *   - Reads --task <name>     (used to find <task>.ts)
- *   - Spawns `npx tsx <task>.ts` with PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+ *   - Reads --out-dir <path>      (the scaffolded output dir)
+ *   - Reads --script <basename>   (file inside --out-dir to run, e.g. acme.ts)
+ *   - Spawns `npx tsx <basename>` with PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
  *   - SCREENSHOT_DIR is set so the script can call snap() into a per-run dir
  *   - Returns: prints a single JSON line {"passed":boolean, ...} on stdout
  *
@@ -28,14 +28,14 @@ function getArg(name) {
 }
 
 const OUT_DIR = getArg("out-dir");
-const TASK = getArg("task");
+const SCRIPT = getArg("script");
 
-if (!OUT_DIR || !TASK) {
-  console.log(JSON.stringify({ passed: false, error: "runner missing --out-dir or --task" }));
+if (!OUT_DIR || !SCRIPT) {
+  console.log(JSON.stringify({ passed: false, error: "runner missing --out-dir or --script" }));
   process.exit(2);
 }
 
-const scriptPath = path.join(OUT_DIR, `${TASK}.ts`);
+const scriptPath = path.join(OUT_DIR, SCRIPT);
 if (!fs.existsSync(scriptPath)) {
   console.log(JSON.stringify({ passed: false, error: `script not found at ${scriptPath}` }));
   process.exit(2);
@@ -63,7 +63,7 @@ const screenshotDir = path.join(OUT_DIR, "screenshots", `verify-${Date.now()}`);
 fs.mkdirSync(screenshotDir, { recursive: true });
 
 process.stderr.write(`[runner.playwright] running ${scriptPath}\n`);
-const run = spawnSync("npx", ["tsx", `${TASK}.ts`], {
+const run = spawnSync("npx", ["tsx", SCRIPT], {
   cwd: OUT_DIR,
   encoding: "utf-8",
   stdio: ["ignore", "pipe", "pipe"],

--- a/skills/autobrowse/codegen/runners/stagehand.mjs
+++ b/skills/autobrowse/codegen/runners/stagehand.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+
+/**
+ * stagehand.mjs — Runner for the Stagehand codegen target.
+ *
+ * Identical contract to runners/playwright.mjs (spawn `npx tsx <task>.ts`,
+ * parse the final {"success":boolean} JSON line). The only differences:
+ *   - No PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD trick (Stagehand uses
+ *     connectOverCDP without bundling a local chromium).
+ *   - Requires ANTHROPIC_API_KEY in env (Stagehand's act/extract are
+ *     LLM-driven).
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { spawnSync } from "node:child_process";
+
+function getArg(name) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : null;
+}
+
+const OUT_DIR = getArg("out-dir");
+const TASK = getArg("task");
+
+if (!OUT_DIR || !TASK) {
+  console.log(JSON.stringify({ passed: false, error: "runner missing --out-dir or --task" }));
+  process.exit(2);
+}
+
+const scriptPath = path.join(OUT_DIR, `${TASK}.ts`);
+if (!fs.existsSync(scriptPath)) {
+  console.log(JSON.stringify({ passed: false, error: `script not found at ${scriptPath}` }));
+  process.exit(2);
+}
+
+if (!process.env.ANTHROPIC_API_KEY && !process.env.ANTHROPIC_AUTH_TOKEN) {
+  console.log(JSON.stringify({ passed: false, error: "ANTHROPIC_API_KEY required for Stagehand verify" }));
+  process.exit(2);
+}
+
+if (!fs.existsSync(path.join(OUT_DIR, "node_modules"))) {
+  process.stderr.write(`[runner.stagehand] installing deps in ${OUT_DIR}\n`);
+  const install = spawnSync("npm", ["install", "--silent", "--no-audit", "--no-fund"], {
+    cwd: OUT_DIR,
+    stdio: ["ignore", "inherit", "inherit"],
+    timeout: 3 * 60 * 1000,
+  });
+  if (install.status !== 0) {
+    console.log(JSON.stringify({ passed: false, error: `npm install exited ${install.status}` }));
+    process.exit(2);
+  }
+}
+
+const screenshotDir = path.join(OUT_DIR, "screenshots", `verify-${Date.now()}`);
+fs.mkdirSync(screenshotDir, { recursive: true });
+
+process.stderr.write(`[runner.stagehand] running ${scriptPath}\n`);
+const run = spawnSync("npx", ["tsx", `${TASK}.ts`], {
+  cwd: OUT_DIR,
+  encoding: "utf-8",
+  stdio: ["ignore", "pipe", "pipe"],
+  env: { ...process.env, SCREENSHOT_DIR: screenshotDir },
+  timeout: 5 * 60 * 1000,
+});
+
+const stdout = run.stdout ?? "";
+const stderr = run.stderr ?? "";
+
+let parsed = null;
+const lines = stdout.trim().split("\n").filter(Boolean);
+for (let i = lines.length - 1; i >= 0; i--) {
+  try {
+    const candidate = JSON.parse(lines[i]);
+    if (typeof candidate?.success === "boolean") {
+      parsed = candidate;
+      break;
+    }
+  } catch {}
+}
+
+const passed = run.status === 0 && parsed?.success === true;
+const result = {
+  passed,
+  exit_code: run.status,
+  script_output: parsed,
+  screenshot_dir: screenshotDir,
+  stderr_tail: stderr.slice(-2000),
+};
+if (!passed) {
+  result.error = parsed?.error || (run.status !== 0 ? `script exited ${run.status}` : "script did not emit success:true");
+}
+console.log(JSON.stringify(result));
+process.exit(passed ? 0 : 2);

--- a/skills/autobrowse/codegen/runners/stagehand.mjs
+++ b/skills/autobrowse/codegen/runners/stagehand.mjs
@@ -21,14 +21,14 @@ function getArg(name) {
 }
 
 const OUT_DIR = getArg("out-dir");
-const TASK = getArg("task");
+const SCRIPT = getArg("script");
 
-if (!OUT_DIR || !TASK) {
-  console.log(JSON.stringify({ passed: false, error: "runner missing --out-dir or --task" }));
+if (!OUT_DIR || !SCRIPT) {
+  console.log(JSON.stringify({ passed: false, error: "runner missing --out-dir or --script" }));
   process.exit(2);
 }
 
-const scriptPath = path.join(OUT_DIR, `${TASK}.ts`);
+const scriptPath = path.join(OUT_DIR, SCRIPT);
 if (!fs.existsSync(scriptPath)) {
   console.log(JSON.stringify({ passed: false, error: `script not found at ${scriptPath}` }));
   process.exit(2);
@@ -56,7 +56,7 @@ const screenshotDir = path.join(OUT_DIR, "screenshots", `verify-${Date.now()}`);
 fs.mkdirSync(screenshotDir, { recursive: true });
 
 process.stderr.write(`[runner.stagehand] running ${scriptPath}\n`);
-const run = spawnSync("npx", ["tsx", `${TASK}.ts`], {
+const run = spawnSync("npx", ["tsx", SCRIPT], {
   cwd: OUT_DIR,
   encoding: "utf-8",
   stdio: ["ignore", "pipe", "pipe"],

--- a/skills/autobrowse/codegen/runners/stagehand.mjs
+++ b/skills/autobrowse/codegen/runners/stagehand.mjs
@@ -3,92 +3,22 @@
 /**
  * stagehand.mjs — Runner for the Stagehand codegen target.
  *
- * Identical contract to runners/playwright.mjs (spawn `npx tsx <task>.ts`,
- * parse the final {"success":boolean} JSON line). The only differences:
+ * Same contract and shared logic as playwright.mjs (see lib/tsx-runner.mjs).
+ * Differences:
  *   - No PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD trick (Stagehand uses
  *     connectOverCDP without bundling a local chromium).
- *   - Requires ANTHROPIC_API_KEY in env (Stagehand's act/extract are
- *     LLM-driven).
+ *   - Requires ANTHROPIC_API_KEY (or ANTHROPIC_AUTH_TOKEN) — Stagehand's
+ *     act/extract are LLM-driven.
  */
 
-import * as fs from "node:fs";
-import * as path from "node:path";
-import { spawnSync } from "node:child_process";
+import { runTsxTarget } from "./lib/tsx-runner.mjs";
 
-function getArg(name) {
-  const i = process.argv.indexOf(`--${name}`);
-  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : null;
-}
-
-const OUT_DIR = getArg("out-dir");
-const SCRIPT = getArg("script");
-
-if (!OUT_DIR || !SCRIPT) {
-  console.log(JSON.stringify({ passed: false, error: "runner missing --out-dir or --script" }));
-  process.exit(2);
-}
-
-const scriptPath = path.join(OUT_DIR, SCRIPT);
-if (!fs.existsSync(scriptPath)) {
-  console.log(JSON.stringify({ passed: false, error: `script not found at ${scriptPath}` }));
-  process.exit(2);
-}
-
-if (!process.env.ANTHROPIC_API_KEY && !process.env.ANTHROPIC_AUTH_TOKEN) {
-  console.log(JSON.stringify({ passed: false, error: "ANTHROPIC_API_KEY required for Stagehand verify" }));
-  process.exit(2);
-}
-
-if (!fs.existsSync(path.join(OUT_DIR, "node_modules"))) {
-  process.stderr.write(`[runner.stagehand] installing deps in ${OUT_DIR}\n`);
-  const install = spawnSync("npm", ["install", "--silent", "--no-audit", "--no-fund"], {
-    cwd: OUT_DIR,
-    stdio: ["ignore", "inherit", "inherit"],
-    timeout: 3 * 60 * 1000,
-  });
-  if (install.status !== 0) {
-    console.log(JSON.stringify({ passed: false, error: `npm install exited ${install.status}` }));
-    process.exit(2);
-  }
-}
-
-const screenshotDir = path.join(OUT_DIR, "screenshots", `verify-${Date.now()}`);
-fs.mkdirSync(screenshotDir, { recursive: true });
-
-process.stderr.write(`[runner.stagehand] running ${scriptPath}\n`);
-const run = spawnSync("npx", ["tsx", SCRIPT], {
-  cwd: OUT_DIR,
-  encoding: "utf-8",
-  stdio: ["ignore", "pipe", "pipe"],
-  env: { ...process.env, SCREENSHOT_DIR: screenshotDir },
-  timeout: 5 * 60 * 1000,
-});
-
-const stdout = run.stdout ?? "";
-const stderr = run.stderr ?? "";
-
-let parsed = null;
-const lines = stdout.trim().split("\n").filter(Boolean);
-for (let i = lines.length - 1; i >= 0; i--) {
-  try {
-    const candidate = JSON.parse(lines[i]);
-    if (typeof candidate?.success === "boolean") {
-      parsed = candidate;
-      break;
+runTsxTarget({
+  label: "stagehand",
+  preflight: () => {
+    if (!process.env.ANTHROPIC_API_KEY && !process.env.ANTHROPIC_AUTH_TOKEN) {
+      return "ANTHROPIC_API_KEY required for Stagehand verify";
     }
-  } catch {}
-}
-
-const passed = run.status === 0 && parsed?.success === true;
-const result = {
-  passed,
-  exit_code: run.status,
-  script_output: parsed,
-  screenshot_dir: screenshotDir,
-  stderr_tail: stderr.slice(-2000),
-};
-if (!passed) {
-  result.error = parsed?.error || (run.status !== 0 ? `script exited ${run.status}` : "script did not emit success:true");
-}
-console.log(JSON.stringify(result));
-process.exit(passed ? 0 : 2);
+    return null;
+  },
+});

--- a/skills/autobrowse/codegen/scaffolds/playwright/package.json
+++ b/skills/autobrowse/codegen/scaffolds/playwright/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "start": "tsx {{TASK}}.ts"
+    "start": "tsx {{SCRIPT}}"
   },
   "dependencies": {
     "dotenv": "{{DOTENV_VERSION}}",

--- a/skills/autobrowse/codegen/scaffolds/playwright/package.json
+++ b/skills/autobrowse/codegen/scaffolds/playwright/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "{{TASK}}-playwright",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx {{TASK}}.ts"
+  },
+  "dependencies": {
+    "dotenv": "16.4.5",
+    "playwright": "1.50.0",
+    "tsx": "4.22.3",
+    "zod": "4.4.3"
+  }
+}

--- a/skills/autobrowse/codegen/scaffolds/playwright/package.json
+++ b/skills/autobrowse/codegen/scaffolds/playwright/package.json
@@ -7,9 +7,9 @@
     "start": "tsx {{TASK}}.ts"
   },
   "dependencies": {
-    "dotenv": "16.4.5",
-    "playwright": "1.50.0",
-    "tsx": "4.22.3",
-    "zod": "4.4.3"
+    "dotenv": "{{DOTENV_VERSION}}",
+    "playwright": "{{PLAYWRIGHT_VERSION}}",
+    "tsx": "{{TSX_VERSION}}",
+    "zod": "{{ZOD_VERSION}}"
   }
 }

--- a/skills/autobrowse/codegen/scaffolds/playwright/tsconfig.json
+++ b/skills/autobrowse/codegen/scaffolds/playwright/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true
+  },
+  "include": ["*.ts"]
+}

--- a/skills/autobrowse/codegen/scaffolds/stagehand/package.json
+++ b/skills/autobrowse/codegen/scaffolds/stagehand/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "start": "tsx {{TASK}}.ts"
+    "start": "tsx {{SCRIPT}}"
   },
   "dependencies": {
     "@browserbasehq/stagehand": "{{STAGEHAND_VERSION}}",

--- a/skills/autobrowse/codegen/scaffolds/stagehand/package.json
+++ b/skills/autobrowse/codegen/scaffolds/stagehand/package.json
@@ -7,9 +7,9 @@
     "start": "tsx {{TASK}}.ts"
   },
   "dependencies": {
-    "@browserbasehq/stagehand": "3.4.0",
-    "dotenv": "16.4.5",
-    "tsx": "4.22.3",
-    "zod": "4.4.3"
+    "@browserbasehq/stagehand": "{{STAGEHAND_VERSION}}",
+    "dotenv": "{{DOTENV_VERSION}}",
+    "tsx": "{{TSX_VERSION}}",
+    "zod": "{{ZOD_VERSION}}"
   }
 }

--- a/skills/autobrowse/codegen/scaffolds/stagehand/package.json
+++ b/skills/autobrowse/codegen/scaffolds/stagehand/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "{{TASK}}-stagehand",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx {{TASK}}.ts"
+  },
+  "dependencies": {
+    "@browserbasehq/stagehand": "3.4.0",
+    "dotenv": "16.4.5",
+    "tsx": "4.22.3",
+    "zod": "4.4.3"
+  }
+}

--- a/skills/autobrowse/codegen/scaffolds/stagehand/tsconfig.json
+++ b/skills/autobrowse/codegen/scaffolds/stagehand/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true
+  },
+  "include": ["*.ts"]
+}

--- a/skills/autobrowse/package.json
+++ b/skills/autobrowse/package.json
@@ -4,7 +4,8 @@
   "description": "Self-improving browser agent via skill learning — autoresearch pattern + Browse CLI + Anthropic API",
   "type": "module",
   "scripts": {
-    "evaluate": "node scripts/evaluate.mjs"
+    "evaluate": "node scripts/evaluate.mjs",
+    "codegen": "node scripts/codegen.mjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",

--- a/skills/autobrowse/references/playwright-cdp-bridge.md
+++ b/skills/autobrowse/references/playwright-cdp-bridge.md
@@ -1,0 +1,149 @@
+# Playwright ↔ Browserbase bridge — patterns the upstream skill doesn't cover
+
+This file covers patterns specific to **running Playwright against a Browserbase
+session over CDP**. The upstream Playwright reference (e.g. the Currents.dev
+best-practices skill at `/tmp/playwright-skill/SKILL.md` if cloned, or
+`https://playwright.dev/docs`) covers the general API — locators, auto-waiting,
+error testing, framework patterns — but doesn't document the Browserbase
+wiring. This is the canonical reference for codegen targets that produce
+Playwright (or Playwright-API-compatible) scripts.
+
+## 1. `connectOverCDP` to a freshly-created Browserbase session
+
+The emitted script **creates its own fresh Browserbase session** at startup.
+Don't try to attach to whatever session autobrowse was on — autobrowse
+releases each iteration's session before the script ever runs, so there's no
+surviving session to reuse anyway. More importantly: the emitted script must
+be self-contained. Anyone who downloads it should be able to run it locally
+with just `BROWSERBASE_API_KEY` set — no implicit dependency on autobrowse
+state.
+
+Pattern is always: **create → connect → use → release.**
+
+```typescript
+import { chromium, type Browser } from "playwright";
+import { execFileSync } from "node:child_process";
+
+function createSession() {
+  // `browse` is on PATH after `npm install -g browse`. The CLI returns a
+  // JSON envelope with `id` + `connectUrl`. The flags below match what
+  // autobrowse uses for stealth; drop --verified or --proxies for
+  // low-anti-bot sites.
+  const stdout = execFileSync("browse", [
+    "cloud", "sessions", "create",
+    "--keep-alive", "--verified", "--proxies",
+  ]).toString();
+  return JSON.parse(stdout) as { id: string; connectUrl: string };
+}
+
+async function connect(connectUrl: string) {
+  const browser = await chromium.connectOverCDP(connectUrl);
+  const [context] = browser.contexts();
+  const page = context.pages()[0] ?? await context.newPage();
+  return { browser, page };
+}
+
+function releaseSession(sessionId: string) {
+  // Fire-and-forget; the CLI handles network errors gracefully.
+  execFileSync("browse", [
+    "cloud", "sessions", "update", sessionId,
+    "--status", "REQUEST_RELEASE",
+  ]);
+}
+
+// Skeleton for main():
+//   const session = createSession();
+//   try {
+//     const { page } = await connect(session.connectUrl);
+//     // … do the work on page …
+//   } finally {
+//     // Do NOT call browser.close() — connectOverCDP tears down the remote
+//     // session prematurely. Release via the CLI instead:
+//     releaseSession(session.id);
+//   }
+```
+
+**Do not** call `browser.close()` on a `connectOverCDP` attachment — it tears
+down the remote session prematurely and can leak underlying Browserbase
+resources. Always release with
+`browse cloud sessions update <id> --status REQUEST_RELEASE` in the `finally`
+block.
+
+## 2. React-fill DOM workaround
+
+Some React-controlled inputs ignore `page.fill()` because their `onChange`
+listener is bound to a synthetic React-managed value. Stripped values,
+autocompletes that don't fire, validators that don't trigger — symptoms of
+this. The fix is to set the value via the native DOM setter so React picks
+it up.
+
+```typescript
+import type { Page } from "playwright";
+
+async function fillField(page: Page, selector: string, value: string) {
+  const locator = page.locator(selector);
+  await locator.click();
+  await locator.evaluate((el: HTMLInputElement, v: string) => {
+    const setter = Object.getOwnPropertyDescriptor(
+      Object.getPrototypeOf(el), "value",
+    )?.set;
+    setter?.call(el, v);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+    el.dispatchEvent(new Event("change", { bubbles: true }));
+  }, value);
+}
+```
+
+Use this when `page.fill()` worked in the autobrowse iteration but the value
+gets stripped on submit (common on React-heavy form wizards).
+
+## 3. `snap()` screenshot helper — the convention codegen expects
+
+When verify runs the script, the runner sets a `SCREENSHOT_DIR` env var per
+attempt. The script can write progress + failure screenshots there so a
+human (or a future LLM rewrite pass) can debug. Every emitted script should
+include this helper.
+
+```typescript
+import type { Page } from "playwright";
+import { join } from "node:path";
+
+async function snap(page: Page, label: string) {
+  const dir = process.env.SCREENSHOT_DIR;
+  if (!dir) return; // local-run no-op, so engineers don't trip on missing dirs
+  await page.screenshot({
+    path: join(dir, `${label}.png`),
+    fullPage: false,
+  });
+}
+```
+
+**Call it at:** the initial page load (`01-landing`), after each meaningful
+step (`02-form-filled`, `03-submitted`, etc.), at the converged final state
+(`08-success`), and inside a top-level
+`try { ... } catch (err) { await snap(page, \`99-error-at-${currentStep}\`); throw err }`
+wrapper so failures always capture the failure-state DOM.
+
+**Naming convention:** zero-padded numeric prefix + kebab-case label, all
+lowercase. Sorting by filename gives iteration order.
+
+## 4. Schema-validated output (Zod)
+
+The script's last action on stdout must be a single JSON line that the runner
+can parse:
+
+```typescript
+import { z } from "zod";
+
+const OutputSchema = z.object({
+  // … task-specific fields …
+});
+
+// At end of main(), after successful extraction:
+const output = OutputSchema.parse({ /* extracted data */ });
+console.log(JSON.stringify({ success: true, data: output }));
+```
+
+On failure, exit non-zero AND emit `{"success":false,"error":"..."}` so the
+runner can distinguish "script ran cleanly but didn't find data" from
+"script crashed".

--- a/skills/autobrowse/scripts/codegen.mjs
+++ b/skills/autobrowse/scripts/codegen.mjs
@@ -361,11 +361,15 @@ function verify(framework, outDir, scriptBasename) {
   if (!fs.existsSync(runnerPath)) {
     return { passed: false, error: `no runner for framework "${framework}" at ${runnerPath}`, runner_missing: true };
   }
+  // The parent timeout must exceed the runner's worst case: tsx-runner allows
+  // up to 3min for npm install + 5min for the tsx run = 8min, plus slack for
+  // process startup and the trailing-JSON parse. 10min keeps us safely above
+  // that so a healthy slow run isn't killed mid-flight.
   const res = spawnSync("node", [runnerPath, "--out-dir", outDir, "--script", scriptBasename], {
     encoding: "utf-8",
     stdio: ["ignore", "pipe", "pipe"],
     env: process.env,
-    timeout: 5 * 60 * 1000,
+    timeout: 10 * 60 * 1000,
   });
   const stdout = res.stdout || "";
   const stderr = res.stderr || "";

--- a/skills/autobrowse/scripts/codegen.mjs
+++ b/skills/autobrowse/scripts/codegen.mjs
@@ -50,7 +50,7 @@ import crypto from "node:crypto";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SKILL_DIR = path.resolve(__dirname, "..");
-const PROMPT_TEMPLATE_VERSION = "2"; // bump to invalidate cache after prompt edits
+const PROMPT_TEMPLATE_VERSION = "1"; // bump to invalidate cache after prompt edits
 
 const DEFAULT_MODEL = "claude-sonnet-4-6";
 const DEFAULT_MAX_TOKENS = 8192;

--- a/skills/autobrowse/scripts/codegen.mjs
+++ b/skills/autobrowse/scripts/codegen.mjs
@@ -1,0 +1,434 @@
+#!/usr/bin/env node
+
+/**
+ * codegen.mjs — Convert a converged autobrowse trace into a runnable script in
+ * one or more frameworks (Playwright, Stagehand, …).
+ *
+ * Pipeline per framework:
+ *   1. Compose the context: task.md + unified-events.jsonl (when present) +
+ *      descriptors.ndjson (when present) + strategy.md + the framework's
+ *      cdp-bridge reference doc.
+ *   2. Compute a cache key over (framework, prompt-template, task, trace,
+ *      descriptors). Cache hit short-circuits with zero LLM cost.
+ *   3. Single Anthropic completion against the framework's prompt template.
+ *      Emit `<task>.<ext>` to the output dir.
+ *   4. Drop the framework's scaffold files (package.json, tsconfig, …).
+ *   5. If --verify: invoke the framework's runner against a fresh Browserbase
+ *      session. On failure, feed the error back into a rewrite call up to
+ *      --max-retries times.
+ *
+ * One JSON status line per framework on stdout. Non-zero exit if any selected
+ * framework's final state is fail.
+ *
+ * Usage:
+ *   node scripts/codegen.mjs --task <name> [options]
+ *
+ * Options:
+ *   --task <name>                  task name under <workspace>/tasks/ (required)
+ *   --workspace <dir>              default ./autobrowse
+ *   --run <id>                     default: latest run-NNN with success: true
+ *   --frameworks <a,b,...>         default: playwright
+ *   --verify | --no-verify         default: --verify
+ *   --max-retries <N>              rewrite-on-verify-failure cap (default: 2)
+ *   --cache-dir <dir>              default <workspace>/codegen-cache
+ *   --out <dir>                    default <workspace>/tasks/<name>/<framework>
+ *   --prompt-template <path>       custom framework prompt (pair with --frameworks custom)
+ *   --force                        bust cache
+ *   --dry-run                      estimate cost without LLM call
+ *   --cache-only                   error if cache miss (no LLM call)
+ *   --model <name>                 override Claude model
+ *   --help
+ */
+
+import "dotenv/config";
+import Anthropic from "@anthropic-ai/sdk";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { execFileSync, spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import crypto from "node:crypto";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SKILL_DIR = path.resolve(__dirname, "..");
+const PROMPT_TEMPLATE_VERSION = "1"; // bump to invalidate cache after prompt edits
+
+const DEFAULT_MODEL = "claude-sonnet-4-6";
+const DEFAULT_MAX_TOKENS = 8192;
+
+// ── CLI ────────────────────────────────────────────────────────────
+
+function getArg(name, fallback) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+const hasFlag = (n) => process.argv.includes(`--${n}`);
+
+if (hasFlag("help") || hasFlag("h")) {
+  console.log(`autobrowse codegen — produce runnable scripts from a converged trace
+
+Usage: node scripts/codegen.mjs --task <name> [options]
+
+Options:
+  --task <name>                  task name under <workspace>/tasks/ (required)
+  --workspace <dir>              default: ./autobrowse
+  --run <id>                     specific run-NNN (default: newest passing)
+  --frameworks <a,b,...>         comma list; default: playwright
+                                 builtins: playwright, stagehand
+  --verify | --no-verify         run the script in a fresh BB session (default: --verify)
+  --max-retries <N>              cap rewrite-on-verify-fail loop (default: 2)
+  --cache-dir <dir>              default: <workspace>/codegen-cache
+  --out <dir>                    default: <workspace>/tasks/<name>/<framework>
+  --prompt-template <path>       custom prompt template (pair with --frameworks=custom)
+  --force                        ignore cache, regenerate
+  --dry-run                      estimate cost; don't call the LLM
+  --cache-only                   error if cache miss
+  --model <name>                 default: ${DEFAULT_MODEL}
+
+Env:
+  ANTHROPIC_API_KEY              required for LLM call
+  BROWSERBASE_API_KEY            required for --verify
+
+Exits 0 if all selected frameworks ended in pass (or --no-verify), 2 if any
+failed, 1 on harness error.`);
+  process.exit(0);
+}
+
+const TASK = getArg("task");
+if (!TASK) {
+  console.error("ERROR: --task <name> is required. Pass --help for usage.");
+  process.exit(1);
+}
+const WORKSPACE = path.resolve(getArg("workspace", "autobrowse"));
+const FORCED_RUN = getArg("run");
+const FRAMEWORKS = getArg("frameworks", "playwright").split(",").map((s) => s.trim()).filter(Boolean);
+const VERIFY = !hasFlag("no-verify");
+const MAX_RETRIES = parseInt(getArg("max-retries", "2"), 10);
+const CACHE_DIR = path.resolve(getArg("cache-dir", path.join(WORKSPACE, "codegen-cache")));
+const OUT_OVERRIDE = getArg("out");
+const PROMPT_TEMPLATE_OVERRIDE = getArg("prompt-template");
+const FORCE = hasFlag("force");
+const DRY_RUN = hasFlag("dry-run");
+const CACHE_ONLY = hasFlag("cache-only");
+const MODEL = getArg("model", DEFAULT_MODEL);
+
+// ── Inputs ─────────────────────────────────────────────────────────
+
+const taskDir = path.join(WORKSPACE, "tasks", TASK);
+const tracesDir = path.join(WORKSPACE, "traces", TASK);
+const taskFile = path.join(taskDir, "task.md");
+
+for (const [label, file] of [["task.md", taskFile]]) {
+  if (!fs.existsSync(file)) {
+    console.error(`ERROR: ${label} not found at ${file}. Run autobrowse first.`);
+    process.exit(1);
+  }
+}
+
+function pickRun() {
+  if (FORCED_RUN) return FORCED_RUN;
+  if (!fs.existsSync(tracesDir)) return null;
+  const runs = fs.readdirSync(tracesDir)
+    .filter((d) => /^run-\d+$/.test(d))
+    .sort()
+    .reverse();
+  for (const r of runs) {
+    const summary = path.join(tracesDir, r, "summary.md");
+    if (!fs.existsSync(summary)) continue;
+    const text = fs.readFileSync(summary, "utf-8");
+    if (/success:\s*true/.test(text) || /"success"\s*:\s*true/.test(text)) return r;
+  }
+  return null;
+}
+
+const RUN_ID = pickRun();
+if (!RUN_ID) {
+  console.error(`ERROR: no passing run found under ${tracesDir}. Pass --run <id> to force, or run autobrowse first.`);
+  process.exit(1);
+}
+const runDir = path.join(tracesDir, RUN_ID);
+
+// Try multiple candidate paths for each input — autobrowse layouts have
+// shifted over time and we want this to be robust to both modern and legacy.
+function readFirstExisting(...candidates) {
+  for (const p of candidates) {
+    if (p && fs.existsSync(p)) return { path: p, content: fs.readFileSync(p, "utf-8") };
+  }
+  return null;
+}
+
+const taskMd = fs.readFileSync(taskFile, "utf-8");
+const strategyMd = readFirstExisting(path.join(taskDir, "strategy.md"))?.content || "";
+const traceJson = readFirstExisting(path.join(runDir, "trace.json"))?.content || "";
+const unifiedEvents = readFirstExisting(path.join(runDir, "unified-events.jsonl"))?.content || "";
+const descriptors = readFirstExisting(
+  path.join(runDir, ".o11y", RUN_ID, "cdp", "descriptors.ndjson"),
+  path.join(runDir, "cdp", "descriptors.ndjson"),
+)?.content || "";
+
+// ── Framework registry ────────────────────────────────────────────
+
+const CODEGEN_DIR = path.join(SKILL_DIR, "codegen");
+const REFERENCES_DIR = path.join(SKILL_DIR, "references");
+
+function frameworkConfig(framework) {
+  const promptPath = PROMPT_TEMPLATE_OVERRIDE && framework === "custom"
+    ? path.resolve(PROMPT_TEMPLATE_OVERRIDE)
+    : path.join(CODEGEN_DIR, "prompts", `${framework}.md`);
+  const scaffoldDir = path.join(CODEGEN_DIR, "scaffolds", framework);
+  const runnerPath = path.join(CODEGEN_DIR, "runners", `${framework}.mjs`);
+  const extByFramework = { playwright: "ts", stagehand: "ts", puppeteer: "js", selenium: "py" };
+  const ext = extByFramework[framework] || "ts";
+  return { promptPath, scaffoldDir, runnerPath, ext };
+}
+
+// ── Context builder ───────────────────────────────────────────────
+
+// Trim a stringified blob to a budget while keeping head + tail.
+function clip(text, maxBytes) {
+  if (text.length <= maxBytes) return text;
+  const head = Math.floor(maxBytes * 0.7);
+  const tail = maxBytes - head - 64;
+  return text.slice(0, head) + `\n\n…[truncated ${text.length - head - tail} bytes]…\n\n` + text.slice(-tail);
+}
+
+function buildContext({ promptTemplate, cdpBridgeDoc, previousAttempt, verifyFailure }) {
+  const parts = [];
+  parts.push("# Task\n\n" + taskMd.trim());
+  if (strategyMd.trim()) parts.push("# Strategy notes\n\n" + strategyMd.trim());
+  if (cdpBridgeDoc) parts.push("# Reference: Playwright ↔ Browserbase bridge\n\n" + cdpBridgeDoc.trim());
+  if (unifiedEvents.trim()) {
+    parts.push("# Unified events (agent + browser, time-ordered)\n\n```\n" + clip(unifiedEvents, 32_000) + "\n```");
+  } else if (traceJson.trim()) {
+    parts.push("# Trace (agent turns)\n\n```json\n" + clip(traceJson, 32_000) + "\n```");
+  }
+  if (descriptors.trim()) {
+    parts.push("# Descriptors (per-command DOM target)\n\n```\n" + clip(descriptors, 16_000) + "\n```");
+  }
+  if (previousAttempt && verifyFailure) {
+    parts.push(
+      "# Previous attempt and the verify failure\n\nYour previous attempt was:\n\n```\n" +
+      clip(previousAttempt, 12_000) +
+      "\n```\n\nIt failed verification with:\n\n```\n" +
+      clip(verifyFailure, 4_000) +
+      "\n```\n\nFix the issue and emit a complete corrected script.",
+    );
+  }
+  return promptTemplate.trim() + "\n\n" + parts.join("\n\n");
+}
+
+// ── Cache ─────────────────────────────────────────────────────────
+
+function hashContent(s) {
+  return crypto.createHash("sha256").update(s).digest("hex").slice(0, 16);
+}
+function cacheKey(framework, promptTemplate) {
+  return hashContent([
+    "v" + PROMPT_TEMPLATE_VERSION,
+    framework,
+    hashContent(promptTemplate),
+    hashContent(taskMd),
+    hashContent(traceJson),
+    hashContent(unifiedEvents),
+    hashContent(descriptors),
+    hashContent(strategyMd),
+  ].join("|"));
+}
+function readCache(key) {
+  const p = path.join(CACHE_DIR, `${key}.txt`);
+  return fs.existsSync(p) ? fs.readFileSync(p, "utf-8") : null;
+}
+function writeCache(key, content) {
+  fs.mkdirSync(CACHE_DIR, { recursive: true });
+  fs.writeFileSync(path.join(CACHE_DIR, `${key}.txt`), content);
+}
+
+// ── LLM call ──────────────────────────────────────────────────────
+
+let _anthropic = null;
+function anthropic() {
+  if (!_anthropic) {
+    if (!process.env.ANTHROPIC_API_KEY && !process.env.ANTHROPIC_AUTH_TOKEN) {
+      throw new Error("ANTHROPIC_API_KEY (or ANTHROPIC_AUTH_TOKEN) is required for codegen.");
+    }
+    _anthropic = new Anthropic();
+  }
+  return _anthropic;
+}
+
+async function callLlm(systemPrompt, userMessage) {
+  const res = await anthropic().messages.create({
+    model: MODEL,
+    max_tokens: DEFAULT_MAX_TOKENS,
+    system: systemPrompt,
+    messages: [{ role: "user", content: userMessage }],
+  });
+  const text = res.content
+    .filter((b) => b.type === "text")
+    .map((b) => b.text)
+    .join("\n");
+  // The agent might emit fences anyway; strip a single outer code block.
+  const fenced = text.match(/^```[\w-]*\n([\s\S]*?)\n```\s*$/);
+  const code = fenced ? fenced[1] : text.trim();
+  const cost = (res.usage?.input_tokens ?? 0) * 3e-6 + (res.usage?.output_tokens ?? 0) * 15e-6;
+  return { code, cost, tokens: res.usage };
+}
+
+// ── Scaffold + write output ───────────────────────────────────────
+
+function templateInterpolate(content, vars) {
+  return Object.entries(vars).reduce(
+    (acc, [k, v]) => acc.replaceAll(`{{${k}}}`, v),
+    content,
+  );
+}
+
+function dropScaffold(scaffoldDir, outDir, taskName) {
+  if (!fs.existsSync(scaffoldDir)) return;
+  for (const entry of fs.readdirSync(scaffoldDir)) {
+    const src = path.join(scaffoldDir, entry);
+    const dst = path.join(outDir, entry);
+    if (fs.existsSync(dst)) continue; // never overwrite a user's file
+    const content = fs.readFileSync(src, "utf-8");
+    fs.writeFileSync(dst, templateInterpolate(content, { TASK: taskName }));
+  }
+}
+
+// ── Verify ────────────────────────────────────────────────────────
+
+function verify(framework, outDir, taskName) {
+  const { runnerPath } = frameworkConfig(framework);
+  if (!fs.existsSync(runnerPath)) {
+    return { passed: false, error: `no runner for framework "${framework}" at ${runnerPath}`, ranner_missing: true };
+  }
+  const res = spawnSync("node", [runnerPath, "--out-dir", outDir, "--task", taskName], {
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+    env: process.env,
+    timeout: 5 * 60 * 1000,
+  });
+  const stdout = res.stdout || "";
+  const stderr = res.stderr || "";
+  // Runners must emit a final JSON line: {"passed":true,...} or {"passed":false,...}
+  const lastLine = stdout.trim().split("\n").pop() || "";
+  let parsed = null;
+  try { parsed = JSON.parse(lastLine); } catch {}
+  if (parsed && typeof parsed.passed === "boolean") {
+    return { ...parsed, stdout, stderr };
+  }
+  return { passed: false, error: `runner did not emit a {passed:boolean} JSON line; exit=${res.status}`, stdout, stderr };
+}
+
+// ── Per-framework pipeline ────────────────────────────────────────
+
+async function generateOne(framework) {
+  const cfg = frameworkConfig(framework);
+  if (!fs.existsSync(cfg.promptPath)) {
+    return { framework, passed: false, error: `no prompt template for "${framework}" at ${cfg.promptPath}` };
+  }
+  const promptTemplate = fs.readFileSync(cfg.promptPath, "utf-8");
+  const cdpBridgeDoc = fs.existsSync(path.join(REFERENCES_DIR, "playwright-cdp-bridge.md"))
+    ? fs.readFileSync(path.join(REFERENCES_DIR, "playwright-cdp-bridge.md"), "utf-8")
+    : "";
+
+  const outDir = OUT_OVERRIDE
+    ? path.resolve(OUT_OVERRIDE)
+    : path.join(taskDir, framework);
+  fs.mkdirSync(outDir, { recursive: true });
+  const scriptPath = path.join(outDir, `${TASK}.${cfg.ext}`);
+
+  // Cache lookup
+  const key = cacheKey(framework, promptTemplate);
+  let cached = !FORCE ? readCache(key) : null;
+  if (CACHE_ONLY && !cached) {
+    return { framework, passed: false, error: `--cache-only set but no cached output for key ${key}` };
+  }
+
+  if (DRY_RUN) {
+    const ctx = buildContext({ promptTemplate, cdpBridgeDoc });
+    const bytes = ctx.length;
+    const estCost = (bytes / 4) * 3e-6; // ~4 chars/token, $3/M in
+    return { framework, dryRun: true, prompt_bytes: bytes, estimated_cost_usd: Number(estCost.toFixed(4)) };
+  }
+
+  let code, cost = 0, attempts = 0;
+  if (cached) {
+    code = cached;
+  } else {
+    const ctx = buildContext({ promptTemplate, cdpBridgeDoc });
+    const { code: c, cost: k } = await callLlm(
+      "You are an expert browser-automation engineer. Output ONLY the contents of the script file — no preamble, no explanation, no markdown fences. The script must be runnable as-is.",
+      ctx,
+    );
+    code = c;
+    cost += k;
+    writeCache(key, code);
+    attempts = 1;
+  }
+
+  fs.writeFileSync(scriptPath, code);
+  dropScaffold(cfg.scaffoldDir, outDir, TASK);
+
+  if (!VERIFY) {
+    return { framework, passed: true, scriptPath, cached: !!cached, verify_skipped: true, cost_usd: cost };
+  }
+
+  // Verify loop with rewrite-on-failure
+  let lastVerify = verify(framework, outDir, TASK);
+  while (!lastVerify.passed && attempts < MAX_RETRIES + 1) {
+    if (lastVerify.ranner_missing) break;
+    attempts++;
+    const previousCode = code;
+    const failureContext =
+      (lastVerify.error || "") +
+      "\n\nstderr:\n" + (lastVerify.stderr || "").slice(-2000) +
+      "\nstdout:\n" + (lastVerify.stdout || "").slice(-2000);
+    const ctx = buildContext({
+      promptTemplate,
+      cdpBridgeDoc,
+      previousAttempt: previousCode,
+      verifyFailure: failureContext,
+    });
+    const { code: c, cost: k } = await callLlm(
+      "You are an expert browser-automation engineer. Output ONLY the corrected script file — no preamble, no explanation, no markdown fences.",
+      ctx,
+    );
+    code = c;
+    cost += k;
+    fs.writeFileSync(scriptPath, code);
+    writeCache(key, code); // overwrite cache with the latest attempt
+    lastVerify = verify(framework, outDir, TASK);
+  }
+
+  return {
+    framework,
+    passed: lastVerify.passed,
+    scriptPath,
+    cached: !!cached && attempts === 0,
+    verify_attempts: attempts,
+    last_error: lastVerify.passed ? null : (lastVerify.error || lastVerify.stderr?.slice(-200) || null),
+    cost_usd: Number(cost.toFixed(4)),
+  };
+}
+
+// ── Main ──────────────────────────────────────────────────────────
+
+async function main() {
+  console.error(`[codegen] task=${TASK} run=${RUN_ID} frameworks=[${FRAMEWORKS.join(",")}] verify=${VERIFY}`);
+  let anyFailed = false;
+  for (const framework of FRAMEWORKS) {
+    try {
+      const result = await generateOne(framework);
+      console.log(JSON.stringify(result));
+      if (result.passed === false) anyFailed = true;
+    } catch (err) {
+      console.log(JSON.stringify({ framework, passed: false, error: err.message }));
+      anyFailed = true;
+    }
+  }
+  process.exit(anyFailed ? 2 : 0);
+}
+
+main().catch((err) => {
+  console.error("FATAL:", err.stack || err.message);
+  process.exit(1);
+});

--- a/skills/autobrowse/scripts/codegen.mjs
+++ b/skills/autobrowse/scripts/codegen.mjs
@@ -50,7 +50,7 @@ import crypto from "node:crypto";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SKILL_DIR = path.resolve(__dirname, "..");
-const PROMPT_TEMPLATE_VERSION = "1"; // bump to invalidate cache after prompt edits
+const PROMPT_TEMPLATE_VERSION = "2"; // bump to invalidate cache after prompt edits or scaffold/runner contract changes
 
 const DEFAULT_MODEL = "claude-sonnet-4-6";
 const DEFAULT_MAX_TOKENS = 8192;
@@ -125,7 +125,15 @@ for (const [label, file] of [["task.md", taskFile]]) {
 }
 
 function pickRun() {
-  if (FORCED_RUN) return FORCED_RUN;
+  if (FORCED_RUN) {
+    // --run was passed; still confirm the directory exists. Without this we'd
+    // happily call codegen with empty trace/events/descriptors and the LLM
+    // would invent a script from just task.md + strategy.md, while logs
+    // still report the forced run id as if it were a real input.
+    const forcedDir = path.join(tracesDir, FORCED_RUN);
+    if (!fs.existsSync(forcedDir)) return null;
+    return FORCED_RUN;
+  }
   if (!fs.existsSync(tracesDir)) return null;
   const runs = fs.readdirSync(tracesDir)
     .filter((d) => /^run-\d+$/.test(d))
@@ -142,7 +150,11 @@ function pickRun() {
 
 const RUN_ID = pickRun();
 if (!RUN_ID) {
-  console.error(`ERROR: no passing run found under ${tracesDir}. Pass --run <id> to force, or run autobrowse first.`);
+  if (FORCED_RUN) {
+    console.error(`ERROR: --run ${FORCED_RUN} not found at ${path.join(tracesDir, FORCED_RUN)}.`);
+  } else {
+    console.error(`ERROR: no passing run found under ${tracesDir}. Pass --run <id> to force, or run autobrowse first.`);
+  }
   process.exit(1);
 }
 const runDir = path.join(tracesDir, RUN_ID);
@@ -275,6 +287,27 @@ async function callLlm(systemPrompt, userMessage) {
 
 // ── Scaffold + write output ───────────────────────────────────────
 
+// Scaffold version pins. Each framework's scaffold/package.json references
+// these via {{PLAYWRIGHT_VERSION}} / {{STAGEHAND_VERSION}} / etc. so callers
+// can canary a new release without forking — set the corresponding env var.
+// Loose semver guard rejects shell-injection shapes before they hit npm.
+const VERSION_RE = /^\d+\.\d+\.\d+(?:-[A-Za-z0-9.-]+)?$/;
+function resolveVersion(envName, fallback) {
+  const raw = process.env[envName];
+  if (!raw) return fallback;
+  if (!VERSION_RE.test(raw)) {
+    throw new Error(`${envName}="${raw}" is not a valid X.Y.Z[-tag] version`);
+  }
+  return raw;
+}
+const SCAFFOLD_VERSIONS = {
+  PLAYWRIGHT_VERSION: resolveVersion("PLAYWRIGHT_VERSION", "1.50.0"),
+  STAGEHAND_VERSION: resolveVersion("STAGEHAND_VERSION", "3.4.0"),
+  TSX_VERSION: resolveVersion("TSX_VERSION", "4.22.3"),
+  ZOD_VERSION: resolveVersion("ZOD_VERSION", "4.4.3"),
+  DOTENV_VERSION: resolveVersion("DOTENV_VERSION", "16.4.5"),
+};
+
 function templateInterpolate(content, vars) {
   return Object.entries(vars).reduce(
     (acc, [k, v]) => acc.replaceAll(`{{${k}}}`, v),
@@ -289,7 +322,7 @@ function dropScaffold(scaffoldDir, outDir, taskName) {
     const dst = path.join(outDir, entry);
     if (fs.existsSync(dst)) continue; // never overwrite a user's file
     const content = fs.readFileSync(src, "utf-8");
-    fs.writeFileSync(dst, templateInterpolate(content, { TASK: taskName }));
+    fs.writeFileSync(dst, templateInterpolate(content, { TASK: taskName, ...SCAFFOLD_VERSIONS }));
   }
 }
 
@@ -298,7 +331,7 @@ function dropScaffold(scaffoldDir, outDir, taskName) {
 function verify(framework, outDir, scriptBasename) {
   const { runnerPath } = frameworkConfig(framework);
   if (!fs.existsSync(runnerPath)) {
-    return { passed: false, error: `no runner for framework "${framework}" at ${runnerPath}`, ranner_missing: true };
+    return { passed: false, error: `no runner for framework "${framework}" at ${runnerPath}`, runner_missing: true };
   }
   const res = spawnSync("node", [runnerPath, "--out-dir", outDir, "--script", scriptBasename], {
     encoding: "utf-8",
@@ -357,7 +390,12 @@ async function generateOne(framework) {
     return { framework, dryRun: true, prompt_bytes: bytes, estimated_cost_usd: Number(estCost.toFixed(4)) };
   }
 
-  let code, cost = 0, attempts = 0;
+  // `attempts` counts emitted-script-versions. Cached and uncached both start
+  // at 1 (the script-on-disk is one version, whether the LLM just wrote it or
+  // we restored it from cache). The retry loop below then increments per
+  // rewrite, bounded by --max-retries. Initializing to 0 on a cache hit gave
+  // cached runs one extra rewrite vs uncached — caught by Bugbot.
+  let code, cost = 0, attempts = 1;
   if (cached) {
     code = cached;
   } else {
@@ -369,7 +407,6 @@ async function generateOne(framework) {
     code = c;
     cost += k;
     writeCache(key, code);
-    attempts = 1;
   }
 
   fs.writeFileSync(scriptPath, code);
@@ -382,7 +419,7 @@ async function generateOne(framework) {
   // Verify loop with rewrite-on-failure
   let lastVerify = verify(framework, outDir, scriptBasename);
   while (!lastVerify.passed && attempts < MAX_RETRIES + 1) {
-    if (lastVerify.ranner_missing) break;
+    if (lastVerify.runner_missing) break;
     attempts++;
     const previousCode = code;
     const failureContext =
@@ -403,14 +440,14 @@ async function generateOne(framework) {
     cost += k;
     fs.writeFileSync(scriptPath, code);
     writeCache(key, code); // overwrite cache with the latest attempt
-    lastVerify = verify(framework, outDir, TASK);
+    lastVerify = verify(framework, outDir, scriptBasename);
   }
 
   return {
     framework,
     passed: lastVerify.passed,
     scriptPath,
-    cached: !!cached && attempts === 0,
+    cached: !!cached && cost === 0,
     verify_attempts: attempts,
     last_error: lastVerify.passed ? null : (lastVerify.error || lastVerify.stderr?.slice(-200) || null),
     cost_usd: Number(cost.toFixed(4)),

--- a/skills/autobrowse/scripts/codegen.mjs
+++ b/skills/autobrowse/scripts/codegen.mjs
@@ -50,7 +50,7 @@ import crypto from "node:crypto";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SKILL_DIR = path.resolve(__dirname, "..");
-const PROMPT_TEMPLATE_VERSION = "1"; // bump to invalidate cache after prompt edits
+const PROMPT_TEMPLATE_VERSION = "2"; // bump to invalidate cache after prompt edits
 
 const DEFAULT_MODEL = "claude-sonnet-4-6";
 const DEFAULT_MAX_TOKENS = 8192;

--- a/skills/autobrowse/scripts/codegen.mjs
+++ b/skills/autobrowse/scripts/codegen.mjs
@@ -315,14 +315,19 @@ function templateInterpolate(content, vars) {
   );
 }
 
-function dropScaffold(scaffoldDir, outDir, taskName) {
+function dropScaffold(scaffoldDir, outDir, taskName, scriptBasename) {
   if (!fs.existsSync(scaffoldDir)) return;
+  // Two distinct template vars: TASK is the slug (used in package name),
+  // SCRIPT is the actual filename (used in the start script). They diverge
+  // in --out mode where files are named <framework>.ts but TASK is the
+  // task slug — without SCRIPT, `npm start` would invoke a missing file.
+  const vars = { TASK: taskName, SCRIPT: scriptBasename, ...SCAFFOLD_VERSIONS };
   for (const entry of fs.readdirSync(scaffoldDir)) {
     const src = path.join(scaffoldDir, entry);
     const dst = path.join(outDir, entry);
     if (fs.existsSync(dst)) continue; // never overwrite a user's file
     const content = fs.readFileSync(src, "utf-8");
-    fs.writeFileSync(dst, templateInterpolate(content, { TASK: taskName, ...SCAFFOLD_VERSIONS }));
+    fs.writeFileSync(dst, templateInterpolate(content, vars));
   }
 }
 
@@ -410,7 +415,7 @@ async function generateOne(framework) {
   }
 
   fs.writeFileSync(scriptPath, code);
-  dropScaffold(cfg.scaffoldDir, outDir, TASK);
+  dropScaffold(cfg.scaffoldDir, outDir, TASK, scriptBasename);
 
   if (!VERIFY) {
     return { framework, passed: true, scriptPath, cached: !!cached, verify_skipped: true, cost_usd: cost };

--- a/skills/autobrowse/scripts/codegen.mjs
+++ b/skills/autobrowse/scripts/codegen.mjs
@@ -325,9 +325,32 @@ function dropScaffold(scaffoldDir, outDir, taskName, scriptBasename) {
   for (const entry of fs.readdirSync(scaffoldDir)) {
     const src = path.join(scaffoldDir, entry);
     const dst = path.join(outDir, entry);
+    const content = templateInterpolate(fs.readFileSync(src, "utf-8"), vars);
+    // Special-case package.json: when --out is shared across frameworks (e.g.
+    // browse.sh passes one dir for playwright+stagehand), the first framework
+    // writes its package.json and the second must MERGE its dependencies in,
+    // not skip. Otherwise the second framework's `node_modules` lacks its own
+    // runtime deps (e.g. @browserbasehq/stagehand) and verify can never pass.
+    if (entry === "package.json" && fs.existsSync(dst)) {
+      try {
+        const existing = JSON.parse(fs.readFileSync(dst, "utf-8"));
+        const incoming = JSON.parse(content);
+        existing.dependencies = {
+          ...(existing.dependencies || {}),
+          ...(incoming.dependencies || {}),
+        };
+        existing.devDependencies = {
+          ...(existing.devDependencies || {}),
+          ...(incoming.devDependencies || {}),
+        };
+        fs.writeFileSync(dst, JSON.stringify(existing, null, 2) + "\n");
+        continue;
+      } catch {
+        // Fall through to never-overwrite policy if either side is malformed.
+      }
+    }
     if (fs.existsSync(dst)) continue; // never overwrite a user's file
-    const content = fs.readFileSync(src, "utf-8");
-    fs.writeFileSync(dst, templateInterpolate(content, vars));
+    fs.writeFileSync(dst, content);
   }
 }
 

--- a/skills/autobrowse/scripts/codegen.mjs
+++ b/skills/autobrowse/scripts/codegen.mjs
@@ -295,12 +295,12 @@ function dropScaffold(scaffoldDir, outDir, taskName) {
 
 // ── Verify ────────────────────────────────────────────────────────
 
-function verify(framework, outDir, taskName) {
+function verify(framework, outDir, scriptBasename) {
   const { runnerPath } = frameworkConfig(framework);
   if (!fs.existsSync(runnerPath)) {
     return { passed: false, error: `no runner for framework "${framework}" at ${runnerPath}`, ranner_missing: true };
   }
-  const res = spawnSync("node", [runnerPath, "--out-dir", outDir, "--task", taskName], {
+  const res = spawnSync("node", [runnerPath, "--out-dir", outDir, "--script", scriptBasename], {
     encoding: "utf-8",
     stdio: ["ignore", "pipe", "pipe"],
     env: process.env,
@@ -330,11 +330,18 @@ async function generateOne(framework) {
     ? fs.readFileSync(path.join(REFERENCES_DIR, "playwright-cdp-bridge.md"), "utf-8")
     : "";
 
-  const outDir = OUT_OVERRIDE
-    ? path.resolve(OUT_OVERRIDE)
-    : path.join(taskDir, framework);
+  // Filename + outDir convention:
+  //  - default mode (--out unset): per-framework subdir, file named after the
+  //    task, so the dir feels like a standalone project — e.g.
+  //    tasks/<task>/playwright/<task>.ts  with its own package.json.
+  //  - --out mode: caller is flattening into someone else's tree (e.g.
+  //    browse.sh's /tmp/skill/{domain}/{task}/), so we use the framework
+  //    name as the filename — playwright.ts + stagehand.ts in the same dir,
+  //    no collision.
+  const outDir = OUT_OVERRIDE ? path.resolve(OUT_OVERRIDE) : path.join(taskDir, framework);
+  const scriptBasename = OUT_OVERRIDE ? `${framework}.${cfg.ext}` : `${TASK}.${cfg.ext}`;
   fs.mkdirSync(outDir, { recursive: true });
-  const scriptPath = path.join(outDir, `${TASK}.${cfg.ext}`);
+  const scriptPath = path.join(outDir, scriptBasename);
 
   // Cache lookup
   const key = cacheKey(framework, promptTemplate);
@@ -373,7 +380,7 @@ async function generateOne(framework) {
   }
 
   // Verify loop with rewrite-on-failure
-  let lastVerify = verify(framework, outDir, TASK);
+  let lastVerify = verify(framework, outDir, scriptBasename);
   while (!lastVerify.passed && attempts < MAX_RETRIES + 1) {
     if (lastVerify.ranner_missing) break;
     attempts++;

--- a/skills/autobrowse/scripts/codegen.mjs
+++ b/skills/autobrowse/scripts/codegen.mjs
@@ -448,6 +448,11 @@ async function generateOne(framework) {
   let lastVerify = verify(framework, outDir, scriptBasename);
   while (!lastVerify.passed && attempts < MAX_RETRIES + 1) {
     if (lastVerify.runner_missing) break;
+    // --cache-only forbids ANY LLM call, including the rewrite path. Without
+    // this guard a cached script that fails verify would still burn quota
+    // through the rewrite loop, contradicting the documented "no LLM call"
+    // CI behavior.
+    if (CACHE_ONLY) break;
     attempts++;
     const previousCode = code;
     const failureContext =


### PR DESCRIPTION
## Summary

Migrates the script-generation apparatus from browse.sh's sandbox prompt into autobrowse itself, so any caller (browse.sh, developers using autobrowse standalone, future apps) can convert a converged trace into a runnable script with one CLI invocation.

Today, codegen lives implicitly inside browse.sh's system-prompt §4b `for target in playwright stagehand; do …; done` loop, with the CDP-bridge reference doc bundled into the sandbox via `src/lib/agent-runtime/script-references.ts` and the Playwright/Stagehand/tsx/zod install block inlined in `src/lib/dispatch.ts`. This PR collapses all of that into one autobrowse stage.

## What this PR adds

```
skills/autobrowse/
├── scripts/codegen.mjs                       orchestrator (~340 lines)
├── codegen/
│   ├── prompts/{playwright,stagehand}.md     framework system prompts
│   ├── scaffolds/{playwright,stagehand}/     pinned deps, self-contained
│   │   ├── package.json
│   │   └── tsconfig.json
│   └── runners/{playwright,stagehand}.mjs    spawn `npx tsx`, parse JSON result
└── references/
    └── playwright-cdp-bridge.md              canonical CDP-attach patterns
                                              (moved here from browse.sh)
```

## Pipeline (per framework)

1. **Compose context** — task.md + unified-events.jsonl + descriptors.ndjson + strategy.md + the framework's prompt template + cdp-bridge doc.
2. **Cache key** — sha256(framework + prompt-version + task + trace + descriptors). Hit short-circuits with \$0 cost.
3. **Single Anthropic completion** — emit `<task>.<ext>` to the output dir.
4. **Drop scaffold files** — `package.json`, `tsconfig.json`, framework-specific deps pinned.
5. **If `--verify`** — invoke the framework's runner against a fresh BB session. On failure, feed the error back into a rewrite call up to `--max-retries` times.
6. **Emit one JSON line per framework** on stdout; non-zero exit if any framework failed.

## CLI

```
--task <name>                  required
--workspace <dir>              default ./autobrowse
--run <id>                     default: newest passing run-NNN
--frameworks <a,b,...>         default: playwright; builtins: playwright,stagehand
--verify | --no-verify         default: --verify
--max-retries <N>              default: 2
--cache-dir / --out / --force / --dry-run / --cache-only / --model
--prompt-template <path>       custom template for --frameworks=custom
```

## Output shape

```bash
$ node scripts/codegen.mjs --task amazon-global-prices --frameworks playwright,stagehand --verify
[codegen] task=amazon-global-prices run=run-003 frameworks=[playwright,stagehand] verify=true
{"framework":"playwright","passed":true,"scriptPath":"tasks/amazon-global-prices/playwright/amazon-global-prices.ts","cached":false,"verify_attempts":1,"cost_usd":0.034}
{"framework":"stagehand","passed":true,"scriptPath":"tasks/amazon-global-prices/stagehand/amazon-global-prices.ts","cached":false,"verify_attempts":2,"cost_usd":0.067}
```

## Dependencies

No new top-level deps. Uses the `@anthropic-ai/sdk` and `dotenv` that `evaluate.mjs` already imports.

## Companion change (separate PR, in browse.sh)

- Collapse system-prompt §4b's `for target in playwright stagehand; do export.mjs ...; done` to a single `codegen.mjs --frameworks $SKILL_FRAMEWORKS` call.
- Delete `prompts/playwright-cdp-bridge.md` and `src/lib/agent-runtime/script-references.ts` (moved into autobrowse).
- Drop the playwright/stagehand/tsx/zod install block and the playwright-best-practices-skill clone from `src/lib/dispatch.ts` (~100 lines).
- Add `SKILL_FRAMEWORKS` env-var passthrough so callers can pick frameworks per request.

## Test plan

- [x] Syntax-check `scripts/codegen.mjs` and both runners (`node --check`)
- [x] `--help` prints usage
- [x] `--task does-not-exist` errors cleanly
- [x] `--cache-only` errors when no cache exists
- [x] `--dry-run` estimates prompt size + cost without LLM call
- [ ] End-to-end on an existing converged trace (validates one framework's prompt + scaffold + runner — to be done against a real BB session before merging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New LLM + live Browserbase verify path and external API keys; failures are mostly isolated to generated task output, but verify runs real sessions and npm installs in output dirs.
> 
> **Overview**
> Adds **in-autobrowse script codegen**: `scripts/codegen.mjs` turns a converged trace into standalone **Playwright** or **Stagehand** TypeScript under `tasks/<task>/<framework>/`, with content-hash caching (`codegen-cache/`), optional **verify** on a fresh Browserbase session, and **rewrite-on-failure** up to `--max-retries`.
> 
> New support files include framework **prompts**, **scaffolds** (`package.json` / `tsconfig` with pinned versions), **runners** (shared `tsx-runner` that installs deps, runs `npx tsx`, parses trailing `{"success":...}` JSON), and **`references/playwright-cdp-bridge.md`** for CDP attach / release patterns. **`SKILL.md`** documents the optional post-convergence step; **`package.json`** adds an `npm run codegen` script.
> 
> Designed for callers like browse.sh: multi-framework via `--frameworks`, shared output dir via `--out` (merged `package.json` deps), and CI via `--cache-only` / `--dry-run` / `--force`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55e7d4c53916766e7c7c87b2efe4b3434984a14d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->