### PR TITLE
[STG-2253] ci: validate skills against agent-skills standards

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -1,0 +1,16 @@
+name: Validate skills
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: node scripts/validate-skills.mjs

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -9,8 +9,8 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
       - run: node scripts/validate-skills.mjs

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -13,4 +13,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 20
+          # validate-skills.mjs uses only Node built-ins; no deps to install,
+          # so skip setup-node's pnpm auto-cache (it errors: pnpm not installed).
+          package-manager-cache: false
       - run: node scripts/validate-skills.mjs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Contributing
+
+This repo is Browserbase's public collection of agent skills — the skills we ship to users via `npx skills add browserbase/skills` and the Claude Code plugin marketplace. Every skill must meet the standards below; CI enforces the machine-checkable ones.
+
+## Skill anatomy
+
+Each skill lives in `skills/<name>/`:
+
+```
+skills/<name>/
+├── SKILL.md        # required — frontmatter + instructions
+├── LICENSE.txt     # required — MIT, Browserbase, Inc.
+├── REFERENCE.md    # optional — full API/flag reference
+├── EXAMPLES.md     # optional — worked examples
+├── references/     # optional — additional docs loaded on demand
+└── scripts/        # optional — helper scripts
+```
+
+Keep `SKILL.md` focused on what the agent needs to act (under ~500 lines). Move exhaustive flag tables, schemas, and edge cases into `REFERENCE.md` or `references/` — agents load those on demand (progressive disclosure). Don't add a "When to use" body section that repeats the frontmatter description.
+
+## Required frontmatter
+
+| Field | Required | Rules |
+|-------|----------|-------|
+| `name` | yes | Must equal the directory name |
+| `description` | yes | Non-empty, max 1024 chars. Third person, states what the skill does *and* when to use it, with concrete triggers — see the [agentskills.io spec](https://agentskills.io/specification) |
+| `license` | yes | Exactly `MIT` |
+| `compatibility` | recommended | Runtime requirements: CLIs, env vars, Node version |
+| `allowed-tools` | recommended | Tools the skill needs, e.g. `Bash Read Grep` |
+
+Example:
+
+```yaml
+---
+name: browser-trace
+description: Capture a full DevTools-protocol trace of any browser automation — CDP firehose, screenshots, and DOM dumps — then bisect the stream into per-page searchable buckets. Use when the user wants to debug a failed run, audit network/console/DOM activity, or attach a trace to an in-progress session.
+license: MIT
+compatibility: "Requires Node 18+ and the browse CLI (`npm install -g browse`)."
+allowed-tools: Bash, Read, Grep
+---
+```
+
+## License
+
+Every skill dir must contain a `LICENSE.txt` with the MIT license and the copyright line `Copyright (c) 2026 Browserbase, Inc.` — contributions are accepted under these terms. Copy one from an existing skill.
+
+## README table
+
+Add a row for your skill to the table in `README.md`, linking `skills/<name>/SKILL.md`. CI fails on missing rows and on rows pointing at skills that no longer exist.
+
+## Scripts
+
+- Prefer zero-dependency `.mjs` scripts using only `node:` builtins.
+- A `package.json` is allowed when dependencies are genuinely needed.
+- Never commit secrets, `.env*` files, `node_modules/`, `setup.json`, or personal local paths (e.g. `/Users/<you>/...`).
+
+## Evals
+
+Add an `evals/evals.json` with a few realistic prompts and expected behaviors so the skill can be regression-tested — see [evaluating skills](https://agentskills.io/skill-creation/evaluating-skills).
+
+## What reviewers check that CI can't
+
+- **Commands actually work** — every documented command must exist and run against the real CLI. Test them; don't document from memory.
+- **Description quality** — would an agent reading only the description know when to fire this skill?
+- **Progressive disclosure** — SKILL.md is lean; depth lives in REFERENCE.md/references/.
+- **No redundancy** — no body section restating the frontmatter description.
+
+## Validate locally
+
+```bash
+node scripts/validate-skills.mjs                 # all skills
+node scripts/validate-skills.mjs --skill <name>  # just yours
+```
+
+CI runs the same script on every PR; errors fail the build, warnings don't.

--- a/scripts/validate-skills.mjs
+++ b/scripts/validate-skills.mjs
@@ -1,0 +1,345 @@
+#!/usr/bin/env node
+/**
+ * validate-skills.mjs — validate every skills/<name>/ dir against the repo's
+ * agent-skills standards. Zero dependencies; Node 20+.
+ *
+ * Usage:
+ *   node scripts/validate-skills.mjs            # validate all skills
+ *   node scripts/validate-skills.mjs --skill browser
+ *
+ * Exit code 0 when only warnings are found, 1 on any error.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+import process from "node:process";
+
+const ROOT = resolve(import.meta.dirname, "..");
+const SKILLS_DIR = join(ROOT, "skills");
+const MAX_DESCRIPTION_LENGTH = 1024;
+const MAX_SKILL_MD_LINES = 500;
+const BANNED_ENTRIES = ["setup.json", "node_modules"];
+
+// ---------------------------------------------------------------------------
+// Minimal strict frontmatter parser
+//
+// Supports the subset used in this repo: `key: value` scalars (optionally
+// quoted), `key: |` block scalars, nested maps, and lists of scalars or maps.
+// Anything else is a parse error.
+// ---------------------------------------------------------------------------
+
+function unquote(value) {
+  if (value.length >= 2) {
+    const first = value[0];
+    const last = value[value.length - 1];
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+      const inner = value.slice(1, -1);
+      return first === '"'
+        ? inner.replace(/\\"/g, '"').replace(/\\\\/g, "\\")
+        : inner;
+    }
+  }
+  return value;
+}
+
+function indentOf(line) {
+  return line.length - line.trimStart().length;
+}
+
+function parseMap(lines, indent) {
+  const map = {};
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    if (!line.trim() || line.trim().startsWith("#")) {
+      i += 1;
+      continue;
+    }
+    if (indentOf(line) !== indent) {
+      throw new Error(`unexpected indentation: "${line.trim()}"`);
+    }
+    const match = line.trim().match(/^([A-Za-z0-9_-]+):(.*)$/);
+    if (!match) {
+      throw new Error(`cannot parse line: "${line.trim()}"`);
+    }
+    const key = match[1];
+    if (key in map) {
+      throw new Error(`duplicate key "${key}"`);
+    }
+    const value = match[2].trim();
+    i += 1;
+
+    // Collect lines indented deeper than the current key.
+    const children = [];
+    while (i < lines.length) {
+      const child = lines[i];
+      if (!child.trim() || indentOf(child) > indent) {
+        children.push(child);
+        i += 1;
+      } else {
+        break;
+      }
+    }
+    const nonEmpty = children.filter((l) => l.trim());
+
+    if (value === "|" || value === "|-" || value === ">" || value === ">-") {
+      if (nonEmpty.length === 0) {
+        throw new Error(`empty block scalar for key "${key}"`);
+      }
+      const childIndent = Math.min(...nonEmpty.map(indentOf));
+      map[key] = children
+        .map((l) => l.slice(childIndent))
+        .join("\n")
+        .trim();
+    } else if (value === "") {
+      if (nonEmpty.length === 0) {
+        map[key] = "";
+      } else {
+        const childIndent = Math.min(...nonEmpty.map(indentOf));
+        map[key] = nonEmpty[0].trim().startsWith("-")
+          ? parseList(nonEmpty, childIndent)
+          : parseMap(nonEmpty, childIndent);
+      }
+    } else {
+      if (nonEmpty.length > 0) {
+        throw new Error(`unexpected indented block under "${key}: ${value}"`);
+      }
+      map[key] = unquote(value);
+    }
+  }
+  return map;
+}
+
+function parseList(lines, indent) {
+  const items = [];
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    if (indentOf(line) !== indent || !line.trim().startsWith("-")) {
+      throw new Error(`cannot parse list item: "${line.trim()}"`);
+    }
+    const rest = line.trim().replace(/^-\s*/, "");
+    i += 1;
+
+    const children = [];
+    while (i < lines.length && (!lines[i].trim() || indentOf(lines[i]) > indent)) {
+      if (lines[i].trim()) children.push(lines[i]);
+      i += 1;
+    }
+
+    if (children.length > 0) {
+      // List item that is a map spanning multiple lines (`- kind: node` + more).
+      const childIndent = indentOf(children[0]);
+      const block = rest ? [" ".repeat(childIndent) + rest, ...children] : children;
+      items.push(parseMap(block, childIndent));
+    } else if (/^[A-Za-z0-9_-]+:(\s|$)/.test(rest)) {
+      items.push(parseMap([rest], 0));
+    } else {
+      items.push(unquote(rest));
+    }
+  }
+  return items;
+}
+
+function parseFrontmatter(content) {
+  const lines = content.split(/\r?\n/);
+  if (lines[0] !== "---") {
+    return { error: "file does not start with a `---` frontmatter block" };
+  }
+  const end = lines.indexOf("---", 1);
+  if (end === -1) {
+    return { error: "frontmatter block is not closed with `---`" };
+  }
+  try {
+    return { data: parseMap(lines.slice(1, end), 0) };
+  } catch (err) {
+    return { error: err.message };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Checks
+// ---------------------------------------------------------------------------
+
+function checkLicenseFile(skillDir, errors) {
+  const licensePath = join(skillDir, "LICENSE.txt");
+  if (!existsSync(licensePath)) {
+    errors.push("LICENSE.txt is missing");
+    return;
+  }
+  const text = readFileSync(licensePath, "utf8");
+  if (!/\bMIT License\b/.test(text)) {
+    errors.push("LICENSE.txt is not an MIT license (no `MIT License` header)");
+  }
+  const copyrightLine = text
+    .split(/\r?\n/)
+    .find((line) => /^copyright/i.test(line.trim()));
+  if (!copyrightLine) {
+    errors.push("LICENSE.txt has no copyright line");
+  } else if (!copyrightLine.includes("Browserbase, Inc.")) {
+    errors.push(
+      `LICENSE.txt copyright line must contain "Browserbase, Inc." (found "${copyrightLine.trim()}")`,
+    );
+  }
+}
+
+function checkBannedFiles(skillDir, errors, relative = "") {
+  const dir = join(skillDir, relative);
+  for (const entry of readdirSync(dir)) {
+    const relPath = relative ? `${relative}/${entry}` : entry;
+    const fullPath = join(dir, entry);
+    const isDir = statSync(fullPath).isDirectory();
+    if (BANNED_ENTRIES.includes(entry) || entry.startsWith(".env")) {
+      errors.push(`banned file: ${relPath}${isDir ? "/" : ""}`);
+      continue; // do not descend into banned directories
+    }
+    if (isDir) {
+      checkBannedFiles(skillDir, errors, relPath);
+    }
+  }
+}
+
+function checkFrontmatter(name, skillDir, errors, warnings) {
+  const skillMdPath = join(skillDir, "SKILL.md");
+  if (!existsSync(skillMdPath)) {
+    errors.push("SKILL.md is missing");
+    return;
+  }
+  const content = readFileSync(skillMdPath, "utf8");
+  const { data, error } = parseFrontmatter(content);
+  if (error) {
+    errors.push(`SKILL.md frontmatter: ${error}`);
+    return;
+  }
+
+  if (!data.name) {
+    errors.push("frontmatter `name` is missing");
+  } else if (data.name !== name) {
+    errors.push(
+      `frontmatter \`name\` ("${data.name}") does not match directory name ("${name}")`,
+    );
+  }
+
+  if (typeof data.description !== "string" || data.description.trim() === "") {
+    errors.push("frontmatter `description` is missing or empty");
+  } else if (data.description.length > MAX_DESCRIPTION_LENGTH) {
+    errors.push(
+      `frontmatter \`description\` is ${data.description.length} chars (max ${MAX_DESCRIPTION_LENGTH})`,
+    );
+  }
+
+  if (!("license" in data)) {
+    errors.push("frontmatter `license` is missing (must be `MIT`)");
+  } else if (data.license !== "MIT") {
+    errors.push(`frontmatter \`license\` must be "MIT" (found "${data.license}")`);
+  }
+
+  if (!("compatibility" in data)) {
+    warnings.push("frontmatter `compatibility` is missing");
+  }
+  if (!("allowed-tools" in data)) {
+    warnings.push("frontmatter `allowed-tools` is missing");
+  }
+
+  const lineCount = content.split(/\r?\n/).length;
+  const hasReference =
+    existsSync(join(skillDir, "REFERENCE.md")) ||
+    existsSync(join(skillDir, "references"));
+  if (lineCount > MAX_SKILL_MD_LINES && !hasReference) {
+    warnings.push(
+      `SKILL.md is ${lineCount} lines (>${MAX_SKILL_MD_LINES}) with no REFERENCE.md or references/ split`,
+    );
+  }
+}
+
+function readmeLinkedSkills() {
+  const readmePath = join(ROOT, "README.md");
+  if (!existsSync(readmePath)) return new Set();
+  const readme = readFileSync(readmePath, "utf8");
+  const linked = new Set();
+  for (const match of readme.matchAll(/\(skills\/([^/)]+)\/SKILL\.md\)/g)) {
+    linked.add(match[1]);
+  }
+  return linked;
+}
+
+// ---------------------------------------------------------------------------
+// Runner
+// ---------------------------------------------------------------------------
+
+function main() {
+  const args = process.argv.slice(2);
+  let only = null;
+  for (let i = 0; i < args.length; i += 1) {
+    if (args[i] === "--skill") {
+      only = args[i + 1];
+      if (!only) {
+        console.error("error: --skill requires a skill name");
+        process.exit(1);
+      }
+      i += 1;
+    } else {
+      console.error(`error: unknown argument "${args[i]}"`);
+      console.error("usage: node scripts/validate-skills.mjs [--skill <name>]");
+      process.exit(1);
+    }
+  }
+
+  const allSkills = readdirSync(SKILLS_DIR)
+    .filter((entry) => statSync(join(SKILLS_DIR, entry)).isDirectory())
+    .sort();
+
+  if (only && !allSkills.includes(only)) {
+    console.error(`error: skill "${only}" not found in skills/`);
+    process.exit(1);
+  }
+  const skills = only ? [only] : allSkills;
+  const linked = readmeLinkedSkills();
+
+  let errorCount = 0;
+  let warningCount = 0;
+  let failedSkills = 0;
+
+  for (const name of skills) {
+    const skillDir = join(SKILLS_DIR, name);
+    const errors = [];
+    const warnings = [];
+
+    checkFrontmatter(name, skillDir, errors, warnings);
+    checkLicenseFile(skillDir, errors);
+    checkBannedFiles(skillDir, errors);
+    if (!linked.has(name)) {
+      errors.push(`README.md table has no row linking skills/${name}/SKILL.md`);
+    }
+
+    const status = errors.length > 0 ? "FAIL" : warnings.length > 0 ? "WARN" : "OK";
+    console.log(`[${status.padEnd(4)}] ${name}`);
+    for (const error of errors) console.log(`  error: ${error}`);
+    for (const warning of warnings) console.log(`  warning: ${warning}`);
+
+    errorCount += errors.length;
+    warningCount += warnings.length;
+    if (errors.length > 0) failedSkills += 1;
+  }
+
+  // Repo-level check: README rows must not point at nonexistent skill dirs.
+  if (!only) {
+    const stale = [...linked].filter((name) => !allSkills.includes(name)).sort();
+    if (stale.length > 0) {
+      console.log("[FAIL] README.md");
+      for (const name of stale) {
+        console.log(`  error: README.md links to nonexistent skill dir skills/${name}/`);
+        errorCount += 1;
+      }
+    }
+  }
+
+  console.log("");
+  console.log(
+    `${skills.length} skill(s) checked: ${skills.length - failedSkills} passed, ` +
+      `${failedSkills} failed, ${errorCount} error(s), ${warningCount} warning(s)`,
+  );
+  process.exit(errorCount > 0 ? 1 : 0);
+}
+
+main();


### PR DESCRIPTION
Adds CI enforcement of the agent-skills standards plus a contributor guide.

Linear: [STG-2253](https://linear.app/browserbase/issue/STG-2253/add-ci-validation-and-contributing-guide-for-skill-standards)

## What's in this PR

- `scripts/validate-skills.mjs` — zero-dependency Node 20+ validator (own minimal strict frontmatter parser, `node:` builtins only). Supports `--skill <name>` for single-skill runs.
- `.github/workflows/validate-skills.yml` — runs the validator on every PR and on pushes to `main`.
- `CONTRIBUTING.md` — skill anatomy, required frontmatter, license rule, README-table rule, scripts convention, evals, and what reviewers check that CI can't.

## What the validator checks

| Check | Severity |
| --- | --- |
| `SKILL.md` missing, or frontmatter block missing/unparseable | error |
| frontmatter `name` missing or not equal to the directory name | error |
| frontmatter `description` missing/empty or >1024 chars | error |
| frontmatter `license` missing or not `MIT` | error |
| `LICENSE.txt` missing, not MIT, or copyright line not containing `Browserbase, Inc.` | error |
| README table missing a row linking `skills/<name>/SKILL.md` | error |
| README rows linking to nonexistent skill dirs | error |
| Banned files in a skill dir: `setup.json`, `node_modules/`, `.env*` | error |
| frontmatter `compatibility` missing | warning |
| frontmatter `allowed-tools` missing | warning |
| `SKILL.md` >500 lines with no `REFERENCE.md`/`references/` split | warning |

Errors exit 1 (fail CI); warnings are printed and exit 0.

> **Note: the `validate-skills` check on THIS PR will be red until the standards-update PR merges** — that red is the validator correctly flagging `main`'s pre-existing violations (missing LICENSE.txt files, stale/missing README rows, non-`MIT` license fields). Rebase/rerun after it merges.

## E2E Test Matrix

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `node scripts/validate-skills.mjs` (against current `main` tree) | Exit 1. Flagged all known violations: `browser-to-api`/`company-research`/`event-prospecting` missing LICENSE.txt; README stale rows `site-debugger` + `bb-usage`; README missing rows for `agent-experience`, `autobrowse`, `browser-to-api`, `company-research`, `event-prospecting`; `autobrowse` license `See LICENSE.txt`; `cookie-sync` missing `license`; plus tracked `skills/autobrowse/.env.example` (matches the `.env*` ban). Summary: `14 skill(s) checked: 8 passed, 6 failed, 13 error(s), 8 warning(s)`. Full excerpt below. | Proves every error and warning class fires on real repo content, including parsing of all 14 real frontmatter variants (quoted scalars, `\|` block scalars, nested `metadata` maps and lists). |
| `node scripts/validate-skills.mjs --skill browser` | `[OK  ] browser` / `1 skill(s) checked: 1 passed... 0 error(s)` / exit 0 | Proves the pass path and single-skill mode exit 0 on a compliant skill. |
| `node scripts/validate-skills.mjs --skill cookie-sync` | Exit 1 with `license` error + `compatibility`/`allowed-tools` warnings | Proves single-skill mode scopes checks and still fails on errors. |
| `node scripts/validate-skills.mjs --skill nope` / `--bogus` | `error: skill "nope" not found in skills/` (exit 1); usage message (exit 1) | Proves arg-handling error paths. |
| Live GitHub Actions run of `validate-skills.yml` on this PR ([run 27369208287](https://github.com/browserbase/skills/actions/runs/27369208287)) | Workflow triggered on `pull_request`, ran `node scripts/validate-skills.mjs` on ubuntu-latest, produced output identical to the local run, exited 1 (red as predicted). | Proves the workflow wiring (checkout + setup-node + script) works end-to-end on GitHub Actions, not just locally. |
| Validator (this branch) run against `origin/update-skills-to-agent-standards` (#135) via `git archive` export | All 14 skills `[OK]` — `14 skill(s) checked: 14 passed, 0 failed, 0 error(s), 0 warning(s)`, exit 0 | Proves the validator goes green once #135's fixes land — merge #135 first, then rerun this PR's CI. |

<details>
<summary>Full validator output against main (proof of detection)</summary>

```
[FAIL] agent-experience
  error: README.md table has no row linking skills/agent-experience/SKILL.md
  warning: frontmatter `compatibility` is missing
[FAIL] autobrowse
  error: frontmatter `license` must be "MIT" (found "See LICENSE.txt")
  error: banned file: .env.example
  error: README.md table has no row linking skills/autobrowse/SKILL.md
[OK  ] browser
[FAIL] browser-to-api
  error: LICENSE.txt is missing
  error: README.md table has no row linking skills/browser-to-api/SKILL.md
[OK  ] browser-trace
[OK  ] browserbase-cli
[FAIL] company-research
  error: LICENSE.txt is missing
  error: README.md table has no row linking skills/company-research/SKILL.md
[FAIL] cookie-sync
  error: frontmatter `license` is missing (must be `MIT`)
  warning: frontmatter `compatibility` is missing
  warning: frontmatter `allowed-tools` is missing
[FAIL] event-prospecting
  error: LICENSE.txt is missing
  error: README.md table has no row linking skills/event-prospecting/SKILL.md
[WARN] fetch
  warning: frontmatter `compatibility` is missing
[WARN] functions
  warning: frontmatter `compatibility` is missing
  warning: frontmatter `allowed-tools` is missing
[WARN] safe-browser
  warning: frontmatter `compatibility` is missing
[WARN] search
  warning: frontmatter `compatibility` is missing
[OK  ] ui-test
[FAIL] README.md
  error: README.md links to nonexistent skill dir skills/bb-usage/
  error: README.md links to nonexistent skill dir skills/site-debugger/

14 skill(s) checked: 8 passed, 6 failed, 13 error(s), 8 warning(s)
```

</details>

No changeset — CI/docs/tooling only, no published package behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and CI-only tooling with no runtime or published-package behavior changes; CI may stay red until a separate standards-fix PR lands on main.
> 
> **Overview**
> Adds **CI enforcement** and a **contributor guide** for agent-skills layout and metadata.
> 
> A new zero-dependency `scripts/validate-skills.mjs` (Node 20+, built-in `node:` modules only) walks every `skills/<name>/` directory and enforces machine-checkable rules: required `SKILL.md` with a parseable frontmatter block (`name` matches the folder, non-empty `description` ≤1024 chars, `license: MIT`), `LICENSE.txt` with MIT + Browserbase copyright, no banned paths (`setup.json`, `node_modules`, `.env*`), and README table links that match real skill dirs (including stale-link detection). Missing `compatibility` / `allowed-tools`, or an oversized `SKILL.md` without `REFERENCE.md`/`references/`, are **warnings** only; everything else fails with exit 1. Supports `--skill <name>` for local single-skill runs.
> 
> `.github/workflows/validate-skills.yml` runs that script on every PR and on pushes to `main` (Node 20, `package-manager-cache: false` so setup-node does not require pnpm). `CONTRIBUTING.md` documents anatomy, frontmatter, license/README/script/eval expectations, reviewer-only checks, and the same local validate commands CI uses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb4df7dbfa209fda63f97e0a99c26a1750722866. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

