### PR TITLE
feat(pitch-prep): sales-meeting prep skill (research → tailored demo brief)

### DIFF
--- a/skills/pitch-prep/LICENSE.txt
+++ b/skills/pitch-prep/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Shubhankar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/pitch-prep/README.md
+++ b/skills/pitch-prep/README.md
@@ -1,0 +1,58 @@
+# pitch-prep
+
+A Claude Code skill that preps you for a sales meeting. Give it **what you're selling** and **who you're selling to**; it researches both — *browsing the prospect's live site* for concrete hooks — proposes **3 ranked demo concepts** for you to pick from, then expands your pick into a tailored, **self-contained HTML demo brief** that opens in your browser.
+
+It's product-agnostic: works whether you're selling an API, a SaaS app, or a browser-automation tool.
+
+## Why it's good
+
+- **Browser-first research.** It doesn't theorize from the company name — it walks the prospect's real money path, mines review sites, and grabs hiring/competitor signals, capturing **screenshots** as evidence.
+- **Uses the full web-data stack.** Search to *find* pages → Fetch to *read* them cheaply → Browse to *walk* flows and capture screenshots / get past anti-bot. (Browserbase's `browse cloud search`, `browse cloud fetch`, and cloud browser sessions; falls back to Claude's `WebSearch`/`WebFetch`.)
+- **One sharp wedge, not a feature dump.** Every brief connects one concrete prospect pain to one product capability, with a single named "wow" moment — and every claim is sourced to a URL.
+- **A sendable artifact.** Output is a self-contained HTML file (screenshots embedded) that auto-opens and can be forwarded as-is.
+
+## Prerequisites
+
+- **Claude Code.**
+- **The `browser` skill** (Browserbase cloud browser automation) for the research spine. The Search/Fetch/Browse commands use the [`@browserbasehq/browse-cli`](https://www.npmjs.com/package/@browserbasehq/browse-cli) with a `BROWSERBASE_API_KEY` set.
+- Without Browserbase configured, it degrades to Claude's built-in `WebSearch` / `WebFetch` (no screenshots, no anti-bot).
+- `python3` (for `embed_images.py`).
+
+## Install
+
+Drop the folder where Claude Code discovers skills (e.g. symlink into `~/.claude/skills/`):
+
+```bash
+ln -s "$(pwd)/pitch-prep" ~/.claude/skills/pitch-prep
+```
+
+Then invoke it:
+
+```
+/pitch-prep <product + URL> <prospect + domain>
+# e.g. /pitch-prep Browserbase browserbase.com  →  Chorus chorus.com
+```
+
+## What you get
+
+1. **Scope check**, then a tight **capability sheet** for the product.
+2. A **browser crawl** of the prospect → sourced hooks + screenshots.
+3. **3 ranked demo concepts** — you pick one (mandatory checkpoint).
+4. A **self-contained HTML brief** (`demo-brief-<prospect>-portable.html`) that auto-opens: TL;DR, screenshot evidence, the wedge, beat-by-beat storyline, reproducible flow, talking points, prospect-specific objections, success criteria.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `SKILL.md` | The skill: workflow, the bar for a good brief, the research stack, guardrails. |
+| `brief-template.md` | Section structure for the brief. |
+| `brief.css` | Styling for the HTML brief (override `--accent` for a light brand touch). |
+| `embed_images.py` | Inlines + compresses screenshots into the HTML and auto-opens it (`--no-open` to suppress). |
+
+## Scope
+
+`pitch-prep` stops at the **brief** — it does not build or run the live demo (that's a product-specific layer), and it does not auto-generate a fully branded slide deck (a planned optional extension). The brief is designed to be the clean input to those next steps.
+
+## License
+
+MIT.

--- a/skills/pitch-prep/SKILL.md
+++ b/skills/pitch-prep/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: pitch-prep
+description: Prep for a sales meeting by deeply researching a product you're selling AND the prospect you're selling to — browsing the prospect's live site for concrete hooks — then proposing 3 ranked demo concepts to pick from, and expanding the chosen one into a tailored, demo-ready brief delivered as a self-contained HTML page. Use when the user says "prep for my [prospect] call", "pitch prep", "build a demo for [prospect]", "what should we demo to [prospect]", "tailor a demo to [customer]", or "research [prospect] for a pitch".
+---
+
+# Pitch Prep
+
+## Overview
+
+This skill turns *"we have a meeting with [prospect]"* into a **demo-ready brief**: a tight, opinionated document that says exactly what to demo, why it will land with *this specific prospect*, and how to walk it beat-by-beat.
+
+It works for **any product** — the skill is given two things: **what you're selling** and **who you're selling to**. The value it adds is research + judgment, not code. (Actually generating/running the live demo is a separate, product-specific layer; this skill stops at the brief.)
+
+The process is deliberately **human-in-the-loop on the one decision that matters**: after research, the skill proposes **3 ranked demo concepts** and the user picks one. Then it expands the chosen concept into the full brief. It does not silently pick a concept and run.
+
+**The whole point is specificity.** A generic "show them how great the product is" brief is a failure. Every brief must be anchored to concrete things found on the prospect's actual site — their real checkout flow, their real job listings, their real pricing page, their real data. If the brief could have been written without visiting their site, it's wrong.
+
+> **About paths in this skill:** this skill ships with three sibling files — `brief-template.md`, `brief.css`, and `embed_images.py`. They live in **this skill's base directory** (the path shown as *"Base directory for this skill:"* when the skill loads). Wherever the steps below say `$SKILL_DIR`, substitute that base directory. The skill has **no machine-specific paths** — it's portable across users.
+
+## The bar for a good brief (read before producing anything)
+
+A brief earns its place only if:
+
+1. **It names real things.** Specific pages, flows, products, data, and pain points found on the prospect's *actual* site — with URLs. Not "their e-commerce experience" but "their checkout at shop.acme.com/cart, which forces account creation before showing shipping cost."
+2. **The wedge is sharp.** It connects ONE concrete prospect pain/opportunity to ONE product capability. Demos that try to show everything show nothing.
+3. **There's a single wow moment.** The one beat that makes them lean in. If you can't name it in a sentence, the concept isn't ready.
+4. **It's runnable.** The flow is concrete enough that someone (or, later, an agent) could reproduce it step-by-step.
+5. **It speaks their language.** Reference their industry, competitors, and the words *they* use on their own site — not the seller's internal jargon.
+
+If research can't surface concrete hooks (thin site, no public surface), say so plainly and propose concepts against a **public vertical target** instead — but flag that it's a fallback.
+
+## Inputs
+
+The skill needs two things. If either is missing from the invocation, ask for it before doing anything else.
+
+1. **The product** — what the user is selling. A name + URL is enough; the skill researches the rest. (e.g. "Browserbase — browserbase.com")
+2. **The prospect** — who they're selling to. A company name + domain. (e.g. "Acme Corp — acme.com")
+
+Optionally accept: known context about the deal (notes, the champion's role, a critical event, what they've already seen), a specific angle the user wants emphasized, or constraints (time-boxed demo, no-login, security-sensitive).
+
+## Research stack — Search + Fetch + Browse (use the combo)
+
+Research is **not** a single tool — it's three, used together. With Browserbase you have the full web-data stack via the `browse` CLI, and using all three *is itself part of the pitch* (the research run shows the product working):
+
+| Tool | Command | Use it for |
+|------|---------|-----------|
+| **Search** | `browse cloud search "<query>" --num-results 10 --json` | Breadth — *find* the right pages fast (their pricing page, G2 reviews, funding news, competitor sites). Start here. |
+| **Fetch** | `browse cloud fetch <url> --format markdown` (add `--proxies` for protected sites; `--format json --schema <…>` for structured extraction) | Depth-by-text — *pull* clean, token-efficient content from a known URL without spinning a full browser. Fast and cheap. |
+| **Browse** | the `browser` skill (`browse open --remote …`, `snapshot`, `screenshot`) | Interactive depth — *walk* JS-heavy flows, click through their money path, and **capture screenshots**. The only tool that gets evidence images and reaches login/anti-bot walls. |
+
+**The pattern:** Search to find → Fetch to read at scale → Browse for the interactive walk + screenshots. Reach for Browse whenever you need to *click, log in, get past bot detection, or capture a screenshot*; use Search/Fetch for everything else because they're faster. Generic fallback when Browserbase isn't configured: `WebSearch` / `WebFetch`.
+
+## Workflow
+
+### Step 1 — Confirm scope
+
+Restate, in one line, what you understood: *"Building a tailored demo brief for **[prospect]**, selling **[product]**."* If product or prospect is missing or ambiguous, ask. Don't proceed on a guess.
+
+### Step 2 — Research the product (build a capability sheet)
+
+Goal: know the product well enough to map its strengths onto the prospect's needs. Keep it tight — you need the *demoable edges*, not a full teardown.
+
+- Use **Search → Fetch**: `browse cloud search "<product> positioning / customers / benchmarks"` to find the right pages, then `browse cloud fetch <url>` to pull the product site + docs as clean markdown. (Browse isn't usually needed here — the product's own marketing is rarely bot-walled.)
+- Produce a short internal **capability sheet**: the product's 2–4 genuinely differentiated capabilities, each with (a) what it does, (b) the kind of pain it removes, (c) the most visceral way to *show* it (not tell). Note proof points (named customers, benchmarks) you can reference.
+- Don't pad. Four sharp capabilities beat twelve features.
+
+### Step 3 — Research the prospect with the browser (this is the spine of the skill)
+
+This is the step that makes or breaks the brief — and it is **browser-first by design**. Two reasons: (1) a real browser sees JS-rendered product surfaces, walks interactive flows, and reaches bot-walled review sites that `WebFetch` simply can't; (2) **this skill is itself a showcase of browser-based prospecting** — the research run should demonstrate the value of doing this with a cloud browser.
+
+Use the **Search + Fetch + Browse combo** (see "Research stack" above): `browse cloud search` to find the hooks (reviews, funding, competitors), `browse cloud fetch` to read pages cheaply, and the **`browser` skill** (Browserbase cloud sessions) for the interactive walk — clicking the money path, getting past anti-bot/login walls, and **capturing screenshots**. Browse is non-negotiable for anything you need to *click, log into, or screenshot*; that's the depth fetch can't give, and it's where the product showcases itself.
+
+Run this **required checklist** every time, capturing **a screenshot + sourced hooks at each step** (screenshots are saved and embedded in the brief — they're free visual evidence once the browser is open):
+
+1. **Walk the money path + screenshot it.** Actually click through their core flow — signup / onboarding / search / checkout / configurator / the AI feature you'll pitch against. Capture the exact screens and any friction. This is what turns "their signup has friction" into "*at step 3 (screenshot) they ask for X before showing Y*."
+2. **Mine one review/sentiment source for real pain.** G2, Capterra, TrustRadius, Reddit, or app-store reviews — the richest hook source, and mostly bot-walled (a cloud browser gets in). The prospect's own users' top complaints *become the demo wedge*.
+3. **Grab hiring + scale signals.** Their live careers page / LinkedIn jobs / eng blog — what roles, how many, what stack → what they're building and scaling right now.
+4. **Grab the customer + competitor signal.** Who they serve (logos/case studies) and 1–2 competitors worth a "they already ship X" line.
+
+Also run `browse cloud search` for hard context (funding, launches, headcount) that isn't on their site.
+
+**Capture concrete hooks** as you go — exact URLs, the specific flow step, the specific friction. A hook is only a hook if it's *specific, verifiable, and ideally has a screenshot*. Keep the browser session/replay link — it goes in the brief as proof the research was real.
+
+**Capturing screenshots — do it right (this matters):**
+- **Viewport captures, NOT full-page.** Screenshot the *specific section that contains the hook* (the hero with the headline, the pricing tier, the friction step) — not the whole page. A full-page capture of a long marketing site embeds as an unreadable, blurry strip. A viewport shot of the hero is sharp and shows the exact quote you're citing.
+- Save them to a per-prospect working dir: `/tmp/pitch-prep-<prospect>/` with descriptive names (`hero.png`, `pricing.png`).
+- If using the Browserbase `browse` CLI (v0.8.x): use the **`--remote` flag** on `open`/`screenshot` (there is no `browse env remote` subcommand); the screenshot path is the **`-p` flag** with an **absolute path** (`browse screenshot -p /tmp/pitch-prep-<prospect>/hero.png`) — a positional path is ignored (prints base64), and a *relative* `-p` saves to the daemon's cwd, not your shell's; **omit `--full-page`** to get the viewport.
+- **Wait for animations to settle** before capturing — many hero sections type/animate in. Wait ~4s after load (`browse wait timeout 4000`) then screenshot, or you'll catch a half-rendered headline.
+- Aim for 1–4 screenshots total — the sharpest hooks, not every page.
+
+If a surface is unreachable or near-empty, say so and move on; if the whole site is too thin for real hooks, switch to a public vertical target (Step 4 note).
+
+### Step 4 — Synthesize 3 ranked demo concepts
+
+Map the **capability sheet** (Step 2) against the **hooks** (Step 3). Produce **exactly 3 concepts**, ranked best-first. Each concept is short and decision-ready:
+
+```
+### Concept N — [punchy title]
+- **Hook:** [the specific thing on their site this exploits — with URL]
+- **Capability shown:** [which product strength it demonstrates]
+- **The wow:** [the one beat that makes them lean in — one sentence]
+- **What runs:** [what the live demo actually does — see the two demo media below]
+- **Effort / risk:** [low/med/high — how reliably this demos live]
+- **Why it ranks here:** [one sentence — why #1 beats #2]
+```
+
+**Two demo media — pick the right one for the product you're selling:**
+- **Automation-medium demo** (product *acts on the web* — e.g. Browserbase, an RPA/agent tool): the demo runs *on the prospect's own public site/flow*. Risk = login walls, anti-bot, pages that change. "What runs" = their site.
+- **Infra/API demo** (product *is consumed by* the prospect's product — e.g. an API, a data/research provider): the demo runs *the product on a prospect-realistic task*, and the prospect's site is the *research material / prompt frame*, not an automation target. "What runs" = a live API/product call on a task their users would actually run. Don't force-fit this into "automate their site."
+
+Ranking criteria, in order: **(1)** sharpness of the wedge (does it hit a real, felt pain?), **(2)** strength of the wow moment, **(3)** how reliably it runs live. A flashy concept that needs a login, trips anti-bot, or is non-deterministic ranks below a solid one that runs clean.
+
+Present the 3 concepts and **stop. Ask the user to pick one** (or blend/adjust). Do not expand a brief until they choose.
+
+### Step 5 — Expand the chosen concept into the brief
+
+Read `$SKILL_DIR/brief-template.md` and fill every section for the chosen concept. Rules:
+
+- **Every claim about the prospect carries a URL** to where you found it.
+- **Embed the screenshots** captured in Step 3 in the "What we saw" evidence section, and inline against the hooks they prove. Include the browser replay link.
+- **The flow section is reproducible** — concrete steps, ideally no auth required. This is also the clean seam for a later agentic layer that actually runs the demo.
+- **Talking points are in the seller's voice**, mapped to the prospect's pain — not feature recitation.
+- **Objections are specific to this prospect** (their scale, their stack, their likely concerns), not boilerplate.
+- Keep it skim-first. A busy AE/SE reads this on a phone before a call. Tight beats complete.
+
+### Step 6 — Deliver (a self-contained HTML brief that auto-opens)
+
+**The deliverable is a single self-contained HTML file that opens in the user's browser** — not bare markdown. A markdown brief with relative image paths (`![](hero.png)`) shows broken images the moment it's moved or sent; that's a failed deliverable. HTML with inlined images renders anywhere and is what people actually want to forward.
+
+1. Write the brief content to `/tmp/pitch-prep-<prospect>/demo-brief-<prospect>.md` (markdown, following `brief-template.md`) — the readable source of record.
+2. Author the HTML brief: a single `.html` in the same dir that inlines the CSS from `$SKILL_DIR/brief.css` into a `<style>` block, lays out the sections (TL;DR card, a "What we saw" evidence `grid` of `<figure>` screenshots with callouts, numbered `.beats` storyline, highlighted `.wow`, called-out `.stat` proof points), and references the screenshots by **local filename** (same dir).
+3. Make it portable and open it — inline every image as base64 (compressed) and auto-open in the browser:
+   ```bash
+   python3 "$SKILL_DIR/embed_images.py" /tmp/pitch-prep-<prospect>/demo-brief-<prospect>.html
+   # → writes demo-brief-<prospect>-portable.html (all images embedded) and opens it
+   ```
+   (Pass `--no-open` to suppress auto-open.)
+4. Confirm the screenshots render sharp (if blurry, you used full-page captures — re-grab viewport shots per Step 3).
+5. Light brand touch is fine (override `--accent` in the CSS with a prospect color); a **full branded slide deck is out of scope** (parked — see "does NOT do").
+
+End by offering the obvious next steps: tweak a section, add a competitor teardown, or *"when you're ready, this brief is the input to actually building the live demo"* (the product-specific layer — out of scope here).
+
+## What this skill does NOT do
+
+- **Does not generate or run the actual demo.** It stops at the brief. Building/running a live demo is a product-specific layer (for browser-automation products like Browserbase, e.g. a demo-creation skill). Don't pretend the brief is a working demo.
+- **Does not auto-pick the concept.** The 3-concepts → human-picks checkpoint is mandatory.
+- **Does not write generic briefs.** If you couldn't find concrete hooks on their site, say so — don't paper over it with vague positioning.
+- **Does not invent facts about the prospect.** Every prospect claim is sourced to a URL you actually fetched. No assumed funding, headcount, or features.
+- **Does not log into or transact on the prospect's site.** Research is read-only against public surfaces.
+- **Does not (yet) generate a branded slide deck / PDF.** The output is an HTML brief with embedded screenshots. A prospect-branded deck (extract their colors/fonts/logo via the browser, theme a deck to match) is a planned optional layer — deliberately kept out of the core path so the universal flow stays simple. Don't auto-build a deck unless asked.
+
+## Tips
+
+- **Crawl before you ideate.** The temptation is to brainstorm concepts from the company name. Resist it — the good concepts only appear *after* you've seen their actual money path.
+- The product capability sheet is reusable across prospects for the same seller. If the user runs this repeatedly for the same product, you can reuse Step 2's output and re-do only Step 3+.
+- When concepts are close, prefer the one that runs most reliably live — a demo that breaks mid-call is worse than a slightly less flashy one that lands.
+- If the user gives deal context (champion role, critical event), weight concepts toward what *that buyer* cares about — an eng champion wants to see it work; a VP wants the business outcome.
+- Default product is **not** assumed. Even if the user works at a known company, confirm the product unless they've stated it.

--- a/skills/pitch-prep/brief-template.md
+++ b/skills/pitch-prep/brief-template.md
@@ -1,0 +1,87 @@
+# Demo Brief — [Product] → [Prospect]
+
+> Prepared [date] · Selling **[Product]** to **[Prospect]** · Concept: **[chosen concept title]**
+
+## TL;DR
+
+One paragraph: what we'll demo, the one pain it hits for this prospect, and why it lands. If a reader stops here, they should still know exactly what's going to happen on the call.
+
+## The prospect, in one screen
+
+- **What they do:** [one line — in their own words, from their site]
+- **Who they serve / scale:** [segment + scale signal, with source URL]
+- **Their money path:** [the core flow that matters — checkout / signup / search / booking, with URL]
+- **Signals we found:** 2–4 concrete, sourced observations from their actual site/news that this demo exploits. Each with a URL.
+  - [signal] — [url]
+  - [signal] — [url]
+
+## What we saw (evidence)
+
+Screenshots captured while walking their site with the browser — proof we did the work, and the visual hooks the demo exploits. Each with a one-line callout and source URL. Use **viewport captures of the specific hook** (the hero, the pricing tier, the friction step) — never full-page captures, which render blurry. In the HTML deliverable these are embedded via `embed_images.py`.
+
+![caption](path/to/screenshot-1.png)
+*[what this screen shows + the friction/opportunity it reveals] — [url]*
+
+![caption](path/to/screenshot-2.png)
+*[callout] — [url]*
+
+> Browserbase research session (replay): [link]
+
+## The wedge — why this demo
+
+The sharp version: **[one concrete prospect pain/opportunity]** meets **[one product capability]**.
+
+2–3 sentences on why this is the right thing to show *this* prospect right now — tied to a signal above, not to generic value.
+
+## The storyline
+
+Beat-by-beat, the arc of the demo:
+
+1. **Setup** — frame the problem in their world (1 line).
+2. **The walk** — what we do, on their actual surface.
+3. **The wow** — the single moment they lean in. *Name it explicitly.*
+4. **The payoff** — what it means for them (outcome, not feature).
+
+Keep it to a tight arc. One wow, not five.
+
+## The flow (reproducible, no-auth, against their live public site)
+
+Concrete enough that someone could run it cold. This is also what a later agentic layer would execute.
+
+1. Go to `[url]`
+2. [action — what to do/show]
+3. [action] → **[the wow beat happens here]**
+4. [action]
+5. [where to land / what to leave on screen]
+
+Note any live-demo risks: anti-bot, rate limits, pages that change, login walls to avoid.
+
+## Talking points
+
+Mapped to their pain, in the seller's voice. What to *say* at each beat — not a feature list.
+
+- At setup: "[line that frames their problem]"
+- At the walk: "[line connecting the action to their world]"
+- At the wow: "[the line that drives it home]"
+- At the payoff: "[the outcome line — quantified if possible]"
+
+## Objections & answers (specific to this prospect)
+
+Anticipate *this* prospect's pushback — given their scale, stack, and segment.
+
+- **"[likely objection]"** → [answer, with proof point if available]
+- **"[likely objection]"** → [answer]
+
+## Success criteria
+
+What "this demo worked" looks like — the reaction or next step to aim for.
+
+- [observable signal of success]
+- [the next step this demo should unlock]
+
+## Appendix — sources
+
+Every prospect claim above, linked.
+
+- [page / article] — [url]
+- [page / article] — [url]

--- a/skills/pitch-prep/brief.css
+++ b/skills/pitch-prep/brief.css
@@ -1,0 +1,38 @@
+/* Demo Architect — brief styling. Inline this into the HTML <style> block.
+   Clean, neutral, skim-first. Override --accent with a prospect brand color
+   if you want a light "made for you" touch (NOT a full deck — that's parked). */
+:root { --ink:#1a1a1a; --muted:#6b6b6b; --line:#e6e6e3; --accent:#0a7cff; --bg:#fbfbfa; --card:#fff; }
+* { box-sizing:border-box; }
+body { margin:0; background:var(--bg); color:var(--ink);
+  font:16px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Helvetica,Arial,sans-serif; }
+.wrap { max-width:820px; margin:0 auto; padding:56px 28px 96px; }
+.kicker { font-size:12px; letter-spacing:.12em; text-transform:uppercase; color:var(--muted); }
+h1 { font-size:34px; line-height:1.15; margin:6px 0 6px; letter-spacing:-.02em; }
+.sub { color:var(--muted); font-size:15px; margin-bottom:34px; }
+h2 { font-size:13px; letter-spacing:.10em; text-transform:uppercase; color:var(--accent);
+  margin:42px 0 12px; border-bottom:1px solid var(--line); padding-bottom:7px; }
+h3 { font-size:17px; margin:22px 0 6px; }
+p { margin:10px 0; }
+ul { margin:10px 0; padding-left:20px; }
+li { margin:6px 0; }
+a { color:var(--accent); text-decoration:none; }
+a:hover { text-decoration:underline; }
+.tldr { background:var(--card); border:1px solid var(--line); border-left:3px solid var(--accent);
+  border-radius:10px; padding:18px 22px; font-size:16px; }
+figure { margin:18px 0; }
+figure img { width:100%; border:1px solid var(--line); border-radius:10px; display:block;
+  box-shadow:0 2px 14px rgba(0,0,0,.05); }
+figcaption { font-size:13px; color:var(--muted); margin-top:8px; }
+.grid { display:grid; grid-template-columns:1fr 1fr; gap:16px; }
+@media(max-width:640px){ .grid { grid-template-columns:1fr; } }
+blockquote { margin:14px 0; padding:10px 16px; background:#f4f4f2; border-radius:8px;
+  color:var(--muted); font-size:14px; }
+.beats { counter-reset:b; list-style:none; padding-left:0; }
+.beats li { counter-increment:b; padding-left:38px; position:relative; margin:12px 0; }
+.beats li::before { content:counter(b); position:absolute; left:0; top:0; width:26px; height:26px;
+  background:var(--accent); color:#fff; border-radius:50%; display:grid; place-items:center;
+  font-size:13px; font-weight:600; }
+.wow { background:#fff7e6; border-left:3px solid #f5a623; padding:1px 6px; border-radius:5px; }
+.stat { font-weight:700; color:var(--ink); }
+code { background:#f0f0ee; padding:1px 6px; border-radius:5px; font-size:13px; }
+.foot { margin-top:40px; font-size:12px; color:var(--muted); border-top:1px solid var(--line); padding-top:14px; }

--- a/skills/pitch-prep/embed_images.py
+++ b/skills/pitch-prep/embed_images.py
@@ -65,22 +65,34 @@ def main() -> int:
     out = pathlib.Path(args[1]).resolve() if len(args) > 1 \
         else inp.with_name(inp.stem + "-portable.html")
     html = inp.read_text()
-    base = inp.parent
+    base = inp.parent.resolve()
 
     def repl(m: re.Match) -> str:
         src = m.group("src")
         if src.startswith(("http://", "https://", "data:")):
             return m.group(0)
         img = (base / src).resolve()
+        # Refuse to embed anything outside the brief's own directory: this file
+        # is meant to be forwarded externally, so a `../` src must not slurp in
+        # arbitrary local files.
+        if not img.is_relative_to(base):
+            print(f"  ! refusing path outside brief dir, left as-is: {src}")
+            return m.group(0)
         if not img.exists():
             print(f"  ! missing image, left as-is: {src}")
             return m.group(0)
         data, mime = compress(img)
         b64 = base64.b64encode(data).decode()
         print(f"  embedded {src} ({len(data)//1024} KB, {mime})")
-        return m.group(0).replace(src, f"data:{mime};base64,{b64}")
+        # Rebuild only the src attribute (pre + new value + closing quote) so a
+        # matching string elsewhere in the tag (alt/title) is never touched.
+        return f"{m.group('pre')}data:{mime};base64,{b64}{m.group('q')}"
 
-    html = re.sub(r'<img\b[^>]*?\bsrc=["\'](?P<src>[^"\']+)["\']', repl, html)
+    # (?<![\w-]) keeps `src=` from matching `data-src=` and similar lazy-load attrs.
+    html = re.sub(
+        r'(?P<pre><img\b[^>]*?(?<![\w-])src\s*=\s*(?P<q>["\']))(?P<src>[^"\']+)(?P=q)',
+        repl, html,
+    )
     out.write_text(html)
     print(f"wrote {out} ({len(html.encode())//1024} KB)")
     if "--no-open" not in flags:

--- a/skills/pitch-prep/embed_images.py
+++ b/skills/pitch-prep/embed_images.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Make an HTML brief self-contained and portable.
+
+Finds every <img src="local-file"> in the input HTML, compresses the image
+(downscale to a sane width + JPEG, via `sips` on macOS when available), and
+rewrites the src to a base64 data URI. Remote (http/https) and existing
+data: srcs are left untouched.
+
+Usage:
+    python3 embed_images.py input.html [output.html] [--no-open]
+
+If output.html is omitted, writes alongside input as <name>-portable.html.
+By default the result is opened in the user's browser (macOS `open`, Linux
+`xdg-open`, Windows `os.startfile`). Pass --no-open to suppress.
+Why this exists: a markdown/HTML brief that references screenshots by relative
+path shows broken images the moment it's moved or sent. Inlining guarantees the
+brief renders anywhere. Keep screenshots as VIEWPORT captures of the specific
+hook (see SKILL.md Step 3) — full-page captures embed blurry.
+"""
+import base64, mimetypes, pathlib, re, shutil, subprocess, sys, tempfile
+
+MAX_WIDTH = 1300      # plenty sharp for a brief; keeps the file small
+JPEG_QUALITY = 88
+
+def compress(src: pathlib.Path) -> tuple[bytes, str]:
+    """Return (bytes, mime). Compress raster images via sips if present."""
+    mime, _ = mimetypes.guess_type(src.name)
+    raw = src.read_bytes()
+    if not shutil.which("sips") or (mime or "").endswith(("svg+xml", "gif")):
+        return raw, (mime or "application/octet-stream")
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            out = pathlib.Path(td) / "out.jpg"
+            subprocess.run(
+                ["sips", "-s", "format", "jpeg", "-s", "formatOptions",
+                 str(JPEG_QUALITY), "--resampleWidth", str(MAX_WIDTH),
+                 str(src), "--out", str(out)],
+                check=True, capture_output=True,
+            )
+            # only use the compressed version if it actually shrank things
+            data = out.read_bytes()
+            return (data, "image/jpeg") if len(data) < len(raw) else (raw, mime or "image/png")
+    except Exception:
+        return raw, (mime or "image/png")
+
+def open_in_browser(path: pathlib.Path) -> None:
+    """Open the file in the default browser, cross-platform. Best-effort."""
+    try:
+        if sys.platform == "darwin":
+            subprocess.run(["open", str(path)], check=False)
+        elif sys.platform.startswith("win"):
+            import os
+            os.startfile(str(path))  # type: ignore[attr-defined]
+        else:
+            subprocess.run(["xdg-open", str(path)], check=False)
+    except Exception as e:
+        print(f"  (could not auto-open: {e})")
+
+def main() -> int:
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    flags = {a for a in sys.argv[1:] if a.startswith("--")}
+    if not args:
+        print(__doc__); return 1
+    inp = pathlib.Path(args[0]).resolve()
+    out = pathlib.Path(args[1]).resolve() if len(args) > 1 \
+        else inp.with_name(inp.stem + "-portable.html")
+    html = inp.read_text()
+    base = inp.parent
+
+    def repl(m: re.Match) -> str:
+        src = m.group("src")
+        if src.startswith(("http://", "https://", "data:")):
+            return m.group(0)
+        img = (base / src).resolve()
+        if not img.exists():
+            print(f"  ! missing image, left as-is: {src}")
+            return m.group(0)
+        data, mime = compress(img)
+        b64 = base64.b64encode(data).decode()
+        print(f"  embedded {src} ({len(data)//1024} KB, {mime})")
+        return m.group(0).replace(src, f"data:{mime};base64,{b64}")
+
+    html = re.sub(r'<img\b[^>]*?\bsrc=["\'](?P<src>[^"\']+)["\']', repl, html)
+    out.write_text(html)
+    print(f"wrote {out} ({len(html.encode())//1024} KB)")
+    if "--no-open" not in flags:
+        open_in_browser(out)
+        print(f"  opened {out.name} in browser")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Adds **`pitch-prep`** — a skill that preps you for a sales meeting. Give it **what you're selling** and **who you're selling to**; it researches both, proposes **3 ranked demo concepts** for you to pick, then expands your pick into a tailored, **self-contained HTML demo brief** that auto-opens in the browser.

Product-agnostic — works whether you're selling an API, a SaaS app, or a browser-automation tool.

## How it works

1. **Confirm scope** → tight **capability sheet** for the product.
2. **Browser-first research** of the prospect using the **Search + Fetch + Browse combo**:
   - `browse cloud search` to *find* the right pages (pricing, reviews, funding, competitors)
   - `browse cloud fetch` to *read* them cheaply as markdown
   - the **`browser` skill** (Browserbase cloud sessions) to *walk* flows, get past anti-bot/login walls, and **capture screenshots**
   - falls back to `WebSearch`/`WebFetch` when Browserbase isn't configured
3. **3 ranked demo concepts** → user picks one (mandatory human checkpoint).
4. **Self-contained HTML brief** (`embed_images.py` inlines + compresses screenshots and auto-opens it): TL;DR, screenshot evidence, the wedge, beat-by-beat storyline, reproducible flow, talking points, prospect-specific objections, success criteria.

## Why browser-first

The good demo concepts only appear *after* you've seen the prospect's real money path — so the skill walks their live site rather than theorizing from the company name. Every prospect claim in the brief is sourced to a URL, and the research run itself showcases the Browserbase web-data stack.

## Files

| File | Purpose |
|------|---------|
| `SKILL.md` | Workflow, the bar for a good brief, the research stack, guardrails |
| `brief-template.md` | Section structure for the brief |
| `brief.css` | Styling for the HTML brief |
| `embed_images.py` | Inlines/compresses screenshots into the HTML and auto-opens it |
| `README.md` / `LICENSE.txt` | Docs + MIT license |

## Scope

Stops at the **brief** — does not build/run the live demo (product-specific layer) and does not auto-generate a fully branded slide deck (planned optional extension). The brief is designed to be the clean input to those next steps.

> Not added to `.claude-plugin/marketplace.json` — following the convention of other `skills/` entries (e.g. `company-research`, `event-prospecting`) that aren't marketplace plugins. Happy to add an entry if we want it installable as a plugin.

Tested end-to-end on Parallel→Notion and Browserbase→Chorus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive documentation and a small local HTML helper script only; no changes to app runtime, auth, or shared infrastructure.
> 
> **Overview**
> Adds a new **`pitch-prep`** Claude Code skill under `skills/pitch-prep/` for sales-call prep: research the seller’s product and the prospect (browser-first via Search/Fetch/Browse, with `WebSearch`/`WebFetch` fallback), present **three ranked demo concepts** with a required user pick, then produce a tailored demo brief.
> 
> The skill is defined in **`SKILL.md`** (workflow, quality bar, guardrails). Supporting assets include **`brief-template.md`**, **`brief.css`**, and **`embed_images.py`** (compresses local screenshots, inlines them as base64, writes a `-portable.html`, optional auto-open; blocks `../` paths outside the brief dir). **`README.md`** documents install/usage; **`LICENSE.txt`** is MIT.
> 
> Deliverable is a self-contained HTML brief (not running the live demo or auto-building a deck). No marketplace plugin entry in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 058ab8f711b6d5778ee91aea86505f40a1927098. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->