### PR TITLE
Add design-system skill: agent-driven design-system snapshot of any URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This plugin includes the following skills (see `skills/` for details):
 |-------|-------------|
 | [browser](skills/browser/SKILL.md) | Automate web browser interactions via CLI commands — supports remote Browserbase sessions with Browserbase Identity, Verified browsers, CAPTCHA solving, and residential proxies |
 | [browserbase-agents](skills/browserbase-agents/SKILL.md) | Create, run, and integrate Browserbase Agents via the Agents API — reusable agents with system prompts and result schemas, runs with variables, polling, downloads, and prompt/schema best practices |
+| [design-system](skills/design-system/SKILL.md) | Agent-driven design-system snapshot of any URL — measured colors/type/breakpoints/states/motion plus proposed semantic tokens with machine-linked evidence |
 | [functions](skills/functions/SKILL.md) | Deploy serverless browser automation to Browserbase cloud using the `browse` CLI |
 | [browser-trace](skills/browser-trace/SKILL.md) | Capture a full DevTools-protocol trace (CDP firehose, screenshots, DOM dumps) alongside any browser automation, then bisect the stream into per-page searchable buckets |
 | [browser-to-api](skills/browser-to-api/SKILL.md) | Turn a website's observable HTTP traffic into a best-effort OpenAPI 3.1 spec by analyzing a `browser-trace` capture |

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This plugin includes the following skills (see `skills/` for details):
 | Skill | Description |
 |-------|-------------|
 | [browser](skills/browser/SKILL.md) | Automate web browser interactions via CLI commands — supports remote Browserbase sessions with Browserbase Identity, Verified browsers, CAPTCHA solving, and residential proxies |
+| [browserbase-agents](skills/browserbase-agents/SKILL.md) | Create, run, and integrate Browserbase Agents via the Agents API — reusable agents with system prompts and result schemas, runs with variables, polling, downloads, and prompt/schema best practices |
 | [functions](skills/functions/SKILL.md) | Deploy serverless browser automation to Browserbase cloud using the `browse` CLI |
 | [browser-trace](skills/browser-trace/SKILL.md) | Capture a full DevTools-protocol trace (CDP firehose, screenshots, DOM dumps) alongside any browser automation, then bisect the stream into per-page searchable buckets |
 | [browser-to-api](skills/browser-to-api/SKILL.md) | Turn a website's observable HTTP traffic into a best-effort OpenAPI 3.1 spec by analyzing a `browser-trace` capture |

--- a/skills/browserbase-agents/LICENSE.txt
+++ b/skills/browserbase-agents/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Browserbase, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/browserbase-agents/SKILL.md
+++ b/skills/browserbase-agents/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: browserbase-agents
+description: Create, run, and integrate Browserbase Agents — autonomous cloud browser agents driven by one API call. Covers the Agents API (create reusable agents with system prompts and result schemas, trigger runs with variables, poll to completion, retrieve structured results and downloads) plus field-tested best practices for prompts, schemas, and anti-bot settings. Use when the user wants to create a Browserbase agent, call the Agents API, run an autonomous browser agent, or automate a web task ("search X and return JSON", "check availability on Y") without writing Playwright or Stagehand code.
+license: MIT
+compatibility: "Requires Python 3.8+ (stdlib only) and BROWSERBASE_API_KEY."
+allowed-tools: Bash, Read, Write
+---
+
+# Browserbase Agents
+
+Browserbase Agents are the highest abstraction of the Browserbase platform: describe a web task in natural language, and Browserbase runs an autonomous agent (browser + web search + files + shell, Stagehand-driven) that completes it and returns structured JSON. No Playwright scripts, no model orchestration, no infrastructure.
+
+**Mental model:** an *Agent* is a reusable configuration (`name` + `systemPrompt` + `resultSchema`); a *run* is one asynchronous execution of a `task` against it, on a dedicated browser session. Create the agent once, then fan runs out across queries, dates, or hundreds of portals by changing only `variables`.
+
+## Prerequisites
+
+- A Browserbase API key (dashboard → Settings), exported as `BROWSERBASE_API_KEY`.
+- No SDK required — the API is plain REST; the bundled script is stdlib-only Python.
+
+## Core workflow
+
+### 1. Design the agent
+
+Write the `systemPrompt` in four blocks — role/scope, inputs (every `%variable%` documented), numbered procedure, guardrails — and pair it with a strict `resultSchema`. **Read `references/prompt_patterns.md` before writing either**; it contains the patterns that separate reliable agents from flaky ones (echo-back `appliedFilters`, outcome enums, null-over-invented-data, read-only guardrails, SSR-blob extraction, variable-drift mitigations).
+
+A ready-to-adapt example payload lives at `assets/example_agent.json`.
+
+### 2. Create the agent
+
+```bash
+python3 scripts/bb_agents.py create --file my_agent.json
+# → returns agentId
+```
+
+Equivalent raw call: `POST https://api.browserbase.com/v1/agents` with header `x-bb-api-key` and body `{name, systemPrompt, resultSchema}`. Only `name` is required.
+
+### 3. Trigger a run
+
+```bash
+python3 scripts/bb_agents.py run --agent-id <agentId> \
+  --task "Search for %query% and return structured JSON." \
+  --var query="wireless earbuds" --var max_pages=1 \
+  --proxies --wait
+```
+
+- `--var key=value` becomes the `variables` object; reference values as `%key%` in prompts. Use variables for anything per-run or sensitive (queries, dates, credentials) — values are not persisted.
+- `--proxies` / `--verified` set `browserSettings` for anti-bot-protected sites.
+- `--context-id` reuses a Browserbase context (cookies/auth) across runs.
+- Omitting `--agent-id` creates a new agent and its first run in one call.
+- `--wait` polls to completion inline; otherwise poll separately.
+
+### 4. Poll to completion
+
+Runs are asynchronous: `PENDING → RUNNING → COMPLETED | FAILED | TIMED_OUT | STOPPED`.
+
+```bash
+python3 scripts/bb_agents.py poll <runId>          # blocks until terminal, prints run
+python3 scripts/bb_agents.py messages <runId>      # step-by-step transcript while running
+```
+
+The structured output is at `result.output` in the run object and conforms to the `resultSchema`. The run's `sessionId` is a normal Browserbase session — use it for Live View, Session Replay, and logs in the dashboard, and for retrieving downloaded files:
+
+```bash
+python3 scripts/bb_agents.py downloads <sessionId>
+```
+
+### 5. Verify and iterate
+
+- Compare echoed fields (`appliedFilters`, `date`) against the variables sent — this catches the two most common first-run failures: filters not applied and date drift.
+- Thin results on protected sites (PerimeterX, DataDome, Akamai)? Re-run with `--proxies --verified`.
+- Use the dashboard **Optimize** tool on any run to get a proposed `systemPrompt` diff, then `scripts/bb_agents.py update <agentId> --file changes.json`.
+- Track `completionRate` / `failRate` / `timeoutRate` / `averageDuration` on the Agent page — optimize against numbers, not impressions.
+
+## Bundled resources
+
+| Resource | Use |
+|---|---|
+| `scripts/bb_agents.py` | Zero-dependency CLI for the full lifecycle: create, update, run (with variables/browserSettings), get, poll, messages, list-agents, list-runs, downloads, delete. Run with `--help` for all flags. |
+| `references/api_reference.md` | Condensed endpoint reference: payloads, response shapes, run lifecycle, pagination, downloads, built-in tools, quality metrics. Load when constructing raw API calls. |
+| `references/prompt_patterns.md` | System-prompt and schema design patterns with field-tested pitfalls (variable drift, silent filter failures, anti-bot settings). Load before designing any agent. |
+| `assets/example_agent.json` | Complete working agent payload (e-commerce search with full filter surface) to copy and adapt. |
+
+## Key facts worth remembering
+
+- Agents choose their own path (may skip the browser entirely if search/fetch suffices); custom tools can't be added yet — extra capability goes in the `systemPrompt`.
+- Integration is poll-based today (webhooks planned). Poll every ~5–10 s; typical runs take 2–10 minutes.
+- Each run is a separate browser session, so parallel fan-out works up to the account concurrency limit.
+- Per-run `resultSchema` overrides the agent's default; per-run `variables` keep secrets out of task text.
+- Files: agents can download and produce files (retrieve via Downloads API with the `sessionId`), but files cannot be uploaded to an agent yet; >1 MB data should flow through downloads, not inline extraction.

