### PR TITLE
Harden autobrowse: restrict trace artifacts to owner-only permissions

### DIFF
--- a/skills/autobrowse/scripts/evaluate.mjs
+++ b/skills/autobrowse/scripts/evaluate.mjs
@@ -28,6 +28,37 @@ const MAX_TURNS = Number(process.env.MAX_TURNS) || 30;
 const MAX_TOKENS = 4096;
 const EXEC_TIMEOUT_MS = 30_000;
 
+// Trace artifacts can contain cookies, auth headers, bearer tokens, passwords,
+// private URLs, and screenshots of authenticated pages. Restrict them to the
+// owner so other local users or processes on a shared host (CI runners, shared
+// dev boxes, multi-tenant containers) can't read them. 0700/0600 are
+// unaffected by the process umask.
+const TRACE_DIR_MODE = 0o700;
+const TRACE_FILE_MODE = 0o600;
+
+// Recursively tighten an already-written trace tree to owner-only. Catches
+// files created by subprocesses (screenshots from the `browse` CLI, .o11y
+// artifacts) whose creation mode we don't control. Symlinks are skipped.
+function lockDownTrace(root) {
+  let entries;
+  try {
+    entries = fs.readdirSync(root, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const p = path.join(root, entry.name);
+    if (entry.isSymbolicLink()) continue;
+    if (entry.isDirectory()) {
+      try { fs.chmodSync(p, TRACE_DIR_MODE); } catch {}
+      lockDownTrace(p);
+    } else if (entry.isFile()) {
+      try { fs.chmodSync(p, TRACE_FILE_MODE); } catch {}
+    }
+  }
+  try { fs.chmodSync(root, TRACE_DIR_MODE); } catch {}
+}
+
 // ── Tool definition ────────────────────────────────────────────────
 
 const TOOLS = [
@@ -462,7 +493,10 @@ async function main() {
   const runId = `run-${String(runNumber).padStart(3, "0")}`;
   const traceDir = path.join(tracesDir, runId);
 
-  fs.mkdirSync(path.join(traceDir, "screenshots"), { recursive: true });
+  fs.mkdirSync(path.join(traceDir, "screenshots"), { recursive: true, mode: TRACE_DIR_MODE });
+  // mkdirSync's mode only applies to dirs it creates; ensure the run dir is
+  // locked down even if a parent already existed with looser perms.
+  fs.chmodSync(traceDir, TRACE_DIR_MODE);
 
   const strategy = fs.readFileSync(strategyFile, "utf-8");
   const task = fs.readFileSync(taskFile, "utf-8");
@@ -593,7 +627,7 @@ async function main() {
     messages.push({ role: "user", content: toolResults });
 
     // Write trace incrementally
-    fs.writeFileSync(path.join(traceDir, "trace.json"), JSON.stringify(trace, null, 2));
+    fs.writeFileSync(path.join(traceDir, "trace.json"), JSON.stringify(trace, null, 2), { mode: TRACE_FILE_MODE });
   }
 
   // ── Write final artifacts ──────────────────────────────────────
@@ -645,9 +679,13 @@ async function main() {
 
   const summary = summaryLines.join("\n");
 
-  fs.writeFileSync(path.join(traceDir, "summary.md"), summary);
-  fs.writeFileSync(path.join(traceDir, "trace.json"), JSON.stringify(trace, null, 2));
-  fs.writeFileSync(path.join(traceDir, "messages.json"), JSON.stringify(messages, null, 2));
+  fs.writeFileSync(path.join(traceDir, "summary.md"), summary, { mode: TRACE_FILE_MODE });
+  fs.writeFileSync(path.join(traceDir, "trace.json"), JSON.stringify(trace, null, 2), { mode: TRACE_FILE_MODE });
+  fs.writeFileSync(path.join(traceDir, "messages.json"), JSON.stringify(messages, null, 2), { mode: TRACE_FILE_MODE });
+
+  // Lock down everything under the run dir, including artifacts written by
+  // subprocesses (screenshots, .o11y) whose creation mode we don't control.
+  lockDownTrace(traceDir);
 
   // Update latest symlink
   const latestLink = path.join(tracesDir, "latest");


### PR DESCRIPTION
## What

Autobrowse writes trace artifacts (`trace.json`, `messages.json`, `summary.md`, and `screenshots/`) for each run. These can contain sensitive material captured during an authenticated browsing session: session cookies, `Authorization`/bearer tokens, passwords from form POSTs, private URLs with embedded tokens, and screenshots of logged-in pages.

These files were written with default `fs.writeFileSync` / `fs.mkdirSync` permissions, which inherit the process umask — typically `0644` for files and `0755` for directories. That makes the whole trace tree **readable by other local users and processes**.

## What we're preventing against

On a shared filesystem, anything with a different UID on the same host could read the trace contents:

- **CI runners** where another job/tenant shares the workspace
- **Shared dev boxes** with multiple user accounts
- **Multi-tenant container hosts** with shared mounts
- Traces accidentally swept into **downloadable CI artifacts**

In those environments, world-readable traces mean another party could lift live session tokens, credentials, and screenshots of authenticated pages belonging to whatever the bot logged into.

## Change

Restrict trace artifacts to the owner:

- Run dir + `screenshots/` created with mode `0700`; the run dir is also `chmod`'d explicitly, since `mkdirSync`'s `mode` only applies to directories it actually creates (a pre-existing parent could otherwise remain traversable).
- `trace.json` / `messages.json` / `summary.md` written with mode `0600`.
- `lockDownTrace()` sweeps the run dir at the end to cover files written by **subprocesses** (screenshots from the `browse` CLI, `.o11y` artifacts) whose creation mode we don't control. The `latest` symlink is skipped.

`0700`/`0600` are not widened by the process umask, so behavior is consistent across hosts.

## Impact on the loop: none

The owner — the same user the self-improvement loop runs as — keeps full read/write. The inner agent writing traces, the outer loop reading them to update `strategy.md`, the `latest` symlink, and multi-iteration runs all work unchanged. Only **cross-user** access is removed.

## Verification

Tested the write/read sequence + the lockdown sweep against a reproduced trace tree:

- Under both `umask 022` and `umask 000`, all artifacts (including the subprocess-written screenshot) end up `0700`/`0600`; no group/other-readable paths remain.
- Full owner flow verified across two consecutive runs: incremental `trace.json` re-read/rewrite mid-run, traversing + listing the run and `screenshots/` dirs, reading every artifact, reading through the `latest` symlink, and `getNextRunNumber` advancing `run-001 → run-002`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Filesystem permission hardening only; same-user read/write for the autobrowse loop is unchanged, with no auth or runtime logic changes.
> 
> **Overview**
> **Hardens trace output permissions** in `evaluate.mjs` so run artifacts (JSON traces, messages, summaries, screenshots) are only readable by the owning user.
> 
> Run directories and `screenshots/` are created with mode **0700**, with an explicit `chmod` on the run dir when a parent already existed with looser perms. **`trace.json`**, **`messages.json`**, and **`summary.md`** are written with **0600**, including incremental `trace.json` updates mid-run.
> 
> A new **`lockDownTrace()`** recursively applies **0700**/**0600** under the run directory after the run finishes, covering files from subprocesses (e.g. browse screenshots, `.o11y`) whose modes aren't controlled at write time. Symlinks (including **`latest`**) are skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab767a62bf087c63fa49ee2bbfac4baa6a70b346. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->