### PR TITLE
Add browserbase-agents skill: create, run, and integrate Agents via the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This plugin includes the following skills (see `skills/` for details):
 | Skill | Description |
 |-------|-------------|
 | [browser](skills/browser/SKILL.md) | Automate web browser interactions via CLI commands — supports remote Browserbase sessions with Browserbase Identity, Verified browsers, CAPTCHA solving, and residential proxies |
+| [browserbase-agents](skills/browserbase-agents/SKILL.md) | Create, run, and integrate Browserbase Agents via the Agents API — reusable agents with system prompts and result schemas, runs with variables, polling, downloads, and prompt/schema best practices |
 | [functions](skills/functions/SKILL.md) | Deploy serverless browser automation to Browserbase cloud using the `browse` CLI |
 | [browser-trace](skills/browser-trace/SKILL.md) | Capture a full DevTools-protocol trace (CDP firehose, screenshots, DOM dumps) alongside any browser automation, then bisect the stream into per-page searchable buckets |
 | [browser-to-api](skills/browser-to-api/SKILL.md) | Turn a website's observable HTTP traffic into a best-effort OpenAPI 3.1 spec by analyzing a `browser-trace` capture |

--- a/skills/browserbase-agents/LICENSE.txt
+++ b/skills/browserbase-agents/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Browserbase, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/browserbase-agents/SKILL.md
+++ b/skills/browserbase-agents/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: browserbase-agents
+description: Create, run, and integrate Browserbase Agents — autonomous cloud browser agents driven by one API call. Covers the Agents API (create reusable agents with system prompts and result schemas, trigger runs with variables, poll to completion, retrieve structured results and downloads) plus field-tested best practices for prompts, schemas, and anti-bot settings. Use when the user wants to create a Browserbase agent, call the Agents API, run an autonomous browser agent, or automate a web task ("search X and return JSON", "check availability on Y") without writing Playwright or Stagehand code.
+license: MIT
+compatibility: "Requires Python 3.8+ (stdlib only) and BROWSERBASE_API_KEY."
+allowed-tools: Bash, Read, Write
+---
+
+# Browserbase Agents
+
+Browserbase Agents are the highest abstraction of the Browserbase platform: describe a web task in natural language, and Browserbase runs an autonomous agent (browser + web search + files + shell, Stagehand-driven) that completes it and returns structured JSON. No Playwright scripts, no model orchestration, no infrastructure.
+
+**Mental model:** an *Agent* is a reusable configuration (`name` + `systemPrompt` + `resultSchema`); a *run* is one asynchronous execution of a `task` against it, on a dedicated browser session. Create the agent once, then fan runs out across queries, dates, or hundreds of portals by changing only `variables`.
+
+## Prerequisites
+
+- A Browserbase API key (dashboard → Settings), exported as `BROWSERBASE_API_KEY`.
+- No SDK required — the API is plain REST; the bundled script is stdlib-only Python.
+
+## Core workflow
+
+### 1. Design the agent
+
+Write the `systemPrompt` in four blocks — role/scope, inputs (every `%variable%` documented), numbered procedure, guardrails — and pair it with a strict `resultSchema`. **Read `references/prompt_patterns.md` before writing either**; it contains the patterns that separate reliable agents from flaky ones (echo-back `appliedFilters`, outcome enums, null-over-invented-data, read-only guardrails, SSR-blob extraction, variable-drift mitigations).
+
+A ready-to-adapt example payload lives at `assets/example_agent.json`.
+
+### 2. Create the agent
+
+```bash
+python3 scripts/bb_agents.py create --file my_agent.json
+# → returns agentId
+```
+
+Equivalent raw call: `POST https://api.browserbase.com/v1/agents` with header `x-bb-api-key` and body `{name, systemPrompt, resultSchema}`. Only `name` is required.
+
+### 3. Trigger a run
+
+```bash
+python3 scripts/bb_agents.py run --agent-id <agentId> \
+  --task "Search for %query% and return structured JSON." \
+  --var query="wireless earbuds" --var max_pages=1 \
+  --proxies --wait
+```
+
+- `--var key=value` becomes the `variables` object; reference values as `%key%` in prompts. Use variables for anything per-run or sensitive (queries, dates, credentials) — values are not persisted.
+- `--proxies` / `--verified` set `browserSettings` for anti-bot-protected sites.
+- `--context-id` reuses a Browserbase context (cookies/auth) across runs.
+- Omitting `--agent-id` creates a new agent and its first run in one call.
+- `--wait` polls to completion inline; otherwise poll separately.
+
+### 4. Poll to completion
+
+Runs are asynchronous: `PENDING → RUNNING → COMPLETED | FAILED | TIMED_OUT | STOPPED`.
+
+```bash
+python3 scripts/bb_agents.py poll <runId>          # blocks until terminal, prints run
+python3 scripts/bb_agents.py messages <runId>      # step-by-step transcript while running
+```
+
+The structured output is at `result.output` in the run object and conforms to the `resultSchema`. The run's `sessionId` is a normal Browserbase session — use it for Live View, Session Replay, and logs in the dashboard, and for retrieving downloaded files:
+
+```bash
+python3 scripts/bb_agents.py downloads <sessionId>
+```
+
+### 5. Verify and iterate
+
+- Compare echoed fields (`appliedFilters`, `date`) against the variables sent — this catches the two most common first-run failures: filters not applied and date drift.
+- Thin results on protected sites (PerimeterX, DataDome, Akamai)? Re-run with `--proxies --verified`.
+- Use the dashboard **Optimize** tool on any run to get a proposed `systemPrompt` diff, then `scripts/bb_agents.py update <agentId> --file changes.json`.
+- Track `completionRate` / `failRate` / `timeoutRate` / `averageDuration` on the Agent page — optimize against numbers, not impressions.
+
+## Bundled resources
+
+| Resource | Use |
+|---|---|
+| `scripts/bb_agents.py` | Zero-dependency CLI for the full lifecycle: create, update, run (with variables/browserSettings), get, poll, messages, list-agents, list-runs, downloads, delete. Run with `--help` for all flags. |
+| `references/api_reference.md` | Condensed endpoint reference: payloads, response shapes, run lifecycle, pagination, downloads, built-in tools, quality metrics. Load when constructing raw API calls. |
+| `references/prompt_patterns.md` | System-prompt and schema design patterns with field-tested pitfalls (variable drift, silent filter failures, anti-bot settings). Load before designing any agent. |
+| `assets/example_agent.json` | Complete working agent payload (e-commerce search with full filter surface) to copy and adapt. |
+
+## Key facts worth remembering
+
+- Agents choose their own path (may skip the browser entirely if search/fetch suffices); custom tools can't be added yet — extra capability goes in the `systemPrompt`.
+- Integration is poll-based today (webhooks planned). Poll every ~5–10 s; typical runs take 2–10 minutes.
+- Each run is a separate browser session, so parallel fan-out works up to the account concurrency limit.
+- Per-run `resultSchema` overrides the agent's default; per-run `variables` keep secrets out of task text.
+- Files: agents can download and produce files (retrieve via Downloads API with the `sessionId`), but files cannot be uploaded to an agent yet; >1 MB data should flow through downloads, not inline extraction.