--- a/skills/browserbase-agents/assets/example_agent.json
+++ b/skills/browserbase-agents/assets/example_agent.json
@@ -1,0 +1,61 @@
+{
+  "name": "Amazon Product Search (Full Filter Surface)",
+  "systemPrompt": "You are an Amazon product search agent. Search www.amazon.com for products matching the query and apply the full filter surface, then return structured JSON for every organic result on the scanned pages.\n\nInputs (variables):\n- %query% — the search query (required)\n- %department% — Amazon department/category to scope the search to (optional; skip if empty or 'any')\n- %brands% — comma-separated brand names to filter by (optional)\n- %min_rating% — minimum star rating, e.g. 4 for '4 Stars & Up' (optional)\n- %price_min% / %price_max% — price bounds in USD (optional)\n- %deals_only% — 'true' to filter to Today's Deals (optional)\n- %condition% — 'new', 'used', or 'renewed' (optional)\n- %sort% — one of: featured, price-asc, price-desc, avg-review, newest, best-sellers (optional; default featured)\n- %max_pages% — number of result pages to scan (default 1, max 3)\n\nProcedure:\n1. Go to https://www.amazon.com and search for %query%. If a CAPTCHA or 'continue shopping' interstitial appears, resolve it and retry.\n2. Apply filters using the left-rail refinements AND/OR URL parameters (rh=, p_36 for price, p_72 for rating, s= for sort) — prefer URL params when reliable: department, brands, min rating, price range, deals, condition.\n3. Apply the requested sort order via the sort dropdown or s= URL param.\n4. Scan up to %max_pages% pages of results using pagination.\n5. For EVERY organic (non-sponsored) result, extract: ASIN (from data-asin attribute or the /dp/ URL), full title, price (display string plus numeric value and currency; null if unavailable), star rating and review count, badges (e.g. \"Best Seller\", \"Amazon's Choice\", \"Overall Pick\", \"Prime\", coupon/deal badges), main image URL, and the canonical product URL in the form https://www.amazon.com/dp/<ASIN>.\n6. Skip sponsored placements, ad carousels, and editorial widgets. Deduplicate by ASIN.\n7. Record which filters you actually managed to apply in appliedFilters. If a filter option does not exist for this query, note it as null and continue rather than failing.\n\nReturn the result conforming to the result schema. Never invent ASINs, prices, or ratings — use null when a field is not present on the page.",
+  "resultSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["query", "appliedFilters", "results"],
+    "properties": {
+      "query": { "type": "string" },
+      "appliedFilters": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "department": { "type": ["string", "null"] },
+          "brands": { "type": "array", "items": { "type": "string" } },
+          "minRating": { "type": ["number", "null"] },
+          "priceMin": { "type": ["number", "null"] },
+          "priceMax": { "type": ["number", "null"] },
+          "dealsOnly": { "type": "boolean" },
+          "condition": { "type": ["string", "null"] },
+          "sort": { "type": ["string", "null"] },
+          "pagesScanned": { "type": "integer" }
+        }
+      },
+      "totalResultsText": { "type": ["string", "null"] },
+      "results": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["asin", "title", "url"],
+          "properties": {
+            "asin": { "type": "string" },
+            "title": { "type": "string" },
+            "price": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "display": { "type": ["string", "null"] },
+                "value": { "type": ["number", "null"] },
+                "currency": { "type": ["string", "null"] },
+                "listPrice": { "type": ["number", "null"] }
+              }
+            },
+            "rating": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "stars": { "type": ["number", "null"] },
+                "reviewCount": { "type": ["integer", "null"] }
+              }
+            },
+            "badges": { "type": "array", "items": { "type": "string" } },
+            "imageUrl": { "type": ["string", "null"] },
+            "url": { "type": "string" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/skills/browserbase-agents/evals/evals.json
+++ b/skills/browserbase-agents/evals/evals.json
@@ -1,0 +1,18 @@
+[
+  {
+    "prompt": "Create a Browserbase agent that searches Hacker News for stories matching a query and returns title, points, and URL as structured JSON, then run it once for 'browser automation' and show me the result.",
+    "expected_behavior": "Writes an agent payload with a systemPrompt documenting %variables% and a strict resultSchema, creates it via POST /v1/agents (scripts/bb_agents.py create), triggers a run with variables, polls to a terminal state, and reports result.output — without inventing data or fields."
+  },
+  {
+    "prompt": "My Browserbase agent run came back with only 1 result on Walmart. What should I change?",
+    "expected_behavior": "Diagnoses anti-bot protection (PerimeterX) and recommends re-running with browserSettings proxies/verified, plus checking appliedFilters echo-back and the session replay via sessionId."
+  },
+  {
+    "prompt": "How do I pass a confirmation code to a Browserbase agent run without putting it in the task text?",
+    "expected_behavior": "Uses the variables object on POST /v1/agents/runs with a %placeholder% reference in the prompt, noting values are not persisted."
+  },
+  {
+    "prompt": "Poll my Browserbase agent run wf-123 until it finishes and get any files it downloaded.",
+    "expected_behavior": "Polls GET /v1/agents/runs/{runId} until a terminal state, reads sessionId from the run, then lists files via GET /v1/downloads?sessionId=."
+  }
+]

--- a/skills/browserbase-agents/references/api_reference.md
+++ b/skills/browserbase-agents/references/api_reference.md
@@ -1,0 +1,127 @@
+# Browserbase Agents API Reference
+
+Base URL: `https://api.browserbase.com/v1`
+Auth header on every request: `x-bb-api-key: $BROWSERBASE_API_KEY`
+Full docs: https://docs.browserbase.com/platform/agents/overview
+
+## Endpoints at a glance
+
+| Method & path | Purpose |
+|---|---|
+| `POST /agents` | Create a reusable agent |
+| `GET /agents` | List agents (cursor pagination) |
+| `GET /agents/{agentId}` | Get one agent |
+| `POST /agents/{agentId}` | Update an agent (partial body; omitted fields unchanged) |
+| `DELETE /agents/{agentId}` | Delete an agent (past runs unaffected) |
+| `POST /agents/runs` | Start a run (with or without `agentId`) |
+| `GET /agents/runs` | List runs; filter by `agentId`, `status`, `startAt`/`endAt` |
+| `GET /agents/runs/{runId}` | Get a run's status + result |
+| `GET /agents/runs/{runId}/messages` | Step-by-step transcript (AI SDK UIMessage format) |
+| `GET /downloads?sessionId={id}` | List files the agent downloaded during the run |
+
+## Create an Agent — `POST /agents`
+
+Only `name` is required. An agent with no `systemPrompt` behaves like an unconfigured run.
+
+```json
+{
+  "name": "Amazon Product Search",              // required, 1-255 chars
+  "systemPrompt": "You are ... use %query% ...", // steers every run
+  "resultSchema": { "type": "object", "...": "..." } // JSON Schema for run output
+}
+```
+
+Response (201) is the Agent object:
+
+```json
+{
+  "agentId": "uuid", "name": "...", "systemPrompt": "...",
+  "resultSchema": {}, "createdAt": "...", "updatedAt": "..."
+}
+```
+
+## Run an Agent — `POST /agents/runs`
+
+```json
+{
+  "agentId": "uuid",                  // optional; omit for ad-hoc run
+  "task": "Search for %query% ...",   // required, natural language
+  "resultSchema": {},                 // optional per-run schema override
+  "variables": {                      // optional %placeholder% values
+    "query": { "value": "wireless earbuds", "description": "what to search" }
+  },
+  "browserSettings": {                // optional session controls
+    "proxies": true,                  // route through Browserbase proxies
+    "verified": true,                 // enable Browserbase Verified
+    "context": { "id": "ctx_...", "persist": true }  // reuse auth/cookies
+  }
+}
+```
+
+Notes:
+- A call with **no `agentId`** creates a new agent and its first run in one call — the response includes both `agentId` and `runId`.
+- Variable values are strings. They are NOT persisted. Reference them as `%name%` in the task or system prompt.
+- Contexts carry cookies/auth between runs; `persist: true` saves state back after the run.
+
+## Run lifecycle
+
+```
+PENDING → RUNNING → COMPLETED | FAILED | TIMED_OUT | STOPPED
+```
+
+`PENDING`/`RUNNING` are active; the rest are terminal and never change again.
+Integration is **poll-based** (webhooks planned): poll `GET /agents/runs/{runId}` every few seconds.
+
+## Get a run — response shape
+
+```json
+{
+  "runId": "...", "agentId": "...", "status": "COMPLETED",
+  "task": "...", "sessionId": "...",
+  "result": { "output": { /* conforms to resultSchema */ } },
+  "createdAt": "...", "startedAt": "...", "endedAt": "..."
+}
+```
+
+- The structured payload lives at `result.output` when a `resultSchema` was set.
+- `sessionId` is a normal Browserbase session ID: use it for Live View, Session Replay in the dashboard, logs, and the Downloads API.
+
+## Run messages — `GET /agents/runs/{runId}/messages`
+
+Chronological transcript in [AI SDK UIMessage format](https://ai-sdk.dev/docs/reference/ai-sdk-core/ui-message): each message has `role` and `parts` (text, tool calls, reasoning, files). Pass the response's `nextSince` back as `?since=` to fetch only newer messages — poll this while a run is active to stream progress.
+
+## Pagination
+
+List endpoints return `nextCursor`; pass it back as `?cursor=` for the next page.
+`GET /agents/runs` filters: `agentId`, `status`, `limit`, `startAt`, `endAt`.
+
+## Files / downloads
+
+Agents have a sandboxed file workspace (read/write, process PDFs, produce CSVs). Files the agent downloads are stored against the run's session:
+
+```bash
+curl "https://api.browserbase.com/v1/downloads?sessionId=$SESSION_ID" \
+  --header "x-bb-api-key: $BROWSERBASE_API_KEY"
+```
+
+Limits: no file *upload* to an agent yet; large (>1 MB) or paginated tabular data should flow through downloads, not inline extraction.
+
+## Built-in tools (not configurable yet)
+
+1. **Browser control** — Stagehand-driven; adapts to layout changes, no selectors.
+2. **Web search** — Search/Fetch APIs to find the right starting URL.
+3. **File system** — sandboxed workspace, downloads land in the session.
+4. **Shell** — sandboxed runtime commands when scripting beats browsing.
+
+Custom tools cannot be added and built-ins cannot be disabled in the current version. The agent may skip the browser entirely if search/fetch answers the task.
+
+## Quality metrics (dashboard Agent page)
+
+| Field | Meaning |
+|---|---|
+| `completionRate` | Fraction of runs that completed |
+| `failRate` | Fraction of runs that failed |
+| `timeoutRate` | Fraction of runs that timed out |
+| `averageDuration` | Average run duration (seconds) |
+
+Rising `timeoutRate`/`failRate` → revisit the prompt or use the dashboard Optimize tool.

--- a/skills/browserbase-agents/references/prompt_patterns.md
+++ b/skills/browserbase-agents/references/prompt_patterns.md
@@ -1,0 +1,123 @@
+# Agent Design Patterns: System Prompts & Result Schemas
+
+Field-tested patterns for writing agents that return reliable, structured results. Every pattern below maps to real fields on `POST /agents` (`systemPrompt`, `resultSchema`) and `POST /agents/runs` (`variables`, `browserSettings`).
+
+## The anatomy of a good system prompt
+
+Structure every system prompt in four blocks:
+
+```text
+1. ROLE + SCOPE     "You are an X agent. Given A and B, return C as structured JSON."
+2. INPUTS           List every %variable% with type, format, and default.
+3. PROCEDURE        Numbered steps: where to go, what to apply, what to extract,
+                    what to skip, how to handle blockers.
+4. GUARDRAILS       Read-only rules, honesty rules ("null over invented data"),
+                    and what to do when the task cannot be completed.
+```
+
+### Example skeleton
+
+```text
+You are an <domain> search agent. Search <site> for <thing> matching the query
+with the requested filters applied, then return structured JSON per result.
+
+Inputs (variables):
+- %query% — the search query (required)
+- %price_max% — maximum price in USD (optional)
+- %max_pages% — result pages to scan (default 1, max 3)
+
+Procedure:
+1. Go to <site> and search %query%. If a CAPTCHA or interstitial appears,
+   resolve it and retry.
+2. Apply filters via the UI AND/OR URL parameters — prefer URL params when
+   reliable: <list the site's known params>.
+3. Scan up to %max_pages% pages. For EVERY organic result extract: <fields>.
+4. Skip sponsored placements. Deduplicate by <stable id>.
+5. Record which filters you actually managed to apply in appliedFilters.
+   If a filter option does not exist, note it as null and continue.
+
+Never invent <ids/prices/times> — use null when a field is not on the page.
+```
+
+## Pattern: echo applied state back (`appliedFilters`)
+
+Agents sometimes fail to apply a filter but extract data anyway. Force honesty by requiring an `appliedFilters` object in the schema that echoes what was *actually* applied (not what was requested). This turns silent filter failures into visible, diffable data — compare `appliedFilters` to the run's variables to detect drift automatically.
+
+## Pattern: outcome enums for availability checks
+
+For "is X available?" tasks (reservations, tee times, day passes, stock), a bare slot list is ambiguous — empty could mean sold out, not found, or blocked. Enumerate every distinct failure mode as a schema-level enum so the agent must pick one:
+
+```json
+"outcome": {
+  "type": "string",
+  "enum": ["available", "sold-out", "not-found", "ambiguous-name",
+           "not-bookable-online", "outside-publish-window", "extraction-blocked"]
+}
+```
+
+In the prompt, define each outcome precisely ("'sold-out' means the date is open for booking but every slot is taken; 'outside-publish-window' means the date has not been released yet"). Pair with a `candidates` array so `ambiguous-name` returns the options instead of a guess. Verified in production: an agent asked for a restaurant that wasn't on the platform correctly returned `venue-not-found` with two near-miss candidates instead of hallucinating slots.
+
+## Pattern: null over invented data
+
+End every prompt with a line like: *"Never invent IDs, prices, or times — use null when a field is not present on the page."* Make nullable schema fields explicitly nullable (`"type": ["number", "null"]`) so validation doesn't push the agent to fabricate. An honest partial result beats a complete-looking fake one.
+
+## Pattern: capture load-bearing tokens
+
+When the output feeds a downstream booking/purchase step, name the token explicitly and say where to find it: *"capture the config_id token — this is load-bearing for downstream booking; read it from the slot button's attributes or the API response visible in page state."* If the token can't be extracted, require a note rather than a guess.
+
+## Pattern: read-only guardrails
+
+For research agents that walk checkout/booking flows, state exactly how far to go:
+
+```text
+Read-only: NEVER place an order, submit payment, book, hold, or create an account.
+You may add an item to the cart and proceed ONLY far enough in checkout to reveal
+delivery options and fees, entering the destination but never payment details.
+```
+
+Agents follow this well, but say it twice — once in role/scope, once at the exact step where the temptation occurs.
+
+## Pattern: prefer deep-links and embedded data over UI walking
+
+- **URL parameters beat click sequences**: most sites encode filters in the URL (e.g. `?covers=2&dateTime=2026-07-18T19:00`, price/sort params, slugged filter paths). Name the known params in the prompt.
+- **Server-rendered JSON beats DOM scraping**: many SPAs embed the full result payload in a script tag (`__NEXT_DATA__`, deferred-state blobs). Telling the agent to parse that blob yields more fields, exact IDs, and immunity to layout changes. Verified in production on a major listings site: the agent found the SSR blob and returned exact listing IDs, coordinates, and total counts.
+- **Canonical URL formats**: specify them (`https://site.com/dp/<ID>`) so output URLs are stable and deduplicable.
+
+## Pattern: variables for anything per-run or sensitive
+
+Anything that changes between runs — queries, dates, party sizes, credentials, confirmation codes — belongs in `variables`, not hardcoded in the prompt. Sensitive values passed as variables never sit inline in the task text and are not persisted.
+
+**Known pitfall (observed in production): date/time drift.** Agents sometimes substitute *today's* date instead of the `%date%` variable. Mitigations:
+- Repeat the variable in the task: `"Check availability on %date% (this exact date, not today)"`.
+- Echo the inputs back in the schema (a required `date` field) so drift is detectable.
+- Validate the echoed field against the variable after the run; retry on mismatch.
+
+## Pattern: one abstract agent, many targets
+
+To cover hundreds of portals/sites, write ONE agent whose prompt describes the goal abstractly ("Portals differ in layout. Do not rely on fixed labels; find the billing area by its meaning.") and pass the portal URL + credentials per run. Each run gets its own browser session, so fan-out is parallel up to the account's concurrency limit.
+
+## Pattern: schema design for scale
+
+- Keep schemas as flat as practical; scalar fields are quick to read and diff.
+- For prices, capture display + numeric + currency: `{"display": "$1,395 - $2,210", "value": 1395, "currency": "USD"}` — display preserves ranges, numeric enables math.
+- Include a free-text `notes` or `summary` field so the agent has a sanctioned place for caveats instead of polluting typed fields.
+- Mark truly-required fields `required`; leave the rest optional/nullable.
+- `additionalProperties: false` keeps output tight and catches schema drift.
+
+## Anti-bot & session controls
+
+| Symptom | Fix |
+|---|---|
+| Thin/blocked results on protected sites (PerimeterX, DataDome, Akamai) | `"browserSettings": {"proxies": true, "verified": true}` on the run |
+| Site needs login state across runs | `"browserSettings": {"context": {"id": "...", "persist": true}}` |
+| Geo-dependent content (metro redirects, region pricing) | proxies + instruct the agent to detect and correct the redirect |
+
+Name known challenges in the prompt: *"This site is protected by PerimeterX — if a 'Robot or human?' press-and-hold challenge appears, solve it and continue."*
+
+## Iterating on quality
+
+1. First runs are exploratory — expect wandering; judge the *output*, then optimize the *path*.
+2. Use the dashboard **Optimize** tool on a run (starter prompts: "Make this faster", "What went wrong", "Alternative approaches", "Write a script"). It proposes a `systemPrompt` diff you can edit, apply, and re-run.
+3. Watch `completionRate` / `failRate` / `timeoutRate` / `averageDuration` on the Agent page over time, not single-run impressions.
+4. Common first-run findings, in practice: filters requested but not applied (visible via `appliedFilters`), thin extraction on anti-bot sites (add proxies/verified), and variable drift (add echo-back validation).
+5. When a run reveals the underlying data endpoint (an API the page calls), consider replaying it with the Fetch API for cheap high-frequency polling, and keep the Agent for pages that only render in a browser.

--- a/skills/browserbase-agents/scripts/bb_agents.py
+++ b/skills/browserbase-agents/scripts/bb_agents.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Browserbase Agents API CLI — create agents, trigger runs, poll to completion.
+
+Zero dependencies (Python 3.8+ stdlib only).
+
+Auth: set BROWSERBASE_API_KEY in the environment, or pass --api-key.
+
+Commands:
+  create        Create a reusable agent from a JSON payload file
+  update        Update an existing agent (partial body)
+  run           Trigger a run (against an agent or ad-hoc)
+  get           Fetch a run's status and result
+  poll          Poll a run until it reaches a terminal state
+  messages      Fetch a run's step-by-step transcript
+  list-agents   List agents on the account
+  list-runs     List runs (filter by agent / status)
+  downloads     List files downloaded during a run's session
+  delete        Delete an agent
+
+Examples:
+  bb_agents.py create --file agent.json
+  bb_agents.py run --agent-id <id> --task "Search for %query%" \
+      --var query="wireless earbuds" --var max_pages=1 --proxies
+  bb_agents.py poll <runId>
+  bb_agents.py messages <runId>
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+API = "https://api.browserbase.com/v1"
+TERMINAL = {"COMPLETED", "FAILED", "STOPPED", "TIMED_OUT"}
+
+
+def request(method, path, api_key, body=None, params=None):
+    url = f"{API}{path}"
+    if params:
+        url += "?" + urllib.parse.urlencode({k: v for k, v in params.items() if v})
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode() if body is not None else None,
+        headers={"x-bb-api-key": api_key, "Content-Type": "application/json"},
+        method=method,
+    )
+    try:
+        with urllib.request.urlopen(req) as r:
+            raw = r.read().decode()
+            return json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as e:
+        sys.exit(f"HTTP {e.code} {method} {path}: {e.read().decode()[:1000]}")
+
+
+def parse_vars(pairs):
+    """--var key=value [--var-desc key='hint'] -> variables object."""
+    out = {}
+    for pair in pairs or []:
+        if "=" not in pair:
+            sys.exit(f"--var must be key=value, got: {pair}")
+        k, v = pair.split("=", 1)
+        out[k] = {"value": v}
+    return out
+
+
+def cmd_create(args, key):
+    payload = json.load(open(args.file))
+    agent = request("POST", "/agents", key, body=payload)
+    print(json.dumps(agent, indent=2))
+
+
+def cmd_update(args, key):
+    payload = json.load(open(args.file))
+    agent = request("POST", f"/agents/{args.agent_id}", key, body=payload)
+    print(json.dumps(agent, indent=2))
+
+
+def cmd_run(args, key):
+    body = {"task": args.task}
+    if args.agent_id:
+        body["agentId"] = args.agent_id
+    variables = parse_vars(args.var)
+    if variables:
+        body["variables"] = variables
+    if args.schema_file:
+        body["resultSchema"] = json.load(open(args.schema_file))
+    settings = {}
+    if args.proxies:
+        settings["proxies"] = True
+    if args.verified:
+        settings["verified"] = True
+    if args.context_id:
+        settings["context"] = {"id": args.context_id, "persist": args.persist_context}
+    if settings:
+        body["browserSettings"] = settings
+    run = request("POST", "/agents/runs", key, body=body)
+    print(json.dumps(run, indent=2))
+    if args.wait:
+        poll(run["runId"], key, args.interval, args.timeout)
+
+
+def cmd_get(args, key):
+    print(json.dumps(request("GET", f"/agents/runs/{args.run_id}", key), indent=2))
+
+
+def poll(run_id, key, interval, timeout):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        run = request("GET", f"/agents/runs/{run_id}", key)
+        status = run.get("status")
+        print(f"{time.strftime('%H:%M:%S')} {status}", file=sys.stderr)
+        if status in TERMINAL:
+            print(json.dumps(run, indent=2))
+            return run
+        time.sleep(interval)
+    sys.exit(f"Timed out after {timeout}s waiting for run {run_id}")
+
+
+def cmd_poll(args, key):
+    poll(args.run_id, key, args.interval, args.timeout)
+
+
+def cmd_messages(args, key):
+    params = {"since": args.since} if args.since else None
+    msgs = request("GET", f"/agents/runs/{args.run_id}/messages", key, params=params)
+    print(json.dumps(msgs, indent=2))
+
+
+def cmd_list_agents(args, key):
+    print(json.dumps(request("GET", "/agents", key, params={"cursor": args.cursor}), indent=2))
+
+
+def cmd_list_runs(args, key):
+    params = {"agentId": args.agent_id, "status": args.status,
+              "limit": args.limit, "cursor": args.cursor}
+    print(json.dumps(request("GET", "/agents/runs", key, params=params), indent=2))
+
+
+def cmd_downloads(args, key):
+    print(json.dumps(request("GET", "/downloads", key, params={"sessionId": args.session_id}), indent=2))
+
+
+def cmd_delete(args, key):
+    request("DELETE", f"/agents/{args.agent_id}", key)
+    print(f"Deleted agent {args.agent_id}")
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--api-key", default=os.environ.get("BROWSERBASE_API_KEY"))
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    s = sub.add_parser("create", help="Create an agent from a JSON payload file")
+    s.add_argument("--file", required=True, help="JSON file: {name, systemPrompt, resultSchema}")
+    s.set_defaults(fn=cmd_create)
+
+    s = sub.add_parser("update", help="Update an agent (partial body)")
+    s.add_argument("agent_id")
+    s.add_argument("--file", required=True)
+    s.set_defaults(fn=cmd_update)
+
+    s = sub.add_parser("run", help="Trigger a run")
+    s.add_argument("--agent-id", help="Omit for an ad-hoc run")
+    s.add_argument("--task", required=True)
+    s.add_argument("--var", action="append", help="key=value, repeatable; referenced as %%key%% in prompts")
+    s.add_argument("--schema-file", help="Per-run resultSchema override (JSON file)")
+    s.add_argument("--proxies", action="store_true")
+    s.add_argument("--verified", action="store_true")
+    s.add_argument("--context-id")
+    s.add_argument("--persist-context", action="store_true")
+    s.add_argument("--wait", action="store_true", help="Poll to completion after starting")
+    s.add_argument("--interval", type=int, default=10)
+    s.add_argument("--timeout", type=int, default=1800)
+    s.set_defaults(fn=cmd_run)
+
+    s = sub.add_parser("get", help="Fetch a run")
+    s.add_argument("run_id")
+    s.set_defaults(fn=cmd_get)
+
+    s = sub.add_parser("poll", help="Poll a run until terminal")
+    s.add_argument("run_id")
+    s.add_argument("--interval", type=int, default=10)
+    s.add_argument("--timeout", type=int, default=1800)
+    s.set_defaults(fn=cmd_poll)
+
+    s = sub.add_parser("messages", help="Fetch run transcript")
+    s.add_argument("run_id")
+    s.add_argument("--since", help="Message ID cursor (nextSince from previous call)")
+    s.set_defaults(fn=cmd_messages)
+
+    s = sub.add_parser("list-agents")
+    s.add_argument("--cursor")
+    s.set_defaults(fn=cmd_list_agents)
+
+    s = sub.add_parser("list-runs")
+    s.add_argument("--agent-id")
+    s.add_argument("--status", choices=sorted(TERMINAL | {"PENDING", "RUNNING"}))
+    s.add_argument("--limit", type=int, default=20)
+    s.add_argument("--cursor")
+    s.set_defaults(fn=cmd_list_runs)
+
+    s = sub.add_parser("downloads", help="List files from a run's session")
+    s.add_argument("session_id")
+    s.set_defaults(fn=cmd_downloads)
+
+    s = sub.add_parser("delete", help="Delete an agent")
+    s.add_argument("agent_id")
+    s.set_defaults(fn=cmd_delete)
+
+    args = p.parse_args()
+    if not args.api_key:
+        sys.exit("Set BROWSERBASE_API_KEY or pass --api-key")
+    args.fn(args, args.api_key)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/design-system/LICENSE.txt
+++ b/skills/design-system/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Browserbase, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/design-system/SKILL.md
+++ b/skills/design-system/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: design-system
+license: MIT
+compatibility: "Requires the browse CLI (`npm install -g browse`) and a Browserbase account (BROWSERBASE_API_KEY, BROWSERBASE_PROJECT_ID)."
+allowed-tools: Bash, Read, Write
+description: Agent-driven design-system snapshot of any website — colors, typography, tokens, components with screenshots, full HTML — using the browse CLI on a Browserbase cloud browser. Use when the user wants to "snapshot" a site's design system, pull brand colors/fonts from a URL, or import an existing site's look into a design canvas. Triggers on "snapshot <url>", "extract the design system from <url>", "pull the brand styles of <site>".
+---
+
+# Design System Snapshot (agent-driven)
+
+You (the agent) explore the site and decide what matters. Deterministic code exists
+only as a *measurement probe* you can invoke — it measures, it never decides.
+Navigation, overlay dismissal, component selection, logo choice, and semantic naming
+are your judgment calls, made by looking at screenshots and the page.
+
+## Primitives (browse CLI)
+
+```bash
+browse open <url> --remote        # Browserbase cloud session (--local for dev)
+browse screenshot -p <path>       # look at the page (add --full-page or --clip x,y,w,h)
+browse snapshot                   # a11y tree with refs for clicking
+browse click <ref|selector>       # interact
+browse eval '<js expression>'     # ground truth from the live page
+browse wait --timeout <ms>        # settle
+browse stop                       # end session
+```
+
+## Workflow
+
+1. **Open and look.** `browse open <url> --remote`, wait for load, screenshot, Read it.
+   Everything downstream depends on you actually looking at the page.
+
+2. **Clear the way.** Cookie walls, newsletter modals, region pickers — find the
+   dismiss/accept control (`browse snapshot`, then `browse click`) and confirm with
+   another screenshot. Don't capture anything while an overlay is up.
+
+3. **Trigger lazy content.** Scroll through the full page, then back to top:
+   ```bash
+   browse eval '(async () => { const s = innerHeight, m = document.documentElement.scrollHeight; for (let y = 0; y < m; y += s) { scrollTo(0, y); await new Promise(r => setTimeout(r, 150)); } scrollTo(0, 0); return m; })()'
+   ```
+
+4. **Measure.** Two deterministic probes:
+   ```bash
+   browse eval "$(cat scripts/harvest-styles.js)"      # colors, type scale, buttons, @font-face, tokens, logo candidates
+   browse eval "$(cat scripts/harvest-structure.js)"   # breakpoints, grid/containers, hover/focus states, motion, icons, contrast
+   ```
+   Re-run the structure probe at tablet and mobile widths to capture the responsive
+   system: `browse viewport 768 900`, wait ~1s, probe; same at `390`. Restore the
+   desktop viewport after. Hex values in your output must come from probes (or your
+   own `browse eval`) — never from reading pixels off a screenshot.
+
+   **Theming across sub-pages** (pillar/section/category colors): visit each key
+   sub-page and frequency-rank its non-neutral computed colors, excluding the
+   universal brand colors — the per-section accent is what remains. Verify sub-page
+   URLs load real pages (check `document.title`), not 404s.
+
+5. **Explore — your judgment.** What the probe can't know:
+   - Open the nav menu / a dropdown and capture its style if it looks distinctive.
+   - If the site has a dark/light toggle, consider capturing both.
+   - If fonts or colors resolve through aliases (e.g. `bodyFont`), map them to real
+     families via the `fontFaces` inventory.
+   - Pick the real logo from `logoCandidates` by looking, not by selector order.
+   - A pricing or product page often has richer components (cards, tables, forms)
+     than the homepage — grab one if it earns its place.
+
+6. **Capture components.** Decide which sections a designer would want on a canvas
+   (header, hero, feature sections, cards, footer — whatever this site actually has).
+   For each: get its rect via `browse eval`, then
+   `browse screenshot --clip x,y,w,h -p <outdir>/components/NN-<name>.png`,
+   and store its outerHTML (via eval) in `components/components.json`.
+   Also: `browse screenshot --full-page -p <outdir>/page-full.png`.
+
+7. **Save the page.** `browse eval 'document.documentElement.outerHTML'` → `page.html`.
+
+8. **Synthesize `design-system.json`.** Three strictly-separated tiers:
+   - `measured` — probe output verbatim: styles, structure (breakpoints,
+     per-viewport layout, states, motion, iconography, contrast), component
+     samples, sub-page theming.
+   - `proposedTokens` / `proposedComponents` — your semantic interpretation under
+     a `_status: INFERRED` banner.
+   - `notProvided` — name what a real design system would add that isn't on the
+     page (formal a11y requirements, motion principles, component APIs). Never
+     fabricate these.
+
+   Normalization rules for the proposal tier:
+   - **Evidence is machine-linked**: every token/contract carries `evidenceRefs` —
+     JSON paths into `measured` (e.g. `componentSamples.interactives[2]`) — not prose.
+   - **Type tokens are semantic roles**, not raw combos: `headline.lead/.card/.compact`,
+     `title.section`, `body.standfirst`, `label.kicker`, `label.badge`, `metadata` —
+     mapped from structural context (run `scripts/harvest-components.js`).
+   - **Classify buttons by role before naming one "primary"**: an element with a
+     `Move/Next/Previous` aria-label and no text is a carousel control, not a CTA.
+     The real CTA usually has text, a distinct background, and appears in the header.
+   - **Grid**: if you measure both a many-track named-line grid and a simpler one,
+     report the former as the implementation grid and the latter as the recommended
+     abstraction — never silently pick one.
+   - **Breakpoints**: name them small/medium/large/wide/maximum, and note that base
+     styles apply below the first breakpoint (mobile-first) — don't call a
+     breakpoint "mobile".
+   - **Radii**: classify every measured value (pill/circle/media) or list it under
+     `rejected` with a reason — no silent drops.
+
+## Output contract
+
+```
+snapshots/<hostname>/
+  design-system.json      # measurements + your semantic interpretation
+  page.html               # full rendered DOM
+  page-full.png           # full-page screenshot
+  components/
+    components.json       # per-component: name, rect, outerHTML, screenshot
+    NN-<name>.png         # one crop per component
+```
+
+## Quality bar
+
+- Every hex value traceable to a computed style, not vision.
+- No overlay in any captured screenshot.
+- Every major visible section captured as a component.
+- Note in `design-system.json` anything you skipped or couldn't verify
+  (`"notes"` field) — silent gaps read as coverage.
+
+## Gotchas
+
+- Env: needs `BROWSERBASE_API_KEY` and `BROWSERBASE_PROJECT_ID` exported before
+  `browse open --remote` will work.
+- `browse eval` returns the expression's value; async IIFEs are awaited.
+- `--clip` is in **page coordinates**, but off-screen content renders blank —
+  scroll the section into view first (`scrollTo(0, y-200)`, wait ~800ms), then
+  clip at the section's page-y. A tiny/uniform PNG (<10KB for a big region) means
+  you captured blank — look at every capture, never trust file creation alone.
+- Sections taller than the viewport, or with scroll-reveal animations, come out
+  half-dark: enlarge the viewport first (`browse viewport 1280 2600`) so the whole
+  section fits, pre-scroll the page to fire the reveal animations, and pass
+  `--animations disabled` when clipping.
+- `-p` screenshot paths resolve relative to the daemon's cwd, not your shell's —
+  always pass absolute paths.
+- Sessions expire when idle. If commands time out, `browse stop -s <name>` and
+  reopen; re-derive section rects on the fresh page (layouts shift between loads).
+- Some sites legitimately have zero CSS variables (next/font aliasing) — the
+  `fontFaces` inventory is the source of truth there.
+- CSS-in-JS sites (emotion etc.) hide `:hover`/`:focus` rules from the CSSOM walk
+  (nested rules); the structure probe falls back to parsing raw `<style>` text.
+  If a probe section comes back empty on a site that visibly has that behavior,
+  distrust the probe before concluding the site lacks it.
+- Consent iframes (e.g. Sourcepoint on news sites) render in a child frame and
+  don't appear in `browse snapshot`. Find the iframe rect via eval, zoom into its
+  corner with a small `--clip` screenshot to locate the exact button, then
+  `browse mouse click x y`. Verify dismissal by checking the iframe is gone.

--- a/skills/design-system/evals/evals.json
+++ b/skills/design-system/evals/evals.json
@@ -1,0 +1,18 @@
+[
+  {
+    "prompt": "Extract the design system from https://stripe.com",
+    "expected_behavior": "Opens a Browserbase remote session via browse CLI, looks at a screenshot before acting, dismisses any consent overlay, runs the three measurement probes (styles, structure at 3 viewport widths, components), captures per-section screenshots after scrolling each into view, and writes design-system.json with strictly separated measured / proposedTokens / notProvided tiers where every proposed token carries evidenceRefs JSON paths."
+  },
+  {
+    "prompt": "Snapshot the brand styles of a news site with editorial sections that have different accent colors",
+    "expected_behavior": "In addition to the base flow, visits each section front, verifies the page loaded (document.title, not a 404), frequency-ranks non-neutral computed colors per section, and proposes per-section accent tokens (e.g. pillar.news) with occurrence counts as evidence."
+  },
+  {
+    "prompt": "Why does the design system you extracted say the primary button is a carousel arrow?",
+    "expected_behavior": "Recognizes the misclassification pattern: an element with a Move/Next/Previous aria-label and no text is a carousel control, not a CTA. Re-classifies using the component probe's accessible-name data and points the CTA token at an element with text and a distinct background."
+  },
+  {
+    "prompt": "The component screenshots came out blank or half-dark",
+    "expected_behavior": "Diagnoses page-coordinate clips of unrendered off-screen content: scrolls each section into view first, enlarges the viewport so tall sections fit, passes --animations disabled, and visually verifies every capture instead of trusting file creation."
+  }
+]

--- a/skills/design-system/scripts/harvest-components.js
+++ b/skills/design-system/scripts/harvest-components.js
@@ -1,0 +1,117 @@
+// Component-contract probe — run via: browse eval "$(cat probes/harvest-components.js)"
+// Measures role-classifiable component ingredients: every interactive element with
+// its accessible name (so carousel arrows are distinguishable from CTAs), named
+// regions, section titles, repeated labels (kickers/badges), and typography by
+// structural context. Returns a JSON string.
+(() => {
+  const toHex = (css) => {
+    const m = css.match(/rgba?\((\d+)[,\s]+(\d+)[,\s]+(\d+)(?:[,\s/]+([\d.]+))?/);
+    if (!m) return null;
+    if (m[4] !== undefined && parseFloat(m[4]) === 0) return null;
+    return '#' + [m[1], m[2], m[3]].map(v => (+v).toString(16).padStart(2, '0')).join('');
+  };
+  const vis = (el) => { const r = el.getBoundingClientRect(); return r.width > 0 && r.height > 0; };
+  const styleOf = (el) => {
+    const s = getComputedStyle(el);
+    return {
+      background: toHex(s.backgroundColor) || 'transparent',
+      color: toHex(s.color) || s.color,
+      fontFamily: s.fontFamily.split(',')[0].trim().replace(/["']/g, ''),
+      fontSize: s.fontSize, fontWeight: s.fontWeight, lineHeight: s.lineHeight,
+      borderRadius: s.borderRadius, padding: s.padding,
+      border: s.borderTopWidth !== '0px' ? `${s.borderTopWidth} solid ${toHex(s.borderTopColor) || ''}` : 'none',
+    };
+  };
+
+  // ---------- interactive elements with accessible names ----------
+  const interactives = [];
+  for (const el of [...document.querySelectorAll('a, button, [role="button"], input[type="submit"]')].slice(0, 400)) {
+    if (!vis(el) || interactives.length >= 80) continue;
+    const r = el.getBoundingClientRect();
+    const text = el.textContent.trim().replace(/\s+/g, ' ').slice(0, 50);
+    const aria = el.getAttribute('aria-label') || el.getAttribute('title') || '';
+    const s = styleOf(el);
+    // keep only elements that look styled (bg, border, or radius) OR have aria/text
+    if (s.background === 'transparent' && s.border === 'none' && s.borderRadius === '0px' && !aria) continue;
+    interactives.push({
+      tag: el.tagName.toLowerCase(),
+      text: text || null, ariaLabel: aria || null,
+      hasOnlySvg: !text && !!el.querySelector('svg'),
+      rect: { w: Math.round(r.width), h: Math.round(r.height) },
+      ...s,
+    });
+  }
+
+  // ---------- named regions ----------
+  const regions = {};
+  for (const [name, sel] of [['header', 'header'], ['nav', 'nav'], ['footer', 'footer']]) {
+    const els = [...document.querySelectorAll(sel)].filter(vis);
+    const el = els.sort((a, b) => (b.getBoundingClientRect().width * b.getBoundingClientRect().height) -
+                                   (a.getBoundingClientRect().width * a.getBoundingClientRect().height))[0];
+    if (!el) continue;
+    const r = el.getBoundingClientRect();
+    const link = el.querySelector('a');
+    regions[name] = {
+      rect: { y: Math.round(r.top + scrollY), w: Math.round(r.width), h: Math.round(r.height) },
+      ...styleOf(el),
+      linkStyle: link ? styleOf(link) : null,
+    };
+  }
+
+  // ---------- section titles (repeated h2-level headings) ----------
+  const titleGroups = new Map();
+  for (const el of [...document.querySelectorAll('main h2, section > h2, [class*="section" i] h2')].slice(0, 60)) {
+    if (!vis(el)) continue;
+    const s = styleOf(el);
+    const key = `${s.fontFamily}|${s.fontSize}|${s.fontWeight}|${s.color}`;
+    if (!titleGroups.has(key)) titleGroups.set(key, { ...s, samples: [], count: 0 });
+    const g = titleGroups.get(key);
+    g.count++;
+    if (g.samples.length < 3) g.samples.push(el.textContent.trim().slice(0, 40));
+  }
+
+  // ---------- repeated small labels: kickers, badges, tags ----------
+  const labelGroups = new Map();
+  for (const el of [...document.querySelectorAll('main span, main div, main b, main strong')].slice(0, 3000)) {
+    const t = el.textContent.trim();
+    if (!t || t.length > 28 || el.children.length > 1) continue;
+    if (!vis(el)) continue;
+    const s = getComputedStyle(el);
+    const fs = parseFloat(s.fontSize);
+    if (fs > 18) continue;
+    const color = toHex(s.color), bg = toHex(s.backgroundColor);
+    const bold = parseInt(s.fontWeight) >= 600;
+    const NEUTRAL = /^#(ffffff|000000|121212|1a1a1a|333333|545454|707070)/;
+    const colored = (color && !NEUTRAL.test(color)) || (bg && !NEUTRAL.test(bg));
+    if (!bold && !colored) continue;
+    const key = `${color}|${bg}|${s.fontSize}|${s.fontWeight}|${s.textTransform}`;
+    if (!labelGroups.has(key)) {
+      labelGroups.set(key, { color, background: bg, fontSize: s.fontSize, fontWeight: s.fontWeight,
+        textTransform: s.textTransform, borderRadius: s.borderRadius, samples: [], count: 0 });
+    }
+    const g = labelGroups.get(key);
+    g.count++;
+    if (g.samples.length < 4 && !g.samples.includes(t)) g.samples.push(t);
+  }
+
+  // ---------- typography by structural context ----------
+  const typeRoles = {};
+  const sample = (name, sel) => {
+    const el = [...document.querySelectorAll(sel)].find(vis);
+    if (el) typeRoles[name] = { ...styleOf(el), sample: el.textContent.trim().slice(0, 60), selector: sel };
+  };
+  sample('headline.lead', 'main h1, main section:first-of-type h2 a, main h3 a');
+  sample('headline.card', 'main li h3, main [class*="card" i] h3, main ul h2');
+  sample('body.standfirst', 'main h1 ~ p, main [class*="standfirst" i], main [class*="trail" i] p');
+  sample('body.paragraph', 'main p');
+  sample('metadata.time', 'main time, [datetime]');
+  sample('label.sectionLink', 'nav a, header nav a');
+
+  return JSON.stringify({
+    interactives,
+    regions,
+    sectionTitles: [...titleGroups.values()].sort((a, b) => b.count - a.count).slice(0, 6),
+    labels: [...labelGroups.values()].sort((a, b) => b.count - a.count).slice(0, 12),
+    typeRoles,
+  });
+})()

--- a/skills/design-system/scripts/harvest-structure.js
+++ b/skills/design-system/scripts/harvest-structure.js
@@ -1,0 +1,196 @@
+// Structure probe — run via: browse eval "$(cat probes/harvest-structure.js)"
+// Measures layout system, breakpoints, interaction states, motion, iconography,
+// and contrast. Complements harvest-styles.js. Returns a JSON string.
+(() => {
+  const topEntries = (map, n) =>
+    [...map.entries()].sort((a, b) => b[1] - a[1]).slice(0, n)
+      .map(([value, count]) => ({ value, count }));
+  const bump = (map, key, w = 1) => { if (key) map.set(key, (map.get(key) || 0) + w); };
+
+  // ---------- stylesheet walk: breakpoints, state rules, keyframes ----------
+  const mediaConditions = new Map();
+  const stateRules = [];
+  const keyframes = [];
+  let reducedMotionHandled = false;
+  let ruleBudget = 40000;
+  const STATE_PROPS = ['background-color', 'color', 'border-color', 'box-shadow', 'outline',
+    'outline-offset', 'text-decoration', 'transform', 'opacity', 'filter', 'text-decoration-line'];
+  const walk = (rules, mediaCtx) => {
+    for (const rule of rules) {
+      if (ruleBudget-- <= 0) return;
+      if (rule instanceof CSSMediaRule) {
+        const cond = rule.conditionText || rule.media.mediaText;
+        bump(mediaConditions, cond);
+        if (/prefers-reduced-motion/.test(cond)) reducedMotionHandled = true;
+        walk(rule.cssRules, cond);
+        continue;
+      }
+      if (rule instanceof CSSKeyframesRule) {
+        if (keyframes.length < 30) keyframes.push(rule.name);
+        continue;
+      }
+      if (rule.cssRules) { walk(rule.cssRules, mediaCtx); continue; }
+      if (!rule.selectorText || !rule.style) continue;
+      if (/:(hover|focus|focus-visible|focus-within|active|disabled)\b/.test(rule.selectorText)) {
+        if (stateRules.length >= 120) continue;
+        const props = {};
+        for (const p of STATE_PROPS) {
+          const v = rule.style.getPropertyValue(p);
+          if (v) props[p] = v;
+        }
+        if (Object.keys(props).length) {
+          stateRules.push({ selector: rule.selectorText.slice(0, 120), media: mediaCtx || null, props });
+        }
+      }
+    }
+  };
+  for (const sheet of document.styleSheets) {
+    try { if (sheet.cssRules) walk(sheet.cssRules, null); } catch {}
+  }
+
+  // parse px breakpoints out of media conditions
+  const bpCounts = new Map();
+  for (const [cond, count] of mediaConditions) {
+    for (const m of cond.matchAll(/(min|max)-width:\s*([\d.]+)(px|em|rem)/g)) {
+      let px = parseFloat(m[2]);
+      if (m[3] !== 'px') px = px * 16;
+      bump(bpCounts, `${Math.round(px)}px (${m[1]})`, count);
+    }
+  }
+
+  // ---------- layout: containers, grids, gaps ----------
+  const maxWidths = new Map(), gridTemplates = new Map(), gaps = new Map(), displays = new Map();
+  const els = [...document.querySelectorAll('body *')].slice(0, 5000);
+  for (const el of els) {
+    const r = el.getBoundingClientRect();
+    if (r.width === 0 || r.height === 0) continue;
+    const s = getComputedStyle(el);
+    if (s.maxWidth && s.maxWidth !== 'none' && s.maxWidth.endsWith('px') && r.width > 400) {
+      bump(maxWidths, s.maxWidth);
+    }
+    if (s.display === 'grid') {
+      bump(displays, 'grid');
+      const cols = s.gridTemplateColumns.split(' ').length;
+      if (cols > 1) bump(gridTemplates, `${cols} cols (${s.gridTemplateColumns.slice(0, 80)})`);
+      if (s.gap && s.gap !== 'normal') bump(gaps, s.gap);
+    } else if (s.display === 'flex') {
+      bump(displays, 'flex');
+      if (s.gap && s.gap !== 'normal' && s.gap !== '0px') bump(gaps, s.gap);
+    }
+  }
+
+  // ---------- motion: computed transitions ----------
+  const durations = new Map(), easings = new Map();
+  for (const el of els.slice(0, 2500)) {
+    const s = getComputedStyle(el);
+    if (s.transitionDuration && s.transitionDuration !== '0s') {
+      for (const d of s.transitionDuration.split(', ')) bump(durations, d);
+      for (const e of s.transitionTimingFunction.split(', ')) bump(easings, e);
+    }
+  }
+
+  // ---------- iconography: inline SVGs ----------
+  const iconSizes = new Map(), strokeWidths = new Map();
+  let currentColorCount = 0, svgCount = 0;
+  for (const svg of [...document.querySelectorAll('svg')].slice(0, 200)) {
+    const r = svg.getBoundingClientRect();
+    if (r.width === 0 || r.width > 100) continue; // icons, not illustrations/logos
+    svgCount++;
+    bump(iconSizes, `${Math.round(r.width)}x${Math.round(r.height)}`);
+    const sw = svg.getAttribute('stroke-width') || svg.querySelector('[stroke-width]')?.getAttribute('stroke-width');
+    if (sw) bump(strokeWidths, sw);
+    const markup = svg.outerHTML.slice(0, 500);
+    if (/currentColor/.test(markup)) currentColorCount++;
+  }
+
+  // ---------- contrast (WCAG) for key pairs ----------
+  const lum = (hex) => {
+    const c = [1, 3, 5].map(i => parseInt(hex.slice(i, i + 2), 16) / 255)
+      .map(v => v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4));
+    return 0.2126 * c[0] + 0.7152 * c[1] + 0.0722 * c[2];
+  };
+  const ratio = (a, b) => {
+    const [l1, l2] = [lum(a), lum(b)].sort((x, y) => y - x);
+    return Math.round(((l1 + 0.05) / (l2 + 0.05)) * 100) / 100;
+  };
+  const toHexQuick = (css) => {
+    const m = css.match(/rgba?\((\d+)[,\s]+(\d+)[,\s]+(\d+)/);
+    return m ? '#' + [m[1], m[2], m[3]].map(v => (+v).toString(16).padStart(2, '0')).join('') : null;
+  };
+  const contrastChecks = [];
+  const seenPairs = new Set();
+  const sampleEls = [document.querySelector('h1'), document.querySelector('p'),
+    ...[...document.querySelectorAll('button, a[class*="btn" i]')].slice(0, 10)].filter(Boolean);
+  for (const el of sampleEls) {
+    const s = getComputedStyle(el);
+    const fg = toHexQuick(s.color);
+    let bgEl = el, bg = null;
+    while (bgEl && !bg) {
+      const bs = getComputedStyle(bgEl);
+      if (bs.backgroundColor && !/rgba?\(\d+[,\s]+\d+[,\s]+\d+[,\s]+0\)/.test(bs.backgroundColor) && bs.backgroundColor !== 'transparent') {
+        bg = toHexQuick(bs.backgroundColor);
+      }
+      bgEl = bgEl.parentElement;
+    }
+    if (fg && bg && fg !== bg) {
+      const key = fg + bg;
+      if (seenPairs.has(key)) continue;
+      seenPairs.add(key);
+      const rt = ratio(fg, bg);
+      contrastChecks.push({
+        element: el.tagName.toLowerCase() + (el.className && typeof el.className === 'string' ? '.' + el.className.split(/\s+/)[0] : ''),
+        fg, bg, ratio: rt,
+        passesAA: rt >= 4.5, passesAALarge: rt >= 3,
+      });
+    }
+  }
+
+  // fallback: CSS-in-JS sites often use nested rules the CSSOM walk misses —
+  // parse raw <style> text when the object-model walk found nothing
+  if (stateRules.length === 0) {
+    const css = [...document.querySelectorAll('style')].map(s => s.textContent).join('\n');
+    for (const m of css.matchAll(/([^{}]{1,100}):(hover|focus|focus-visible|active)([^{},]{0,60})\{([^{}]{1,250})\}/g)) {
+      if (stateRules.length >= 60) break;
+      const props = m[4].trim();
+      if (/color|decoration|background|opacity|border|outline|transform|shadow/.test(props)) {
+        stateRules.push({
+          selector: (m[1].trim().split(',').pop() + ':' + m[2] + m[3]).slice(-100),
+          media: null, props: { raw: props.slice(0, 200) }, source: 'text-parse',
+        });
+      }
+    }
+  }
+
+  // focus ring style
+  const focusRules = stateRules.filter(r => /:focus/.test(r.selector) &&
+    (r.props['outline'] || r.props['box-shadow'] || /outline|shadow/.test(r.props.raw || '')));
+
+  return JSON.stringify({
+    viewport: { width: innerWidth, height: innerHeight },
+    breakpoints: topEntries(bpCounts, 12),
+    mediaConditionsTop: topEntries(mediaConditions, 10),
+    layout: {
+      containerMaxWidths: topEntries(maxWidths, 6),
+      gridTemplates: topEntries(gridTemplates, 8),
+      gaps: topEntries(gaps, 10),
+      displayCounts: topEntries(displays, 2),
+    },
+    states: {
+      rules: stateRules.slice(0, 60),
+      focusRingExamples: focusRules.slice(0, 5),
+    },
+    motion: {
+      transitionDurations: topEntries(durations, 8),
+      easings: topEntries(easings, 6),
+      keyframes: keyframes,
+      reducedMotionHandled,
+    },
+    iconography: {
+      inlineSvgCount: svgCount,
+      commonSizes: topEntries(iconSizes, 6),
+      strokeWidths: topEntries(strokeWidths, 4),
+      currentColorRatio: svgCount ? Math.round((currentColorCount / svgCount) * 100) / 100 : null,
+    },
+    contrastChecks,
+  });
+})()

--- a/skills/design-system/scripts/harvest-styles.js
+++ b/skills/design-system/scripts/harvest-styles.js
@@ -1,0 +1,195 @@
+// Measurement probe — run via: browse eval "$(cat probes/harvest-styles.js)"
+// Deterministic bulk harvest of computed styles. It MEASURES; it does not decide.
+// Component selection, logo choice, semantic naming, and navigation are the
+// agent's job. Returns a JSON string.
+(() => {
+  const MAX_ELEMENTS = 5000;
+
+  const _cvs = document.createElement('canvas');
+  _cvs.width = _cvs.height = 1;
+  const _ctx = _cvs.getContext('2d', { willReadFrequently: true });
+  const _colorCache = new Map();
+  // canvas normalizes ANY css color (rgb, lab, oklch, color()...) to RGBA
+  const toHex = (cssColor) => {
+    if (!cssColor || cssColor === 'transparent') return null;
+    if (_colorCache.has(cssColor)) return _colorCache.get(cssColor);
+    let out = null;
+    const m = cssColor.match(/^rgba?\(([\d.]+)[,\s]+([\d.]+)[,\s]+([\d.]+)(?:[,\s/]+([\d.]+%?))?\)$/);
+    if (m) {
+      const [r, g, b] = [m[1], m[2], m[3]].map(v => Math.round(parseFloat(v)));
+      let a = m[4] === undefined ? 1 : parseFloat(m[4]);
+      if (m[4] && m[4].endsWith('%')) a = a / 100;
+      if (a > 0) out = '#' + [r, g, b].map(v => v.toString(16).padStart(2, '0')).join('');
+    } else {
+      _ctx.clearRect(0, 0, 1, 1);
+      _ctx.fillStyle = cssColor;
+      _ctx.fillRect(0, 0, 1, 1);
+      const [r, g, b, a255] = _ctx.getImageData(0, 0, 1, 1).data;
+      if (a255 > 0) out = '#' + [r, g, b].map(v => v.toString(16).padStart(2, '0')).join('');
+    }
+    _colorCache.set(cssColor, out);
+    return out;
+  };
+
+  const isVisible = (el) => {
+    const r = el.getBoundingClientRect();
+    return r.width > 0 && r.height > 0;
+  };
+  const bump = (map, key, weight = 1) => { if (key) map.set(key, (map.get(key) || 0) + weight); };
+  const topEntries = (map, n) =>
+    [...map.entries()].sort((a, b) => b[1] - a[1]).slice(0, n)
+      .map(([value, count]) => ({ value, count: Math.round(count) }));
+
+  // CSS custom properties + @font-face, recursive through @media/@layer/@supports
+  const cssVariables = {};
+  const fontFaces = [];
+  const stylesheets = [];
+  let ruleBudget = 30000;
+  const walkRules = (rules) => {
+    for (const rule of rules) {
+      if (ruleBudget-- <= 0) return;
+      if (rule.cssRules) { walkRules(rule.cssRules); continue; }
+      if (rule instanceof CSSFontFaceRule) {
+        fontFaces.push({
+          family: rule.style.getPropertyValue('font-family').replace(/["']/g, '').trim(),
+          weight: rule.style.getPropertyValue('font-weight') || null,
+          style: rule.style.getPropertyValue('font-style') || null,
+          src: (rule.style.getPropertyValue('src').match(/url\(["']?([^"')]+)["']?\)/) || [])[1] || null,
+        });
+        continue;
+      }
+      if (!rule.style) continue;
+      for (const prop of rule.style) {
+        if (prop.startsWith('--')) cssVariables[prop] = rule.style.getPropertyValue(prop).trim();
+      }
+    }
+  };
+  for (const sheet of document.styleSheets) {
+    if (sheet.href) stylesheets.push(sheet.href);
+    try { if (sheet.cssRules) walkRules(sheet.cssRules); } catch {} // cross-origin
+  }
+
+  const bgColors = new Map(), textColors = new Map(), borderColors = new Map();
+  const fontFamilies = new Map(), radii = new Map(), shadows = new Map();
+  const typeScale = new Map(), spacing = new Map(), bgImages = new Map();
+
+  for (const el of [...document.querySelectorAll('body *')].slice(0, MAX_ELEMENTS)) {
+    if (!isVisible(el)) continue;
+    const s = getComputedStyle(el);
+    const rect = el.getBoundingClientRect();
+    const area = Math.min(rect.width * rect.height, 500000);
+
+    const bg = toHex(s.backgroundColor);
+    if (bg) bump(bgColors, bg, Math.sqrt(area));
+    if (s.backgroundImage && s.backgroundImage !== 'none') {
+      const u = (s.backgroundImage.match(/url\(["']?([^"')]+)["']?\)/) || [])[1];
+      if (u && !u.startsWith('data:')) bump(bgImages, u);
+    }
+    const hasText = [...el.childNodes].some(n => n.nodeType === 3 && n.textContent.trim());
+    if (hasText) {
+      const fg = toHex(s.color);
+      if (fg) bump(textColors, fg, el.textContent.trim().length);
+      const fam = s.fontFamily.split(',')[0].trim().replace(/["']/g, '');
+      bump(fontFamilies, fam);
+      bump(typeScale, `${fam} ${s.fontSize}/${s.lineHeight} w${s.fontWeight}`);
+    }
+    for (const v of [s.paddingTop, s.paddingBottom, s.paddingLeft, s.paddingRight,
+                     s.marginTop, s.marginBottom, s.rowGap, s.columnGap]) {
+      if (v && v !== '0px' && v !== 'normal' && v.endsWith('px')) bump(spacing, v);
+    }
+    if (s.borderTopWidth !== '0px') { const bc = toHex(s.borderTopColor); if (bc) bump(borderColors, bc); }
+    if (s.borderRadius && s.borderRadius !== '0px') bump(radii, s.borderRadius);
+    if (s.boxShadow && s.boxShadow !== 'none') bump(shadows, s.boxShadow);
+  }
+
+  const typography = {};
+  for (const tag of ['h1', 'h2', 'h3', 'h4', 'p', 'a']) {
+    const el = [...document.querySelectorAll(tag)].find(isVisible);
+    if (!el) continue;
+    const s = getComputedStyle(el);
+    typography[tag] = {
+      fontFamily: s.fontFamily.split(',')[0].trim().replace(/["']/g, ''),
+      fontSize: s.fontSize, fontWeight: s.fontWeight, lineHeight: s.lineHeight,
+      letterSpacing: s.letterSpacing, color: toHex(s.color) || s.color,
+    };
+  }
+
+  const buttonStyles = new Map();
+  for (const el of [...document.querySelectorAll(
+    'button, [role="button"], a[class*="btn" i], a[class*="button" i], input[type="submit"]'
+  )].filter(isVisible).slice(0, 40)) {
+    const s = getComputedStyle(el);
+    const key = JSON.stringify({
+      background: toHex(s.backgroundColor) || 'transparent',
+      color: toHex(s.color) || s.color,
+      borderRadius: s.borderRadius, fontSize: s.fontSize, fontWeight: s.fontWeight,
+      padding: s.padding,
+      border: s.borderTopWidth !== '0px' ? `${s.borderTopWidth} solid ${toHex(s.borderTopColor) || ''}` : 'none',
+    });
+    if (!buttonStyles.has(key)) {
+      buttonStyles.set(key, { ...JSON.parse(key), sampleText: el.textContent.trim().slice(0, 40), count: 0, html: el.outerHTML.slice(0, 2000) });
+    }
+    buttonStyles.get(key).count++;
+  }
+
+  // logo CANDIDATES only — the agent looks at them and picks
+  const logoCandidates = [];
+  for (const sel of [
+    'header a[href="/"] svg', 'nav a[href="/"] svg', 'header a[href="/"] img', 'nav a[href="/"] img',
+    'header [class*="logo" i] svg', 'header [class*="logo" i] img',
+    'header img[src*="logo" i]', 'header svg', '[class*="logo" i] svg', 'img[alt*="logo" i]',
+  ]) {
+    const el = document.querySelector(sel);
+    if (!el || !isVisible(el)) continue;
+    const r = el.getBoundingClientRect();
+    logoCandidates.push({
+      selector: sel,
+      type: el.tagName.toLowerCase() === 'svg' ? 'svg' : 'img',
+      rect: { x: Math.round(r.left), y: Math.round(r.top), width: Math.round(r.width), height: Math.round(r.height) },
+      src: el.src || null,
+      markup: el.tagName.toLowerCase() === 'svg' ? el.outerHTML.slice(0, 5000) : null,
+    });
+    if (logoCandidates.length >= 3) break;
+  }
+
+  const images = [...document.querySelectorAll('img')]
+    .filter(el => isVisible(el) && el.src && !el.src.startsWith('data:'))
+    .slice(0, 20)
+    .map(el => {
+      const r = el.getBoundingClientRect();
+      return { src: el.src, alt: el.alt || null, width: Math.round(r.width), height: Math.round(r.height) };
+    });
+
+  const bodyStyle = getComputedStyle(document.body);
+  const pageBg = toHex(bodyStyle.backgroundColor) || toHex(getComputedStyle(document.documentElement).backgroundColor);
+
+  return JSON.stringify({
+    url: location.href,
+    title: document.title,
+    viewport: { width: innerWidth, height: innerHeight, pageHeight: document.documentElement.scrollHeight },
+    page: {
+      backgroundColor: pageBg || 'transparent',
+      textColor: toHex(bodyStyle.color) || bodyStyle.color,
+      baseFontFamily: bodyStyle.fontFamily,
+      baseFontSize: bodyStyle.fontSize,
+    },
+    colors: {
+      backgrounds: topEntries(bgColors, 10),
+      text: topEntries(textColors, 8),
+      borders: topEntries(borderColors, 5),
+    },
+    typography,
+    typeScale: topEntries(typeScale, 15),
+    fontFamilies: topEntries(fontFamilies, 6),
+    fontFaces: fontFaces.slice(0, 20),
+    spacingScale: topEntries(spacing, 12),
+    buttons: [...buttonStyles.values()].sort((a, b) => b.count - a.count).slice(0, 6),
+    borderRadii: topEntries(radii, 6),
+    shadows: topEntries(shadows, 4),
+    cssVariables,
+    stylesheets: stylesheets.slice(0, 15),
+    images,
+    backgroundImages: topEntries(bgImages, 10).map(e => e.value),
+    logoCandidates,
+  });
+})()


### PR DESCRIPTION
## What

New skill: `design-system` — point it at a URL and it reverse-engineers the site's design system using the browse CLI on a Browserbase remote session.

## How it works

**Bitter-lesson split**: deterministic code only *measures*; the agent *decides*.

- Three zero-dependency probes (evaluated in-page via `browse eval`):
  - `harvest-styles.js` — colors (canvas-normalized, handles `lab()`/`oklch()`), type scale, @font-face inventory, CSS variables, buttons, logo candidates
  - `harvest-structure.js` — breakpoints from @media rules, containers/grids per viewport, hover/focus states (with raw-CSS-text fallback for CSS-in-JS sites), motion, iconography, WCAG contrast
  - `harvest-components.js` — interactive elements with accessible names (so carousel arrows can't masquerade as CTAs), named regions, section titles, kickers/badges, typography by structural context
- The agent handles everything judgment-shaped: consent overlays (a11y-ref click or coordinate click into cross-origin iframes), lazy-content scrolling, component selection and screenshot capture, sub-page theming diffs, semantic naming.

**Output contract** — three strictly-separated tiers in `design-system.json`:
1. `measured` — probe output verbatim
2. `proposedTokens` / `proposedComponents` — inferred semantics, every entry carrying `evidenceRefs` (JSON paths into `measured`), under a `_status: INFERRED` banner
3. `notProvided` — what a real design system adds that isn't on the page (never fabricated)

## Validation

Run end-to-end on two sites:
- **theguardian.com** — dismissed the Sourcepoint consent iframe by coordinate click, recovered the Source focus ring (`0 0 0 3px #0077B6`) from raw CSS text, and reconstructed the five-pillar accent system (news/opinion/sport/culture/lifestyle) by diffing section fronts. Extracted breakpoints match Guardian Source's published scale (480/740/980/1140/1300).
- **launchdarkly.com** — handled scroll-reveal animations (viewport enlarge + pre-scroll + `--animations disabled`), resolved next/font aliases through the @font-face inventory, and corrected a vision-guessed CTA color to the measured `#ddff46`.

The SKILL.md gotchas encode every failure mode hit during those runs (page-coordinate clips, blank off-screen captures, daemon-relative paths, CSS-in-JS nested rules, session expiry).

`node scripts/validate-skills.mjs --skill design-system` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and additive skill assets only; the Python CLI calls Browserbase APIs with the user’s API key but does not change existing plugin runtime behavior.
> 
> **Overview**
> Adds **two new Claude Code skills** and lists them in the root **README** skills table.
> 
> **`browserbase-agents`** documents the Browserbase Agents API end-to-end: create/update agents, trigger runs with `%variables%`, poll, messages, downloads, and delete. It ships a **stdlib-only** `scripts/bb_agents.py` CLI, condensed **`references/api_reference.md`** and **`prompt_patterns.md`**, an Amazon search **`example_agent.json`**, and **`evals/evals.json`**.
> 
> **`design-system`** is an agent-driven workflow to snapshot a site’s look via the **`browse` CLI** on Browserbase. Deterministic **`browse eval` probes** (`harvest-styles.js`, `harvest-structure.js`, `harvest-components.js`) only measure; **`SKILL.md`** defines navigation, overlays, responsive re-probes, component crops, and a **`design-system.json`** contract with **`measured`**, **`proposedTokens`** (with **`evidenceRefs`**), and **`notProvided`** tiers. Output goes under **`snapshots/<hostname>/`** with HTML, full-page PNG, and per-component assets.
> 
> Both skills include MIT **`LICENSE.txt`** and eval fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdd8ca7b431f442594285d82cb2f31027a1ef3ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->