### PR TITLE
Add canonical Codex marketplace catalog (.agents/plugins/marketplace.json)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,88 @@
+{
+  "name": "browserbase",
+  "owner": {
+    "name": "Browserbase",
+    "email": "support@browserbase.com"
+  },
+  "metadata": {
+    "description": "Browser automation and Browserbase CLI skills",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "browse",
+      "source": "./",
+      "description": "Automate web browser interactions using natural language. Use when the user asks to browse websites, navigate web pages, extract data from websites, take screenshots, fill forms, click buttons, or interact with web applications.",
+      "version": "0.0.1",
+      "author": {
+        "name": "Browserbase"
+      },
+      "category": "automation",
+      "keywords": ["browser", "automation", "web-scraping", "stagehand", "screenshots"],
+      "strict": false,
+      "skills": [
+        "./skills/browser"
+      ]
+    },
+    {
+      "name": "functions",
+      "source": "./",
+      "description": "Deploy serverless browser automation to the cloud using Browserbase Functions. Use when the user wants to deploy automation to run on a schedule, needs a webhook endpoint for browser automation, wants to run automation in the cloud instead of locally, or asks about Browserbase Functions.",
+      "version": "0.0.1",
+      "author": {
+        "name": "Browserbase"
+      },
+      "category": "automation",
+      "keywords": ["serverless", "functions", "deployment", "cloud", "webhook", "scheduled-automation"],
+      "strict": false,
+      "skills": [
+        "./skills/functions"
+      ]
+    },
+    {
+      "name": "browserbase-cli",
+      "source": "./",
+      "description": "Use the Browserbase CLI (`bb`) for Browserbase Functions and platform API workflows. Use when the user asks to run `bb`, deploy or invoke functions, manage sessions, projects, contexts, or extensions, fetch a page through the Browserbase Fetch API, or open the Browserbase dashboard from the command line.",
+      "version": "0.0.1",
+      "author": {
+        "name": "Browserbase"
+      },
+      "category": "automation",
+      "keywords": ["browserbase", "cli", "bb", "functions", "sessions", "fetch"],
+      "strict": false,
+      "skills": [
+        "./skills/browserbase-cli"
+      ]
+    },
+    {
+      "name": "browser-trace",
+      "source": "./",
+      "description": "Capture a full DevTools-protocol trace (CDP firehose, screenshots, DOM dumps) alongside any browser automation, then bisect the stream into per-page searchable buckets. Use when the user wants to debug a failed run, audit network/console/DOM activity, attach a trace to an in-flight Browserbase session, or feed structured per-page summaries back into an agent loop.",
+      "version": "0.0.1",
+      "author": {
+        "name": "Browserbase"
+      },
+      "category": "automation",
+      "keywords": ["debugging", "trace", "observability", "cdp", "devtools-protocol", "session-debugging", "network-audit"],
+      "strict": false,
+      "skills": [
+        "./skills/browser-trace"
+      ]
+    },
+    {
+      "name": "safe-browser",
+      "source": "./",
+      "description": "Build local constrained-browser agents with a safe_browser tool that owns CDP, enforces a domain allowlist with Fetch interception, and lets a runtime Claude Agent SDK agent complete browsing tasks without raw browser, shell, or CDP access.",
+      "version": "0.0.1",
+      "author": {
+        "name": "Browserbase"
+      },
+      "category": "security",
+      "keywords": ["safe-browser", "domain-policy", "allowlist", "cdp", "fetch-interception", "claude-agent-sdk", "browser-security", "prompt-injection"],
+      "strict": false,
+      "skills": [
+        "./skills/safe-browser"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What
Makes **Codex** support first-class by adding `.agents/plugins/marketplace.json` (Codex's canonical marketplace path), mirroring the existing `.claude-plugin/marketplace.json`.

## Why
Codex resolves marketplaces from `.agents/plugins/marketplace.json` and *falls back* to `.claude-plugin/marketplace.json`. So `codex plugin marketplace add browserbase/skills` likely already resolves via the fallback — this publishes the catalog at the canonical path so it's first-class and future-proof.

## Install (Codex)
```
codex plugin marketplace add browserbase/skills
codex plugin install browse
```

## Notes
- Content is a verbatim mirror of `.claude-plugin/marketplace.json` (same schema Codex accepts).
- Draft — part of a batch of marketplace updates (Cursor / Anthropic / Grok) for @shrey150 to review before we ping external contacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)