### PR TITLE
Add Grok plugin manifest (.grok-plugin/plugin.json)

### DIFF
--- a/.grok-plugin/plugin.json
+++ b/.grok-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "browse",
+  "version": "1.0.0",
+  "description": "Browser automation for Grok via the Browserbase browse CLI. Drive a local or Browserbase-hosted browser, inspect pages with accessibility snapshots, click/type/extract, capture network, and discover Browse.sh skills.",
+  "author": {
+    "name": "Browserbase",
+    "url": "https://browserbase.com"
+  },
+  "homepage": "https://browse.sh",
+  "repository": "https://github.com/browserbase/skills",
+  "license": "MIT",
+  "keywords": ["browser", "automation", "browserbase", "stagehand", "web-scraping", "browse"]
+}


### PR DESCRIPTION
## What
Adds a root `.grok-plugin/plugin.json` so `browserbase/skills` can be listed as the official **`browse`** plugin in **Grok Build** (`xai-org/plugin-marketplace`).

## Why
xAI's marketplace is one central repo. To list a third-party plugin, you add a catalog entry there with a **remote `url` source** that clones the plugin repo and reads `.grok-plugin/plugin.json` from its **root**, then auto-discovers `skills/`. This repo had no such manifest, so this adds it (neon-style; no Codex `interface` block; no MCP — the skills drive the `browse` CLI).

## Pairs with
The companion catalog entry in `xai-org/plugin-marketplace` (separate cross-org PR) points its `url` source at this repo pinned to the SHA that includes this commit.

## Notes
- Draft — part of the marketplace batch for @shrey150 to review before we ping Andrew (xAI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)