--- a/skills/browserbase-agents/assets/example_agent.json
+++ b/skills/browserbase-agents/assets/example_agent.json
@@ -1,0 +1,61 @@
+{
+  "name": "Amazon Product Search (Full Filter Surface)",
+  "systemPrompt": "You are an Amazon product search agent. Search www.amazon.com for products matching the query and apply the full filter surface, then return structured JSON for every organic result on the scanned pages.\n\nInputs (variables):\n- %query% — the search query (required)\n- %department% — Amazon department/category to scope the search to (optional; skip if empty or 'any')\n- %brands% — comma-separated brand names to filter by (optional)\n- %min_rating% — minimum star rating, e.g. 4 for '4 Stars & Up' (optional)\n- %price_min% / %price_max% — price bounds in USD (optional)\n- %deals_only% — 'true' to filter to Today's Deals (optional)\n- %condition% — 'new', 'used', or 'renewed' (optional)\n- %sort% — one of: featured, price-asc, price-desc, avg-review, newest, best-sellers (optional; default featured)\n- %max_pages% — number of result pages to scan (default 1, max 3)\n\nProcedure:\n1. Go to https://www.amazon.com and search for %query%. If a CAPTCHA or 'continue shopping' interstitial appears, resolve it and retry.\n2. Apply filters using the left-rail refinements AND/OR URL parameters (rh=, p_36 for price, p_72 for rating, s= for sort) — prefer URL params when reliable: department, brands, min rating, price range, deals, condition.\n3. Apply the requested sort order via the sort dropdown or s= URL param.\n4. Scan up to %max_pages% pages of results using pagination.\n5. For EVERY organic (non-sponsored) result, extract: ASIN (from data-asin attribute or the /dp/ URL), full title, price (display string plus numeric value and currency; null if unavailable), star rating and review count, badges (e.g. \"Best Seller\", \"Amazon's Choice\", \"Overall Pick\", \"Prime\", coupon/deal badges), main image URL, and the canonical product URL in the form https://www.amazon.com/dp/<ASIN>.\n6. Skip sponsored placements, ad carousels, and editorial widgets. Deduplicate by ASIN.\n7. Record which filters you actually managed to apply in appliedFilters. If a filter option does not exist for this query, note it as null and continue rather than failing.\n\nReturn the result conforming to the result schema. Never invent ASINs, prices, or ratings — use null when a field is not present on the page.",
+  "resultSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["query", "appliedFilters", "results"],
+    "properties": {
+      "query": { "type": "string" },
+      "appliedFilters": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "department": { "type": ["string", "null"] },
+          "brands": { "type": "array", "items": { "type": "string" } },
+          "minRating": { "type": ["number", "null"] },
+          "priceMin": { "type": ["number", "null"] },
+          "priceMax": { "type": ["number", "null"] },
+          "dealsOnly": { "type": "boolean" },
+          "condition": { "type": ["string", "null"] },
+          "sort": { "type": ["string", "null"] },
+          "pagesScanned": { "type": "integer" }
+        }
+      },
+      "totalResultsText": { "type": ["string", "null"] },
+      "results": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["asin", "title", "url"],
+          "properties": {
+            "asin": { "type": "string" },
+            "title": { "type": "string" },
+            "price": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "display": { "type": ["string", "null"] },
+                "value": { "type": ["number", "null"] },
+                "currency": { "type": ["string", "null"] },
+                "listPrice": { "type": ["number", "null"] }
+              }
+            },
+            "rating": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "stars": { "type": ["number", "null"] },
+                "reviewCount": { "type": ["integer", "null"] }
+              }
+            },
+            "badges": { "type": "array", "items": { "type": "string" } },
+            "imageUrl": { "type": ["string", "null"] },
+            "url": { "type": "string" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/skills/browserbase-agents/evals/evals.json
+++ b/skills/browserbase-agents/evals/evals.json
@@ -1,0 +1,18 @@
+[
+  {
+    "prompt": "Create a Browserbase agent that searches Hacker News for stories matching a query and returns title, points, and URL as structured JSON, then run it once for 'browser automation' and show me the result.",
+    "expected_behavior": "Writes an agent payload with a systemPrompt documenting %variables% and a strict resultSchema, creates it via POST /v1/agents (scripts/bb_agents.py create), triggers a run with variables, polls to a terminal state, and reports result.output — without inventing data or fields."
+  },
+  {
+    "prompt": "My Browserbase agent run came back with only 1 result on Walmart. What should I change?",
+    "expected_behavior": "Diagnoses anti-bot protection (PerimeterX) and recommends re-running with browserSettings proxies/verified, plus checking appliedFilters echo-back and the session replay via sessionId."
+  },
+  {
+    "prompt": "How do I pass a confirmation code to a Browserbase agent run without putting it in the task text?",
+    "expected_behavior": "Uses the variables object on POST /v1/agents/runs with a %placeholder% reference in the prompt, noting values are not persisted."
+  },
+  {
+    "prompt": "Poll my Browserbase agent run wf-123 until it finishes and get any files it downloaded.",
+    "expected_behavior": "Polls GET /v1/agents/runs/{runId} until a terminal state, reads sessionId from the run, then lists files via GET /v1/downloads?sessionId=."
+  }
+]

--- a/skills/browserbase-agents/references/api_reference.md
+++ b/skills/browserbase-agents/references/api_reference.md
@@ -1,0 +1,127 @@
+# Browserbase Agents API Reference
+
+Base URL: `https://api.browserbase.com/v1`
+Auth header on every request: `x-bb-api-key: $BROWSERBASE_API_KEY`
+Full docs: https://docs.browserbase.com/platform/agents/overview
+
+## Endpoints at a glance
+
+| Method & path | Purpose |
+|---|---|
+| `POST /agents` | Create a reusable agent |
+| `GET /agents` | List agents (cursor pagination) |
+| `GET /agents/{agentId}` | Get one agent |
+| `POST /agents/{agentId}` | Update an agent (partial body; omitted fields unchanged) |
+| `DELETE /agents/{agentId}` | Delete an agent (past runs unaffected) |
+| `POST /agents/runs` | Start a run (with or without `agentId`) |
+| `GET /agents/runs` | List runs; filter by `agentId`, `status`, `startAt`/`endAt` |
+| `GET /agents/runs/{runId}` | Get a run's status + result |
+| `GET /agents/runs/{runId}/messages` | Step-by-step transcript (AI SDK UIMessage format) |
+| `GET /downloads?sessionId={id}` | List files the agent downloaded during the run |
+
+## Create an Agent — `POST /agents`
+
+Only `name` is required. An agent with no `systemPrompt` behaves like an unconfigured run.
+
+```json
+{
+  "name": "Amazon Product Search",              // required, 1-255 chars
+  "systemPrompt": "You are ... use %query% ...", // steers every run
+  "resultSchema": { "type": "object", "...": "..." } // JSON Schema for run output
+}
+```
+
+Response (201) is the Agent object:
+
+```json
+{
+  "agentId": "uuid", "name": "...", "systemPrompt": "...",
+  "resultSchema": {}, "createdAt": "...", "updatedAt": "..."
+}
+```
+
+## Run an Agent — `POST /agents/runs`
+
+```json
+{
+  "agentId": "uuid",                  // optional; omit for ad-hoc run
+  "task": "Search for %query% ...",   // required, natural language
+  "resultSchema": {},                 // optional per-run schema override
+  "variables": {                      // optional %placeholder% values
+    "query": { "value": "wireless earbuds", "description": "what to search" }
+  },
+  "browserSettings": {                // optional session controls
+    "proxies": true,                  // route through Browserbase proxies
+    "verified": true,                 // enable Browserbase Verified
+    "context": { "id": "ctx_...", "persist": true }  // reuse auth/cookies
+  }
+}
+```
+
+Notes:
+- A call with **no `agentId`** creates a new agent and its first run in one call — the response includes both `agentId` and `runId`.
+- Variable values are strings. They are NOT persisted. Reference them as `%name%` in the task or system prompt.
+- Contexts carry cookies/auth between runs; `persist: true` saves state back after the run.
+
+## Run lifecycle
+
+```
+PENDING → RUNNING → COMPLETED | FAILED | TIMED_OUT | STOPPED
+```
+
+`PENDING`/`RUNNING` are active; the rest are terminal and never change again.
+Integration is **poll-based** (webhooks planned): poll `GET /agents/runs/{runId}` every few seconds.
+
+## Get a run — response shape
+
+```json
+{
+  "runId": "...", "agentId": "...", "status": "COMPLETED",
+  "task": "...", "sessionId": "...",
+  "result": { "output": { /* conforms to resultSchema */ } },
+  "createdAt": "...", "startedAt": "...", "endedAt": "..."
+}
+```
+
+- The structured payload lives at `result.output` when a `resultSchema` was set.
+- `sessionId` is a normal Browserbase session ID: use it for Live View, Session Replay in the dashboard, logs, and the Downloads API.
+
+## Run messages — `GET /agents/runs/{runId}/messages`
+
+Chronological transcript in [AI SDK UIMessage format](https://ai-sdk.dev/docs/reference/ai-sdk-core/ui-message): each message has `role` and `parts` (text, tool calls, reasoning, files). Pass the response's `nextSince` back as `?since=` to fetch only newer messages — poll this while a run is active to stream progress.
+
+## Pagination
+
+List endpoints return `nextCursor`; pass it back as `?cursor=` for the next page.
+`GET /agents/runs` filters: `agentId`, `status`, `limit`, `startAt`, `endAt`.
+
+## Files / downloads
+
+Agents have a sandboxed file workspace (read/write, process PDFs, produce CSVs). Files the agent downloads are stored against the run's session:
+
+```bash
+curl "https://api.browserbase.com/v1/downloads?sessionId=$SESSION_ID" \
+  --header "x-bb-api-key: $BROWSERBASE_API_KEY"
+```
+
+Limits: no file *upload* to an agent yet; large (>1 MB) or paginated tabular data should flow through downloads, not inline extraction.
+
+## Built-in tools (not configurable yet)
+
+1. **Browser control** — Stagehand-driven; adapts to layout changes, no selectors.
+2. **Web search** — Search/Fetch APIs to find the right starting URL.
+3. **File system** — sandboxed workspace, downloads land in the session.
+4. **Shell** — sandboxed runtime commands when scripting beats browsing.
+
+Custom tools cannot be added and built-ins cannot be disabled in the current version. The agent may skip the browser entirely if search/fetch answers the task.
+
+## Quality metrics (dashboard Agent page)
+
+| Field | Meaning |
+|---|---|
+| `completionRate` | Fraction of runs that completed |
+| `failRate` | Fraction of runs that failed |
+| `timeoutRate` | Fraction of runs that timed out |
+| `averageDuration` | Average run duration (seconds) |
+
+Rising `timeoutRate`/`failRate` → revisit the prompt or use the dashboard Optimize tool.

--- a/skills/browserbase-agents/references/prompt_patterns.md
+++ b/skills/browserbase-agents/references/prompt_patterns.md
@@ -1,0 +1,123 @@
+# Agent Design Patterns: System Prompts & Result Schemas
+
+Field-tested patterns for writing agents that return reliable, structured results. Every pattern below maps to real fields on `POST /agents` (`systemPrompt`, `resultSchema`) and `POST /agents/runs` (`variables`, `browserSettings`).
+
+## The anatomy of a good system prompt
+
+Structure every system prompt in four blocks:
+
+```text
+1. ROLE + SCOPE     "You are an X agent. Given A and B, return C as structured JSON."
+2. INPUTS           List every %variable% with type, format, and default.
+3. PROCEDURE        Numbered steps: where to go, what to apply, what to extract,
+                    what to skip, how to handle blockers.
+4. GUARDRAILS       Read-only rules, honesty rules ("null over invented data"),
+                    and what to do when the task cannot be completed.
+```
+
+### Example skeleton
+
+```text
+You are an <domain> search agent. Search <site> for <thing> matching the query
+with the requested filters applied, then return structured JSON per result.
+
+Inputs (variables):
+- %query% — the search query (required)
+- %price_max% — maximum price in USD (optional)
+- %max_pages% — result pages to scan (default 1, max 3)
+
+Procedure:
+1. Go to <site> and search %query%. If a CAPTCHA or interstitial appears,
+   resolve it and retry.
+2. Apply filters via the UI AND/OR URL parameters — prefer URL params when
+   reliable: <list the site's known params>.
+3. Scan up to %max_pages% pages. For EVERY organic result extract: <fields>.
+4. Skip sponsored placements. Deduplicate by <stable id>.
+5. Record which filters you actually managed to apply in appliedFilters.
+   If a filter option does not exist, note it as null and continue.
+
+Never invent <ids/prices/times> — use null when a field is not on the page.
+```
+
+## Pattern: echo applied state back (`appliedFilters`)
+
+Agents sometimes fail to apply a filter but extract data anyway. Force honesty by requiring an `appliedFilters` object in the schema that echoes what was *actually* applied (not what was requested). This turns silent filter failures into visible, diffable data — compare `appliedFilters` to the run's variables to detect drift automatically.
+
+## Pattern: outcome enums for availability checks
+
+For "is X available?" tasks (reservations, tee times, day passes, stock), a bare slot list is ambiguous — empty could mean sold out, not found, or blocked. Enumerate every distinct failure mode as a schema-level enum so the agent must pick one:
+
+```json
+"outcome": {
+  "type": "string",
+  "enum": ["available", "sold-out", "not-found", "ambiguous-name",
+           "not-bookable-online", "outside-publish-window", "extraction-blocked"]
+}
+```
+
+In the prompt, define each outcome precisely ("'sold-out' means the date is open for booking but every slot is taken; 'outside-publish-window' means the date has not been released yet"). Pair with a `candidates` array so `ambiguous-name` returns the options instead of a guess. Verified in production: an agent asked for a restaurant that wasn't on the platform correctly returned `venue-not-found` with two near-miss candidates instead of hallucinating slots.
+
+## Pattern: null over invented data
+
+End every prompt with a line like: *"Never invent IDs, prices, or times — use null when a field is not present on the page."* Make nullable schema fields explicitly nullable (`"type": ["number", "null"]`) so validation doesn't push the agent to fabricate. An honest partial result beats a complete-looking fake one.
+
+## Pattern: capture load-bearing tokens
+
+When the output feeds a downstream booking/purchase step, name the token explicitly and say where to find it: *"capture the config_id token — this is load-bearing for downstream booking; read it from the slot button's attributes or the API response visible in page state."* If the token can't be extracted, require a note rather than a guess.
+
+## Pattern: read-only guardrails
+
+For research agents that walk checkout/booking flows, state exactly how far to go:
+
+```text
+Read-only: NEVER place an order, submit payment, book, hold, or create an account.
+You may add an item to the cart and proceed ONLY far enough in checkout to reveal
+delivery options and fees, entering the destination but never payment details.
+```
+
+Agents follow this well, but say it twice — once in role/scope, once at the exact step where the temptation occurs.
+
+## Pattern: prefer deep-links and embedded data over UI walking
+
+- **URL parameters beat click sequences**: most sites encode filters in the URL (e.g. `?covers=2&dateTime=2026-07-18T19:00`, price/sort params, slugged filter paths). Name the known params in the prompt.
+- **Server-rendered JSON beats DOM scraping**: many SPAs embed the full result payload in a script tag (`__NEXT_DATA__`, deferred-state blobs). Telling the agent to parse that blob yields more fields, exact IDs, and immunity to layout changes. Verified in production on a major listings site: the agent found the SSR blob and returned exact listing IDs, coordinates, and total counts.
+- **Canonical URL formats**: specify them (`https://site.com/dp/<ID>`) so output URLs are stable and deduplicable.
+
+## Pattern: variables for anything per-run or sensitive
+
+Anything that changes between runs — queries, dates, party sizes, credentials, confirmation codes — belongs in `variables`, not hardcoded in the prompt. Sensitive values passed as variables never sit inline in the task text and are not persisted.
+
+**Known pitfall (observed in production): date/time drift.** Agents sometimes substitute *today's* date instead of the `%date%` variable. Mitigations:
+- Repeat the variable in the task: `"Check availability on %date% (this exact date, not today)"`.
+- Echo the inputs back in the schema (a required `date` field) so drift is detectable.
+- Validate the echoed field against the variable after the run; retry on mismatch.
+
+## Pattern: one abstract agent, many targets
+
+To cover hundreds of portals/sites, write ONE agent whose prompt describes the goal abstractly ("Portals differ in layout. Do not rely on fixed labels; find the billing area by its meaning.") and pass the portal URL + credentials per run. Each run gets its own browser session, so fan-out is parallel up to the account's concurrency limit.
+
+## Pattern: schema design for scale
+
+- Keep schemas as flat as practical; scalar fields are quick to read and diff.
+- For prices, capture display + numeric + currency: `{"display": "$1,395 - $2,210", "value": 1395, "currency": "USD"}` — display preserves ranges, numeric enables math.
+- Include a free-text `notes` or `summary` field so the agent has a sanctioned place for caveats instead of polluting typed fields.
+- Mark truly-required fields `required`; leave the rest optional/nullable.
+- `additionalProperties: false` keeps output tight and catches schema drift.
+
+## Anti-bot & session controls
+
+| Symptom | Fix |
+|---|---|
+| Thin/blocked results on protected sites (PerimeterX, DataDome, Akamai) | `"browserSettings": {"proxies": true, "verified": true}` on the run |
+| Site needs login state across runs | `"browserSettings": {"context": {"id": "...", "persist": true}}` |
+| Geo-dependent content (metro redirects, region pricing) | proxies + instruct the agent to detect and correct the redirect |
+
+Name known challenges in the prompt: *"This site is protected by PerimeterX — if a 'Robot or human?' press-and-hold challenge appears, solve it and continue."*
+
+## Iterating on quality
+
+1. First runs are exploratory — expect wandering; judge the *output*, then optimize the *path*.
+2. Use the dashboard **Optimize** tool on a run (starter prompts: "Make this faster", "What went wrong", "Alternative approaches", "Write a script"). It proposes a `systemPrompt` diff you can edit, apply, and re-run.
+3. Watch `completionRate` / `failRate` / `timeoutRate` / `averageDuration` on the Agent page over time, not single-run impressions.
+4. Common first-run findings, in practice: filters requested but not applied (visible via `appliedFilters`), thin extraction on anti-bot sites (add proxies/verified), and variable drift (add echo-back validation).
+5. When a run reveals the underlying data endpoint (an API the page calls), consider replaying it with the Fetch API for cheap high-frequency polling, and keep the Agent for pages that only render in a browser.

--- a/skills/browserbase-agents/scripts/bb_agents.py
+++ b/skills/browserbase-agents/scripts/bb_agents.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Browserbase Agents API CLI — create agents, trigger runs, poll to completion.
+
+Zero dependencies (Python 3.8+ stdlib only).
+
+Auth: set BROWSERBASE_API_KEY in the environment, or pass --api-key.
+
+Commands:
+  create        Create a reusable agent from a JSON payload file
+  update        Update an existing agent (partial body)
+  run           Trigger a run (against an agent or ad-hoc)
+  get           Fetch a run's status and result
+  poll          Poll a run until it reaches a terminal state
+  messages      Fetch a run's step-by-step transcript
+  list-agents   List agents on the account
+  list-runs     List runs (filter by agent / status)
+  downloads     List files downloaded during a run's session
+  delete        Delete an agent
+
+Examples:
+  bb_agents.py create --file agent.json
+  bb_agents.py run --agent-id <id> --task "Search for %query%" \
+      --var query="wireless earbuds" --var max_pages=1 --proxies
+  bb_agents.py poll <runId>
+  bb_agents.py messages <runId>
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+API = "https://api.browserbase.com/v1"
+TERMINAL = {"COMPLETED", "FAILED", "STOPPED", "TIMED_OUT"}
+
+
+def request(method, path, api_key, body=None, params=None):
+    url = f"{API}{path}"
+    if params:
+        url += "?" + urllib.parse.urlencode({k: v for k, v in params.items() if v})
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode() if body is not None else None,
+        headers={"x-bb-api-key": api_key, "Content-Type": "application/json"},
+        method=method,
+    )
+    try:
+        with urllib.request.urlopen(req) as r:
+            raw = r.read().decode()
+            return json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as e:
+        sys.exit(f"HTTP {e.code} {method} {path}: {e.read().decode()[:1000]}")
+
+
+def parse_vars(pairs):
+    """--var key=value [--var-desc key='hint'] -> variables object."""
+    out = {}
+    for pair in pairs or []:
+        if "=" not in pair:
+            sys.exit(f"--var must be key=value, got: {pair}")
+        k, v = pair.split("=", 1)
+        out[k] = {"value": v}
+    return out
+
+
+def cmd_create(args, key):
+    payload = json.load(open(args.file))
+    agent = request("POST", "/agents", key, body=payload)
+    print(json.dumps(agent, indent=2))
+
+
+def cmd_update(args, key):
+    payload = json.load(open(args.file))
+    agent = request("POST", f"/agents/{args.agent_id}", key, body=payload)
+    print(json.dumps(agent, indent=2))
+
+
+def cmd_run(args, key):
+    body = {"task": args.task}
+    if args.agent_id:
+        body["agentId"] = args.agent_id
+    variables = parse_vars(args.var)
+    if variables:
+        body["variables"] = variables
+    if args.schema_file:
+        body["resultSchema"] = json.load(open(args.schema_file))
+    settings = {}
+    if args.proxies:
+        settings["proxies"] = True
+    if args.verified:
+        settings["verified"] = True
+    if args.context_id:
+        settings["context"] = {"id": args.context_id, "persist": args.persist_context}
+    if settings:
+        body["browserSettings"] = settings
+    run = request("POST", "/agents/runs", key, body=body)
+    print(json.dumps(run, indent=2))
+    if args.wait:
+        poll(run["runId"], key, args.interval, args.timeout)
+
+
+def cmd_get(args, key):
+    print(json.dumps(request("GET", f"/agents/runs/{args.run_id}", key), indent=2))
+
+
+def poll(run_id, key, interval, timeout):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        run = request("GET", f"/agents/runs/{run_id}", key)
+        status = run.get("status")
+        print(f"{time.strftime('%H:%M:%S')} {status}", file=sys.stderr)
+        if status in TERMINAL:
+            print(json.dumps(run, indent=2))
+            return run
+        time.sleep(interval)
+    sys.exit(f"Timed out after {timeout}s waiting for run {run_id}")
+
+
+def cmd_poll(args, key):
+    poll(args.run_id, key, args.interval, args.timeout)
+
+
+def cmd_messages(args, key):
+    params = {"since": args.since} if args.since else None
+    msgs = request("GET", f"/agents/runs/{args.run_id}/messages", key, params=params)
+    print(json.dumps(msgs, indent=2))
+
+
+def cmd_list_agents(args, key):
+    print(json.dumps(request("GET", "/agents", key, params={"cursor": args.cursor}), indent=2))
+
+
+def cmd_list_runs(args, key):
+    params = {"agentId": args.agent_id, "status": args.status,
+              "limit": args.limit, "cursor": args.cursor}
+    print(json.dumps(request("GET", "/agents/runs", key, params=params), indent=2))
+
+
+def cmd_downloads(args, key):
+    print(json.dumps(request("GET", "/downloads", key, params={"sessionId": args.session_id}), indent=2))
+
+
+def cmd_delete(args, key):
+    request("DELETE", f"/agents/{args.agent_id}", key)
+    print(f"Deleted agent {args.agent_id}")
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--api-key", default=os.environ.get("BROWSERBASE_API_KEY"))
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    s = sub.add_parser("create", help="Create an agent from a JSON payload file")
+    s.add_argument("--file", required=True, help="JSON file: {name, systemPrompt, resultSchema}")
+    s.set_defaults(fn=cmd_create)
+
+    s = sub.add_parser("update", help="Update an agent (partial body)")
+    s.add_argument("agent_id")
+    s.add_argument("--file", required=True)
+    s.set_defaults(fn=cmd_update)
+
+    s = sub.add_parser("run", help="Trigger a run")
+    s.add_argument("--agent-id", help="Omit for an ad-hoc run")
+    s.add_argument("--task", required=True)
+    s.add_argument("--var", action="append", help="key=value, repeatable; referenced as %%key%% in prompts")
+    s.add_argument("--schema-file", help="Per-run resultSchema override (JSON file)")
+    s.add_argument("--proxies", action="store_true")
+    s.add_argument("--verified", action="store_true")
+    s.add_argument("--context-id")
+    s.add_argument("--persist-context", action="store_true")
+    s.add_argument("--wait", action="store_true", help="Poll to completion after starting")
+    s.add_argument("--interval", type=int, default=10)
+    s.add_argument("--timeout", type=int, default=1800)
+    s.set_defaults(fn=cmd_run)
+
+    s = sub.add_parser("get", help="Fetch a run")
+    s.add_argument("run_id")
+    s.set_defaults(fn=cmd_get)
+
+    s = sub.add_parser("poll", help="Poll a run until terminal")
+    s.add_argument("run_id")
+    s.add_argument("--interval", type=int, default=10)
+    s.add_argument("--timeout", type=int, default=1800)
+    s.set_defaults(fn=cmd_poll)
+
+    s = sub.add_parser("messages", help="Fetch run transcript")
+    s.add_argument("run_id")
+    s.add_argument("--since", help="Message ID cursor (nextSince from previous call)")
+    s.set_defaults(fn=cmd_messages)
+
+    s = sub.add_parser("list-agents")
+    s.add_argument("--cursor")
+    s.set_defaults(fn=cmd_list_agents)
+
+    s = sub.add_parser("list-runs")
+    s.add_argument("--agent-id")
+    s.add_argument("--status", choices=sorted(TERMINAL | {"PENDING", "RUNNING"}))
+    s.add_argument("--limit", type=int, default=20)
+    s.add_argument("--cursor")
+    s.set_defaults(fn=cmd_list_runs)
+
+    s = sub.add_parser("downloads", help="List files from a run's session")
+    s.add_argument("session_id")
+    s.set_defaults(fn=cmd_downloads)
+
+    s = sub.add_parser("delete", help="Delete an agent")
+    s.add_argument("agent_id")
+    s.set_defaults(fn=cmd_delete)
+
+    args = p.parse_args()
+    if not args.api_key:
+        sys.exit("Set BROWSERBASE_API_KEY or pass --api-key")
+    args.fn(args, args.api_key)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

New skill `skills/browserbase-agents/` that teaches an agent (or a customer's coding agent) the full **Browserbase Agents API** lifecycle:

- **Create** reusable agents (`POST /v1/agents` with `name`, `systemPrompt`, `resultSchema`)
- **Run** them with `%variable%` placeholders, per-run schema overrides, and `browserSettings` (proxies / verified / contexts)
- **Poll** runs to a terminal state, stream `messages`, read `result.output`
- **Retrieve downloads** via the run's `sessionId`

## Contents

| File | Purpose |
|---|---|
| `SKILL.md` | Lean 5-step workflow (design → create → run → poll → verify/iterate) |
| `scripts/bb_agents.py` | Zero-dependency (Python stdlib) CLI: create, update, run, get, poll, messages, list-agents, list-runs, downloads, delete |
| `references/api_reference.md` | Condensed endpoint/payload/lifecycle reference from docs.browserbase.com |
| `references/prompt_patterns.md` | System-prompt + schema design patterns: outcome enums, `appliedFilters` echo-back, null-over-invented-data, read-only guardrails, SSR-blob extraction, anti-bot settings |
| `assets/example_agent.json` | Complete working agent payload (e-commerce search, full filter surface) |
| `evals/evals.json` | 4 realistic prompts with expected behaviors |

## Why

Repeatedly needed during SE demo-building: today we created 11 agents (Amazon/eBay/Walmart search, Resy/OpenTable availability, tee times, Airbnb, Apartments.com, Google Flights, hotel day passes, bakery delivery) and ran 11/11 to completion. The patterns doc encodes what actually went wrong on first runs (filters silently not applied, PerimeterX-thin extraction, `%date%` variable drift) and how to catch it via schema design — knowledge that isn't in the docs.

## Testing

- `node scripts/validate-skills.mjs --skill browserbase-agents` — passes, 0 warnings
- CLI live-tested against the real API (list-agents, get-run against a completed run with structured output)
- Every documented command was executed today against api.browserbase.com

Note: script is Python stdlib rather than `.mjs` — chosen so customers can run it with no Node/npm install at all; happy to port if reviewers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a local helper CLI only; no changes to auth, core browse CLI, or production runtime code.
> 
> **Overview**
> Adds a new **`browserbase-agents`** skill so coding agents can design, create, run, poll, and iterate on **Browserbase Agents** without Playwright/Stagehand code. The README skills table gains a row linking to `skills/browserbase-agents/SKILL.md`.
> 
> The skill bundles a **five-step workflow** (design prompt + schema → create → run with `%variables%` and `browserSettings` → poll/messages → verify via echo-back fields and dashboard metrics), a **stdlib-only** `scripts/bb_agents.py` CLI (create/update/run/get/poll/messages/list/downloads/delete), condensed **`references/api_reference.md`**, field-tested **`references/prompt_patterns.md`** (e.g. `appliedFilters`, outcome enums, anti-bot), **`assets/example_agent.json`**, **`evals/evals.json`**, and MIT **`LICENSE.txt`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d709bbf4105943377a0f580f716efb242606524f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->